### PR TITLE
Simple-minded search

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -24,3 +24,25 @@ class InstructorMatchForm(forms.Form):
         skills = Skill.objects.all()
         for s in skills:
             self.fields[s.name] = forms.BooleanField(label=s.name, required=False)
+
+
+class SearchForm(forms.Form):
+    '''Represent general searching form.'''
+
+    term = forms.CharField(label='term',
+                           max_length=100)
+    in_site_names = forms.BooleanField(label='in site names',
+                                       required=False,
+                                       initial=True)
+    in_site_notes = forms.BooleanField(label='in site notes',
+                                       required=False,
+                                       initial=True)
+    in_event_names = forms.BooleanField(label='in event names',
+                                        required=False,
+                                        initial=True)
+    in_event_notes = forms.BooleanField(label='in event notes',
+                                        required=False,
+                                        initial=True)
+    in_persons = forms.BooleanField(label='in persons',
+                                    required=False,
+                                    initial=True)

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -5,7 +5,7 @@ from workshops.models import Skill
 INSTRUCTOR_SEARCH_LEN = 10   # how many instrutors to return from a search by default
 
 
-class InstructorMatchForm(forms.Form):
+class InstructorsForm(forms.Form):
     '''Represent instructor matching form.'''
 
     wanted = forms.IntegerField(label='Number Wanted',
@@ -20,7 +20,7 @@ class InstructorMatchForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         '''Build checkboxes for skills dynamically.'''
-        super(InstructorMatchForm, self).__init__(*args, **kwargs)
+        super(InstructorsForm, self).__init__(*args, **kwargs)
         skills = Skill.objects.all()
         for s in skills:
             self.fields[s.name] = forms.BooleanField(label=s.name, required=False)

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -31,18 +31,9 @@ class SearchForm(forms.Form):
 
     term = forms.CharField(label='term',
                            max_length=100)
-    in_site_names = forms.BooleanField(label='in site names',
-                                       required=False,
-                                       initial=True)
-    in_site_notes = forms.BooleanField(label='in site notes',
-                                       required=False,
-                                       initial=True)
-    in_event_names = forms.BooleanField(label='in event names',
-                                        required=False,
-                                        initial=True)
-    in_event_notes = forms.BooleanField(label='in event notes',
-                                        required=False,
-                                        initial=True)
-    in_persons = forms.BooleanField(label='in persons',
-                                    required=False,
-                                    initial=True)
+    in_sites = forms.BooleanField(label='in sites',
+                                  required=False,
+                                  initial=True)
+    in_events = forms.BooleanField(label='in events',
+                                   required=False,
+                                   initial=True)

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -28,10 +28,10 @@
 	<li><a href="{% url 'all_tasks' %}">all tasks</a></li>
 	<li><a href="{% url 'all_cohorts' %}">all cohorts</a></li>
 	<li><a href="{% url 'all_badges' %}">all badges</a></li>
-	<li><a href="{% url 'match' %}">match instructors</a></li>
+	<li><a href="{% url 'instructors' %}">find instructors</a></li>
 	<li><a href="{% url 'search' %}">search</a></li>
 	<li><a href="{% url 'export' 'badges' %}">export badges</a></li>
-	<li><a href="{% url 'export' 'instructors' %}">export instructor locations</a></li>
+	<li><a href="{% url 'export' 'instructors' %}">export instructors</a></li>
       </ul>
     </td>
     <td valign="top">

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -27,6 +27,7 @@
 	<li><a href="{% url 'all_persons' %}">all persons</a></li>
 	<li><a href="{% url 'all_tasks' %}">all tasks</a></li>
 	<li><a href="{% url 'all_cohorts' %}">all cohorts</a></li>
+	<li><a href="{% url 'search' %}">search</a></li>
 	<li><a href="{% url 'match' %}">match instructors</a></li>
 	<li><a href="{% url 'export' 'badges' %}">export badges</a></li>
 	<li><a href="{% url 'export' 'instructors' %}">export instructor locations</a></li>

--- a/workshops/templates/workshops/instructors.html
+++ b/workshops/templates/workshops/instructors.html
@@ -3,11 +3,11 @@
 {% load breadcrumbs %}
 {% block breadcrumbs %}
     {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'Instructor Search'  %}
+    {% breadcrumb_active 'Instructors'  %}
 {% endblock %}
 
 {% block content %}
-<form action="{% url 'match' %}" method="post">
+<form action="{% url 'instructors' %}" method="post">
     {% csrf_token %}
     <table class="table table-striped">
     {{ form.as_table }}

--- a/workshops/templates/workshops/search.html
+++ b/workshops/templates/workshops/search.html
@@ -14,10 +14,23 @@
     </table>
     <input type="submit" value="Submit" />
 </form>
-<p>term: {{ term }}</p>
-<p>in_site_names: {{ in_site_names }}</p>
-<p>in_site_notes: {{ in_site_notes }}</p>
-<p>in_event_names: {{ in_event_names }}</p>
-<p>in_event_notes: {{ in_event_notes }}</p>
-<p>in_persons: {{ in_persons }}</p>
+
+<h2>Sites</h2>
+{% if sites %}
+<ul>
+  {% for s in sites %}
+  <li><a href="{% url 'site_details' s.domain %}">{{ s.domain }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+<h2>Events</h2>
+{% if events %}
+<ul>
+  {% for e in events %}
+  <li><a href="{% url 'event_details' e.slug %}">{{ e.slug }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+
 {% endblock %}

--- a/workshops/templates/workshops/search.html
+++ b/workshops/templates/workshops/search.html
@@ -1,0 +1,23 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% block breadcrumbs %}
+    {% breadcrumb_url 'Amy' 'index'  %}
+    {% breadcrumb_active 'Text Search'  %}
+{% endblock %}
+
+{% block content %}
+<form action="{% url 'search' %}" method="post">
+    {% csrf_token %}
+    <table class="table table-striped">
+    {{ form.as_table }}
+    </table>
+    <input type="submit" value="Submit" />
+</form>
+<p>term: {{ term }}</p>
+<p>in_site_names: {{ in_site_names }}</p>
+<p>in_site_notes: {{ in_site_notes }}</p>
+<p>in_event_names: {{ in_event_names }}</p>
+<p>in_event_notes: {{ in_event_notes }}</p>
+<p>in_persons: {{ in_persons }}</p>
+{% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -39,7 +39,9 @@ urlpatterns = [
     url(r'^cohort/(?P<cohort_name>[\w\.-]+)/edit$', CohortUpdate.as_view(), name='cohort_edit'),
     url(r'^cohorts/add/$', CohortCreate.as_view(), name='cohort_add'),
 
+    url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
+
     url(r'^match/?$', views.match, name='match'),
 
-    url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
+    url(r'^search/?$', views.search, name='search'),
 ]

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -1,11 +1,4 @@
 from django.conf.urls import url
-from .views import AirportCreate, AirportUpdate, \
-                   PersonCreate, PersonUpdate, \
-                   SiteCreate, SiteUpdate, \
-                   TaskCreate, TaskUpdate, \
-                   CohortCreate, CohortUpdate, \
-                   match
-
 from workshops import views
 
 urlpatterns = [
@@ -13,18 +6,18 @@ urlpatterns = [
 
     url(r'^sites/?$', views.all_sites, name='all_sites'),
     url(r'^site/(?P<site_domain>[\w\.-]+)/?$', views.site_details, name='site_details'),
-    url(r'^site/(?P<site_domain>[\w\.-]+)/edit$', SiteUpdate.as_view(), name='site_edit'),
-    url(r'^sites/add/$', SiteCreate.as_view(), name='site_add'),
+    url(r'^site/(?P<site_domain>[\w\.-]+)/edit$', views.SiteUpdate.as_view(), name='site_edit'),
+    url(r'^sites/add/$', views.SiteCreate.as_view(), name='site_add'),
 
     url(r'^airports/?$', views.all_airports, name='all_airports'),
     url(r'^airport/(?P<airport_iata>[\w\.-]+)/?$', views.airport_details, name='airport_details'),
-    url(r'^airport/(?P<airport_iata>[\w\.-]+)/edit$', AirportUpdate.as_view(), name='airport_edit'),
-    url(r'^airports/add/$', AirportCreate.as_view(), name='airport_add'),
+    url(r'^airport/(?P<airport_iata>[\w\.-]+)/edit$', views.AirportUpdate.as_view(), name='airport_edit'),
+    url(r'^airports/add/$', views.AirportCreate.as_view(), name='airport_add'),
 
     url(r'^persons/?$', views.all_persons, name='all_persons'),
     url(r'^person/(?P<person_id>[\w\.-]+)/?$', views.person_details, name='person_details'),
-    url(r'^person/(?P<person_id>[\w\.-]+)/edit$', PersonUpdate.as_view(), name='person_edit'),
-    url(r'^persons/add/$', PersonCreate.as_view(), name='person_add'),
+    url(r'^person/(?P<person_id>[\w\.-]+)/edit$', views.PersonUpdate.as_view(), name='person_edit'),
+    url(r'^persons/add/$', views.PersonCreate.as_view(), name='person_add'),
 
     url(r'^events/?$', views.all_events, name='all_events'),
     url(r'^event/(?P<event_slug>[\w\.-]+)/?$', views.event_details, name='event_details'),
@@ -32,20 +25,20 @@ urlpatterns = [
 
     url(r'^tasks/?$', views.all_tasks, name='all_tasks'),
     url(r'^task/(?P<event_slug>[\w\.-]+)/(?P<person_id>[\w\.-]+)/(?P<role_name>[\w\.-]+)/?$', views.task_details, name='task_details'),
-    url(r'^task/(?P<event_slug>[\w\.-]+)/(?P<person_id>[\w\.-]+)/(?P<role_name>[\w\.-]+)/edit$', TaskUpdate.as_view(), name='task_edit'),
-    url(r'^tasks/add/$', TaskCreate.as_view(), name='task_add'),
+    url(r'^task/(?P<event_slug>[\w\.-]+)/(?P<person_id>[\w\.-]+)/(?P<role_name>[\w\.-]+)/edit$', views.TaskUpdate.as_view(), name='task_edit'),
+    url(r'^tasks/add/$', views.TaskCreate.as_view(), name='task_add'),
 
     url(r'^cohorts/?$', views.all_cohorts, name='all_cohorts'),
     url(r'^cohort/(?P<cohort_name>[\w\.-]+)/?$', views.cohort_details, name='cohort_details'),
-    url(r'^cohort/(?P<cohort_name>[\w\.-]+)/edit$', CohortUpdate.as_view(), name='cohort_edit'),
-    url(r'^cohorts/add/$', CohortCreate.as_view(), name='cohort_add'),
+    url(r'^cohort/(?P<cohort_name>[\w\.-]+)/edit$', views.CohortUpdate.as_view(), name='cohort_edit'),
+    url(r'^cohorts/add/$', views.CohortCreate.as_view(), name='cohort_add'),
 
     url(r'^badges/?$', views.all_badges, name='all_badges'),
     url(r'^badge/(?P<badge_name>[\w\.-]+)/?$', views.badge_details, name='badge_details'),
 
-    url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
-
-    url(r'^match/?$', views.match, name='match'),
+    url(r'^instructors/?$', views.instructors, name='instructors'),
 
     url(r'^search/?$', views.search, name='search'),
+
+    url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
 ]

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -8,7 +8,7 @@ from django.views.generic.edit import CreateView, UpdateView
 from django.db.models import Count
 
 from workshops.models import Site, Airport, Event, Person, Task, Cohort, Skill, Trainee, Badge, Award
-from workshops.forms import InstructorMatchForm
+from workshops.forms import InstructorMatchForm, SearchForm
 from workshops.util import earth_distance
 
 #------------------------------------------------------------
@@ -279,6 +279,44 @@ def match(request):
                'form': form,
                'persons' : persons}
     return render(request, 'workshops/match.html', context)
+
+#------------------------------------------------------------
+
+def search(request):
+    '''Search the database by term.'''
+
+    term = ''
+    in_site_names = False
+    in_site_notes = False
+    in_event_names = False
+    in_event_notes = False
+    in_persons = False
+
+    if request.method == 'POST':
+        form = SearchForm(request.POST)
+        if form.is_valid():
+            term = form.cleaned_data['term'],
+            in_site_names = form.cleaned_data['in_site_names']
+            in_site_notes = form.cleaned_data['in_site_notes']
+            in_event_names = form.cleaned_data['in_event_names']
+            in_event_notes = form.cleaned_data['in_event_notes']
+            in_persons = form.cleaned_data['in_persons']
+        else:
+            pass # FIXME: error message
+
+    # if a GET (or any other method) we'll create a blank form
+    else:
+        form = SearchForm()
+
+    context = {'title' : 'Search',
+               'form': form,
+               'term' : term,
+               'in_site_names': in_site_names,
+               'in_site_notes': in_site_notes,
+               'in_event_names': in_event_names,
+               'in_event_notes': in_event_notes,
+               'in_persons': in_persons}
+    return render(request, 'workshops/search.html', context)
 
 #------------------------------------------------------------
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -9,7 +9,7 @@ from django.views.generic.edit import CreateView, UpdateView
 from django.db.models import Count, Q
 
 from workshops.models import Site, Airport, Event, Person, Task, Cohort, Skill, Trainee, Badge, Award
-from workshops.forms import InstructorMatchForm, SearchForm
+from workshops.forms import InstructorsForm, SearchForm
 from workshops.util import earth_distance
 from workshops.check import check_file
 
@@ -281,13 +281,13 @@ def badge_details(request, badge_name):
 
 #------------------------------------------------------------
 
-def match(request):
+def instructors(request):
     '''Search for instructors.'''
 
     persons = None
 
     if request.method == 'POST':
-        form = InstructorMatchForm(request.POST)
+        form = InstructorsForm(request.POST)
         if form.is_valid():
 
             # Filter by skills.
@@ -321,12 +321,12 @@ def match(request):
 
     # if a GET (or any other method) we'll create a blank form
     else:
-        form = InstructorMatchForm()
+        form = InstructorsForm()
 
-    context = {'title' : 'Instructor Search',
+    context = {'title' : 'Find Instructors',
                'form': form,
                'persons' : persons}
-    return render(request, 'workshops/match.html', context)
+    return render(request, 'workshops/instructors.html', context)
 
 #------------------------------------------------------------
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -333,21 +333,21 @@ def match(request):
 def search(request):
     '''Search the database by term.'''
 
-    term = ''
-    in_sites, sites = False, None
-    in_events, events = False, None
+    term, sites, events = '', None, None
 
     if request.method == 'POST':
         form = SearchForm(request.POST)
         if form.is_valid():
             term = form.cleaned_data['term']
-            in_sites = form.cleaned_data['in_sites']
-            sites = Site.objects.filter(Q(domain__contains=term) | \
-                                        Q(fullname__contains=term) | \
-                                        Q(notes__contains=term))
-            in_events = form.cleaned_data['in_events']
-            events = Event.objects.filter(Q(slug__contains=term) | \
-                                          Q(notes__contains=term))
+            if form.cleaned_data['in_sites']:
+                sites = Site.objects.filter(
+                    Q(domain__contains=term) |
+                    Q(fullname__contains=term) |
+                    Q(notes__contains=term))
+            if form.cleaned_data['in_events']:
+                events = Event.objects.filter(
+                    Q(slug__contains=term) |
+                    Q(notes__contains=term))
         else:
             pass # FIXME: error message
 
@@ -358,9 +358,7 @@ def search(request):
     context = {'title' : 'Search',
                'form': form,
                'term' : term,
-               'in_sites': in_sites,
                'sites' : sites,
-               'in_events': in_events,
                'events' : events}
     return render(request, 'workshops/search.html', context)
 


### PR DESCRIPTION
This addresses #24 and is an alternative to #101:

1.  Add a simple search form allowing a single word to be searched for (case sensitive) with radio buttons controlling search in site and event fields.
2.  Look for that word in fields of site and event.
3.  Return unsorted list of links to matching sites/events.

Search is implemented using SQL `like` (via Django's `contains`).