### PR TITLE
workshops/models.py: Add help_text to Person.active

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -91,7 +91,8 @@ class Person(models.Model):
     family     = models.CharField(max_length=STR_LONG)
     email      = models.CharField(max_length=STR_LONG, unique=True, null=True)
     gender     = models.CharField(max_length=1, choices=GENDER_CHOICES, null=True, blank=True)
-    active     = models.NullBooleanField()
+    active     = models.NullBooleanField(
+        help_text='Are we currently allowed to contact this person?')
     airport    = models.ForeignKey(Airport, null=True)
     github     = models.CharField(max_length=STR_MED, unique=True, null=True)
     twitter    = models.CharField(max_length=STR_MED, unique=True, null=True)


### PR DESCRIPTION
The field name doesn't make the meaning obvious, so record it in the
[help_text][1].  Discussion behind my phrasing is in #127.

[1]: https://docs.djangoproject.com/en/1.7/ref/models/fields/#help-text