### PR TITLE
WIP: workshops/models.py: Add Host and EventHost models

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -15,6 +15,24 @@ STR_REG_KEY =  20         # length of Eventbrite registration key
 class Site(models.Model):
     '''Represent a site where workshops are hosted.'''
 
+    name      = models.CharField(max_length=STR_LONG, unique=True)
+    latitude  = models.FloatField()
+    longitude = models.FloatField()
+    country   = models.CharField(max_length=STR_LONG, null=True, blank=True)
+    airport   = models.ForeignKey(Airport, null=True, blank=True)
+    notes     = models.TextField(null=True, blank=True)
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse('site_details', args=[str(self.id)])
+
+#------------------------------------------------------------
+
+class Host(models.Model):
+    '''A hosting organization.'''
+
     domain     = models.CharField(max_length=STR_LONG, unique=True)
     fullname   = models.CharField(max_length=STR_LONG, unique=True)
     country    = models.CharField(max_length=STR_LONG, null=True)
@@ -24,7 +42,7 @@ class Site(models.Model):
         return self.domain
 
     def get_absolute_url(self):
-        return reverse('site_details', args=[str(self.domain)])
+        return reverse('host_details', args=[str(self.domain)])
 
 #------------------------------------------------------------
 
@@ -221,6 +239,18 @@ class Event(models.Model):
 
     def get_absolute_url(self):
         return reverse('event_details', args=[str(self.slug)])
+
+#------------------------------------------------------------
+
+class EventHost(models.Model):
+    '''Associate a host with an event.
+
+    With optional notes explaining the host's contribution.
+    '''
+    event = models.ForeignKey(Event)
+    host  = models.ForeignKey(Host)
+    notes = models.TextField(null=True, blank=True)
+
 
 #------------------------------------------------------------
 


### PR DESCRIPTION
To distinguish between the Site (a physical location, e.g. TGAG, the
Genome Analysis Centre, Norwich Research Park, Colney, Norwich,
Norfolk, United Kingdom, 52.621699 N, 1.21888 E) and the Host
(possibly a diffuse entity, e.g. ELIXIR, the European life-sciences
Infrastructure for biological Information).  A diffuse host can have
many sites, and a particular workshop can have many collaborating
hosts.  The many-to-many relationship (one host can support several
events, and one event may have several hosts) is not layed out
explicitly in our charter, but [we have][1]:

> *Hosting* a workshop means providing space for it, supporting travel
> costs for instructors (if applicable), etc.

and its conceivable that one host could provide space while others
could fund instructor travel, etc.  I've added the free-form
EventHost.notes to keep track of this, and I expect it will have
values like "providing the site", "funding travel for instructor Alice
Bobsdaughter", "providing coffee and snacks for the first day of the
event", etc.  If a single host provides for the whole event, I'd just
leave this field blank.

This pull request is currently a work-in-progress while we work out
the models, after which I'll go through and fill in the migrations,
view changes, etc.  I'll remove the WIP note in the summary once I
think it's ready for merging.

Fixes #5 and #6.

[1]: https://github.com/swcarpentry/board/blob/master/membership.md#terminology