### PR TITLE
Make sortable DataTables tables for the all airports page

### DIFF
--- a/workshops/templates/workshops/_page.html
+++ b/workshops/templates/workshops/_page.html
@@ -4,9 +4,16 @@
   <head>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.4/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="{% static 'amy.css' %}">
     <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="https://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" class="init">
+      $(document).ready(function() {
+      $('#sortable_table').DataTable();
+      } );
+    </script>
     <title>Amy: {{ title }}</title>
   </head>
   <body>

--- a/workshops/templates/workshops/_page.html
+++ b/workshops/templates/workshops/_page.html
@@ -9,11 +9,6 @@
     <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" class="init">
-      $(document).ready(function() {
-      $('#sortable_table').DataTable();
-      } );
-    </script>
     <title>Amy: {{ title }}</title>
   </head>
   <body>

--- a/workshops/templates/workshops/_single_table_page.html
+++ b/workshops/templates/workshops/_single_table_page.html
@@ -1,0 +1,28 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% block breadcrumbs %}
+    {% breadcrumb_url 'Amy' 'index'  %}
+    {% breadcrumb_active 'All events'  %}
+{% endblock %}
+
+{% block content %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           {% block column_definitions %}{% endblock column_definitions %}
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
+    <p>No rows.</p>
+  {% endif %}
+
+{% block add_new_link %}{% endblock add_new_link %}
+
+{% endblock content %}

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -1,19 +1,6 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All airports'  %}
-{% endblock %}
-
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
+{% block column_definitions %}
            "order": [[ 0, "asc" ]],
            // Definitions of each column
            "columnDefs": [
@@ -26,12 +13,8 @@
                }
              }
            ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No airports.</p>
-  {% endif %}
+{% endblock column_definitions %}
+
+{% block add_new_link %}
   <p class="add-new"><a href="{% url 'airport_add' %}">Add a new airport</a></p>
-{% endblock %}
+{% endblock add_new_link %}

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -7,31 +7,38 @@
 {% endblock %}
 
 {% block content %}
-{% if all_airports %}
-
-<table id="sortable_table">
-  <thead>
-    <tr>
-      <th>IATA</th>
-      <th>full name</th>
-      <th>latitude</th>
-      <th>longitude</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for airport in all_airports %}
-    <tr>
-      <td>{{ airport.iata }}</td>
-      <td><a href="{% url 'airport_details' airport.iata %}">{{ airport.fullname }}</a></td>
-      <td>{{ airport.latitude }}</td>
-      <td>{{ airport.longitude }}</td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
-{% else %}
-  <p>No airports.</p>
-{% endif %}
-
-<p class="add-new"><a href="{% url 'airport_add' %}">Add a new airport</a></p>
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The second column is airport location.  Add in a link to the
+               // airport page using the hidden fifth column
+               "targets": 1,
+               "render": function ( data, type, row ) {
+                 return '<a href="' + row[5] + '">' + data + '</a>'
+               }
+             },
+             {
+               // The 6th column is the URL of the airport page, to be used for
+               // generating the URL in the first column.  Hide it.
+               "targets": 5,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
+    <p>No airports.</p>
+  {% endif %}
+  <p class="add-new"><a href="{% url 'airport_add' %}">Add a new airport</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -24,13 +24,6 @@
                "render": function ( data, type, row ) {
                  return '<a href="' + row[5] + '">' + data + '</a>'
                }
-             },
-             {
-               // The 6th column is the URL of the airport page, to be used for
-               // generating the URL in the first column.  Hide it.
-               "targets": 5,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -8,24 +8,30 @@
 
 {% block content %}
 {% if all_airports %}
-    <table class="table table-striped">
-        <tr>
-	    <th>IATA</th>
-	    <th>full name</th>
-	    <th>latitude</th>
-	    <th>longitude</th>
-	</tr>
-    {% for airport in all_airports %}
-        <tr>
-            <td>{{ airport.iata }}</td>
-            <td><a href="{% url 'airport_details' airport.iata %}">{{ airport.fullname }}</a></td>
-            <td>{{ airport.latitude }}</td>
-            <td>{{ airport.longitude }}</td>
-	</tr>
-    {% endfor %}
-    </table>
+
+<table id="sortable_table">
+  <thead>
+    <tr>
+      <th>IATA</th>
+      <th>full name</th>
+      <th>latitude</th>
+      <th>longitude</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for airport in all_airports %}
+    <tr>
+      <td>{{ airport.iata }}</td>
+      <td><a href="{% url 'airport_details' airport.iata %}">{{ airport.fullname }}</a></td>
+      <td>{{ airport.latitude }}</td>
+      <td>{{ airport.longitude }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% else %}
-    <p>No airports.</p>
+  <p>No airports.</p>
 {% endif %}
+
 <p class="add-new"><a href="{% url 'airport_add' %}">Add a new airport</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -1,37 +1,16 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All badges'  %}
-{% endblock %}
-
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           // Order alphabetically by badge name
-           "order": [[ 0, "asc" ]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // The first column is the badge name, make it into a link using
-               // the URL hidden in the fourth column
-               "targets": 0,
-               "render": function ( data, type, row ) {
-                 return '<a href="' + row[3] + '">' + data + '</a>'
-               }
-             }
-           ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No sites.</p>
-  {% endif %}
-{% endblock %}
+{% block column_definitions %}
+  "order": [[ 0, "asc" ]],
+  // Definitions of each column
+  "columnDefs": [
+    {
+      // The first column is the badge name, make it into a link using
+      // the URL hidden in the fourth column
+      "targets": 0,
+      "render": function ( data, type, row ) {
+        return '<a href="' + row[3] + '">' + data + '</a>'
+      }
+    }
+  ],
+{% endblock column_definitions %}

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -25,13 +25,6 @@
                "render": function ( data, type, row ) {
                  return '<a href="' + row[3] + '">' + data + '</a>'
                }
-             },
-             {
-               // The 4th column is the URL of the badge page, to be used for
-               // generating the URL in the first column.  Hide it.
-               "targets": 3,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -7,20 +7,38 @@
 {% endblock %}
 
 {% block content %}
-<table class="table table-striped">
-  <tr>
-    <th>name</th>
-    <th>title</th>
-    <th>criteria</th>
-    <th>number awarded</th>
-  </tr>
-  {% for badge in all_badges %}
-  <tr>
-    <td><a href="{% url 'badge_details' badge.name %}">{{ badge.name }}</a></td>
-    <td>{{ badge.title }}</td>
-    <td>{{ badge.criteria }}</td>
-    <td>{{ badge.num_awarded }}</td>
-  </tr>
-  {% endfor %}
-</table>
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           // Order alphabetically by badge name
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The first column is the badge name, make it into a link using
+               // the URL hidden in the fourth column
+               "targets": 0,
+               "render": function ( data, type, row ) {
+                 return '<a href="' + row[3] + '">' + data + '</a>'
+               }
+             },
+             {
+               // The 4th column is the URL of the badge page, to be used for
+               // generating the URL in the first column.  Hide it.
+               "targets": 3,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
+    <p>No sites.</p>
+  {% endif %}
 {% endblock %}

--- a/workshops/templates/workshops/all_cohorts.html
+++ b/workshops/templates/workshops/all_cohorts.html
@@ -1,37 +1,20 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All cohorts'  %}
-{% endblock %}
+{% block column_definitions %}
+  "order": [[ 0, "asc" ]],
+  // Definitions of each column
+  "columnDefs": [
+    {
+      // The first column is the badge name, make it into a link using
+      // the URL hidden in the third column
+      "targets": 0,
+      "render": function ( data, type, row ) {
+        return '<a href="' + row[2] + '">' + data + '</a>'
+      }
+    }
+  ],
+{% endblock column_definitions %}
 
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           "order": [[ 0, "asc" ]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // The first column is the badge name, make it into a link using
-               // the URL hidden in the third column
-               "targets": 0,
-               "render": function ( data, type, row ) {
-                 return '<a href="' + row[2] + '">' + data + '</a>'
-               }
-             }
-           ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No cohorts.</p>
-  {% endif %}
+{% block add_new_link %}
   <p class="add-new"><a href="{% url 'cohort_add' %}">Add a new cohort</a></p>
-{% endblock %}
+{% endblock add_new_link %}

--- a/workshops/templates/workshops/all_cohorts.html
+++ b/workshops/templates/workshops/all_cohorts.html
@@ -24,13 +24,6 @@
                "render": function ( data, type, row ) {
                  return '<a href="' + row[2] + '">' + data + '</a>'
                }
-             },
-             {
-               // The 3rd column is the URL of the cohort page, to be used for
-               // generating the URL in the first column.  Hide it.
-               "targets": 2,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_cohorts.html
+++ b/workshops/templates/workshops/all_cohorts.html
@@ -7,21 +7,38 @@
 {% endblock %}
 
 {% block content %}
-{% if all_cohorts %}
-    <table class="table table-striped">
-        <tr>
-	    <th>name</th>
-	    <th>start date</th>
-	</tr>
-    {% for cohort in all_cohorts %}
-        <tr>
-	  <td><a href="{% url 'cohort_details' cohort.name %}">{{ cohort.name }}</a></td>
-	  <td>{{ cohort.start }}</td>
-	</tr>
-    {% endfor %}
-    </table>
-{% else %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The first column is the badge name, make it into a link using
+               // the URL hidden in the third column
+               "targets": 0,
+               "render": function ( data, type, row ) {
+                 return '<a href="' + row[2] + '">' + data + '</a>'
+               }
+             },
+             {
+               // The 3rd column is the URL of the cohort page, to be used for
+               // generating the URL in the first column.  Hide it.
+               "targets": 2,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
     <p>No cohorts.</p>
-{% endif %}
-<p class="add-new"><a href="{% url 'cohort_add' %}">Add a new cohort</a></p>
+  {% endif %}
+  <p class="add-new"><a href="{% url 'cohort_add' %}">Add a new cohort</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -1,76 +1,59 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All events'  %}
-{% endblock %}
+{% block column_definitions %}
+   // Sort by id, ascending
+   "order": [[ 0, "asc" ]],
+   // Definitions of each column
+   "columnDefs": [
+     {
+       // The 4th column contains the number of instructors.  If this
+       // is zero then wrap the text in a warning div
+       "targets": 3,
+       "render": function ( data, type, row ) {
+         if (data === 0) {
+            return '<div class="warning">' + data + '</div>'
+         } else {
+            return data
+         }
+       }
+     },
+     {
+       // The fifth column contains the slug and a link to the page.
+       // Take the link from the hidden 11th column, and if there is
+       // no slug then wrap the content in a warning div
+       "targets": 4,
+       "render": function ( data, type, row ) {
+          if (data == null) {
+             return '<div class="warning">No slug</div>'
+          } else {
+             return '<a href="' + row[10] + '">' + data + '</a>'
+         }
+       }
+     },
+     {
+       // The sixth column links to an external github URL.  If the
+       // URL is missing then highlight with a warning div
+       "targets": 5,
+       "render": function ( data, type, row ) {
+          if (data == null) {
+             return '<div class="warning">No URL</div>'
+          } else {
+             return '<a href="' + data + '">' +
+                     data.replace("https://github.com", "") + '</a>'
+          }
+       }
+     },
+     {
+       // The seventh column gives the site.  Use the hidden 12th
+       // column to retrieve the URL.
+       "targets": 6,
+       "render": function ( data, type, row ) {
+          return '<a href="' + row[11] + '">' + data + '</a>'
+       }
+     }
+   ],
+{% endblock column_definitions %}
 
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           // Sort by id, ascending
-           "order": [[ 0, "asc" ]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // The 4th column contains the number of instructors.  If this
-               // is zero then wrap the text in a warning div
-               "targets": 3,
-               "render": function ( data, type, row ) {
-                 if (data === 0) {
-                    return '<div class="warning">' + data + '</div>'
-                 } else {
-                    return data
-                 }
-               }
-             },
-             {
-               // The fifth column contains the slug and a link to the page.
-               // Take the link from the hidden 11th column, and if there is
-               // no slug then wrap the content in a warning div
-               "targets": 4,
-               "render": function ( data, type, row ) {
-                  if (data == null) {
-                     return '<div class="warning">No slug</div>'
-                  } else {
-                     return '<a href="' + row[10] + '">' + data + '</a>'
-                 }
-               }
-             },
-             {
-               // The sixth column links to an external github URL.  If the
-               // URL is missing then highlight with a warning div
-               "targets": 5,
-               "render": function ( data, type, row ) {
-                  if (data == null) {
-                     return '<div class="warning">No URL</div>'
-                  } else {
-                     return '<a href="' + data + '">' +
-                             data.replace("https://github.com", "") + '</a>'
-                  }
-               }
-             },
-             {
-               // The seventh column gives the site.  Use the hidden 12th
-               // column to retrieve the URL.
-               "targets": 6,
-               "render": function ( data, type, row ) {
-                  return '<a href="' + row[11] + '">' + data + '</a>'
-               }
-             }
-           ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No events.</p>
-  {% endif %}
-<p class="add-new"><a href="{% url 'event_add' %}">Add a new event</a></p>
-{% endblock %}
+{% block add_new_link %}
+  <p class="add-new"><a href="{% url 'event_add' %}">Add a new event</a></p>
+{% endblock add_new_link %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -63,20 +63,6 @@
                "render": function ( data, type, row ) {
                   return '<a href="' + row[11] + '">' + data + '</a>'
                }
-             },
-             {
-               // The 11th column contains the URL for the event.  Hide this
-               // column from the user as it is only used to render other cols
-               "targets": 10,
-               "visible": false,
-               "searchable": false
-             },
-             {
-               // The 12th column contains the URL for the site.  Hide this
-               // column from the user as it is only used to render other cols
-               "targets": 11,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -7,68 +7,84 @@
 {% endblock %}
 
 {% block content %}
-{% if all_events %}
-    <table class="table table-striped">
-        <tr>
-	    <th>ID</th>
-	    <th>published</th>
-	    <th>project</th>
-	    <th>instructors</th>
-	    <th>slug</th>
-	    <th>url</th>
-	    <th>site</th>
-	    <th>dates</th>
-	    <th>Eventbrite</th>
-	    <th>attendance</th>
-	</tr>
-    {% for event in all_events %}
-        <tr>
-	    <td>{{ event.id }}</td>
-	    <td>{{ event.published }}</td>
-	    <td>{{ event.project }}</td>
-	    <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
-	      {{ event.num_instructors }}
-	    </td>
-	    <td {% if not event.slug %}class="warning"{% endif %}>
-	      {% if not event.slug %}
-	        ---
-	      {% else %}
-	        <a href="{% url 'event_details' event.slug %}">
-		  {{ event.slug }}
-	        </a>
-	      {% endif %}
-	    </td>
-	    <td {% if not event.url %}class="warning"{% endif %}>
-	      {% if event.url %}
-	      <a href="{{ event.url }}">{{ event.url|cut:"https://github.com/" }}</a>
-	      {% else %}
-	      ---
-	      {% endif %}
-	    </td>
-	    <td><a href="{% url 'site_details' event.site.domain %}">{{ event.site }}</a></td>
-	    <td>{{ event.start }} &ndash; {{ event.end }}</td>
-	    <td>{{ event.reg_key }}</td>
-	    <td>{{ event.attendance }}</td>
-	</tr>
-    {% endfor %}
-    </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_events.has_previous %}
-             <a href="?page={{ all_events.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_events.number }} of {{ all_events.paginator.num_pages }}.
-         </span>
-
-         {% if all_events.has_next %}
-             <a href="?page={{ all_events.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
-{% else %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           // Sort by id, ascending
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The 4th column contains the number of instructors.  If this
+               // is zero then wrap the text in a warning div
+               "targets": 3,
+               "render": function ( data, type, row ) {
+                 if (data === 0) {
+                    return '<div class="warning">' + data + '</div>'
+                 } else {
+                    return data
+                 }
+               }
+             },
+             {
+               // The fifth column contains the slug and a link to the page.
+               // Take the link from the hidden 11th column, and if there is
+               // no slug then wrap the content in a warning div
+               "targets": 4,
+               "render": function ( data, type, row ) {
+                  if (data == null) {
+                     return '<div class="warning">No slug</div>'
+                  } else {
+                     return '<a href="' + row[10] + '">' + data + '</a>'
+                 }
+               }
+             },
+             {
+               // The sixth column links to an external github URL.  If the
+               // URL is missing then highlight with a warning div
+               "targets": 5,
+               "render": function ( data, type, row ) {
+                  if (data == null) {
+                     return '<div class="warning">No URL</div>'
+                  } else {
+                     return '<a href="' + data + '">' +
+                             data.replace("https://github.com", "") + '</a>'
+                  }
+               }
+             },
+             {
+               // The seventh column gives the site.  Use the hidden 12th
+               // column to retrieve the URL.
+               "targets": 6,
+               "render": function ( data, type, row ) {
+                  return '<a href="' + row[11] + '">' + data + '</a>'
+               }
+             },
+             {
+               // The 11th column contains the URL for the event.  Hide this
+               // column from the user as it is only used to render other cols
+               "targets": 10,
+               "visible": false,
+               "searchable": false
+             },
+             {
+               // The 12th column contains the URL for the site.  Hide this
+               // column from the user as it is only used to render other cols
+               "targets": 11,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
     <p>No events.</p>
-{% endif %}
+  {% endif %}
 <p class="add-new"><a href="{% url 'event_add' %}">Add a new event</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -21,7 +21,6 @@
                // The 4th column is a link to a person's page, use the URL hidden
                // in the 6th column to render the link
                "targets": 4,
-               "orderable": false,
                "render": function ( data, type, row ) {
                  return '<a href="' + row[5] + '">...</a>'
                }

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -25,13 +25,6 @@
                "render": function ( data, type, row ) {
                  return '<a href="' + row[5] + '">...</a>'
                }
-             },
-             {
-               // The 6th column is the URL of the person page, to be used for
-               // generating the URL.  Hide it.
-               "targets": 5,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -1,37 +1,20 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All persons'  %}
-{% endblock %}
+{% block column_definitions %}
+  "order": [[ 2, "asc" ], [0, "asc"]],
+  // Definitions of each column
+  "columnDefs": [
+    {
+      // The 4th column is a link to a person's page, use the URL hidden
+      // in the 6th column to render the link
+      "targets": 4,
+      "render": function ( data, type, row ) {
+        return '<a href="' + row[5] + '">...</a>'
+      }
+    }
+  ],
+{% endblock column_definitions %}
 
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           "order": [[ 2, "asc" ], [0, "asc"]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // The 4th column is a link to a person's page, use the URL hidden
-               // in the 6th column to render the link
-               "targets": 4,
-               "render": function ( data, type, row ) {
-                 return '<a href="' + row[5] + '">...</a>'
-               }
-             }
-           ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No persons.</p>
-  {% endif %}
-<p class="add-new"><a href="{% url 'person_add' %}">Add a new person</a></p>
+{% block add_new_link %}
+  <p class="add-new"><a href="{% url 'person_add' %}">Add a new person</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -7,42 +7,39 @@
 {% endblock %}
 
 {% block content %}
-{% if all_persons %}
-    <table class="table table-striped">
-        <tr>
-	    <th>personal</th>
-	    <th>middle</th>
-	    <th>family</th>
-	    <th>email</th>
-	    <th></th>
-	</tr>
-    {% for person in all_persons %}
-        <tr>
-	    <td>{{ person.personal }}</td>
-	    <td>{{ person.middle }}</td>
-	    <td>{{ person.family }}</td>
-	    <td>{{ person.email }}</td>
-	    <td><a href="{% url 'person_details' person.id %}">...</a></td>
-	</tr>
-    {% endfor %}
-    </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_persons.has_previous %}
-             <a href="?page={{ all_persons.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_persons.number }} of {{ all_persons.paginator.num_pages }}.
-         </span>
-
-         {% if all_persons.has_next %}
-             <a href="?page={{ all_persons.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
-{% else %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           "order": [[ 2, "asc" ], [0, "asc"]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The 4th column is a link to a person's page, use the URL hidden
+               // in the 6th column to render the link
+               "targets": 4,
+               "orderable": false,
+               "render": function ( data, type, row ) {
+                 return '<a href="' + row[5] + '">...</a>'
+               }
+             },
+             {
+               // The 6th column is the URL of the person page, to be used for
+               // generating the URL.  Hide it.
+               "targets": 5,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
     <p>No persons.</p>
-{% endif %}
+  {% endif %}
 <p class="add-new"><a href="{% url 'person_add' %}">Add a new person</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -7,38 +7,45 @@
 {% endblock %}
 
 {% block content %}
-{% if all_sites %}
-    <table class="table table-striped">
-        <tr>
-            <th>full name</th>
-            <th>domain</th>
-            <th>notes</th>
-        </tr>
-    {% for site in all_sites %}
-        <tr>
-            <td><a href="{% url 'site_details' site.domain %}">{{ site.fullname }}</a></td>
-            <td><a href="http://{{ site.domain }}">{{ site.domain }}</a></td>
-            <td>{{ site.notes|truncatechars:40 }}</td>
-        </tr>
-    {% endfor %}
-    </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_sites.has_previous %}
-             <a href="?page={{ all_sites.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_sites.number }} of {{ all_sites.paginator.num_pages }}.
-         </span>
-
-         {% if all_sites.has_next %}
-             <a href="?page={{ all_sites.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
-{% else %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // Replace the first column with a link to the site page
+               "targets": 0,
+               "render": function ( data, type, row ) {
+                 return '<a href="' + row[3] + '">' + data + '</a>'
+               }
+             },
+             {
+               // The second column is the domain of the site, prepend http:// and
+               // add a link
+               "targets": 1,
+               "render": function ( data, type, row ) {
+                 return '<a href="http://' + data + '">' + data + '</a>'
+               }
+             },
+             {
+               // The third column is the URL of the site page, to be used for
+               // generating the URL in the first column.  Hide it.
+               "targets": 3,
+               "visible": false,
+               "searchable": false
+             }
+           ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
     <p>No sites.</p>
-{% endif %}
-<p class="add-new"><a href="{% url 'site_add' %}">Add a new site</a></p>
+  {% endif %}
+  <p class="add-new"><a href="{% url 'site_add' %}">Add a new site</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -31,13 +31,6 @@
                "render": function ( data, type, row ) {
                  return '<a href="http://' + data + '">' + data + '</a>'
                }
-             },
-             {
-               // The third column is the URL of the site page, to be used for
-               // generating the URL in the first column.  Hide it.
-               "targets": 3,
-               "visible": false,
-               "searchable": false
              }
            ],
          })

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -1,44 +1,28 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All sites'  %}
-{% endblock %}
+{% block column_definitions %}
+  // Sort by the first column, ascending
+  "order": [[ 0, "asc" ]],
+  // Definitions of each column
+  "columnDefs": [
+    {
+      // Replace the first column with a link to the site page
+      "targets": 0,
+      "render": function ( data, type, row ) {
+        return '<a href="' + row[3] + '">' + data + '</a>'
+      }
+    },
+    {
+      // The second column is the domain of the site, prepend http:// and
+      // add a link
+      "targets": 1,
+      "render": function ( data, type, row ) {
+        return '<a href="http://' + data + '">' + data + '</a>'
+      }
+    }
+  ],
+{% endblock column_definitions %}
 
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           "order": [[ 0, "asc" ]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // Replace the first column with a link to the site page
-               "targets": 0,
-               "render": function ( data, type, row ) {
-                 return '<a href="' + row[3] + '">' + data + '</a>'
-               }
-             },
-             {
-               // The second column is the domain of the site, prepend http:// and
-               // add a link
-               "targets": 1,
-               "render": function ( data, type, row ) {
-                 return '<a href="http://' + data + '">' + data + '</a>'
-               }
-             }
-           ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No sites.</p>
-  {% endif %}
+{% block add_new_link %}
   <p class="add-new"><a href="{% url 'site_add' %}">Add a new site</a></p>
-{% endblock %}
+{% endblock add_new_link %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -7,40 +7,32 @@
 {% endblock %}
 
 {% block content %}
-{% if all_tasks %}
-    <table class="table table-striped">
-        <tr>
-	    <th>event</th>
-	    <th>person</th>
-	    <th>role</th>
-	    <td></td>
-	</tr>
-    {% for task in all_tasks %}
-        <tr>
-            <td>{{ task.event }}</td>
-            <td>{{ task.person }}</a></td>
-            <td>{{ task.role }}</a></td>
-	    <td><a href="{% url 'task_details' task.event.slug task.person.id task.role.name %}">...</a></td>
-	</tr>
-    {% endfor %}
-    </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_tasks.has_previous %}
-             <a href="?page={{ all_tasks.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_tasks.number }} of {{ all_tasks.paginator.num_pages }}.
-         </span>
-
-         {% if all_tasks.has_next %}
-             <a href="?page={{ all_tasks.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
-{% else %}
+  {% if data %}
+     <script type="text/javascript" class="init">
+       $(document).ready(function() {
+         $('#data_table').DataTable({
+           "data": {{data|safe}},
+           "columns": {{columns|safe}},
+           "deferRender": true,
+           "order": [[ 0, "asc" ]],
+           // Definitions of each column
+           "columnDefs": [
+             {
+               // The fourth column is a link to the task page.  Render the
+               // link and stop the column from being sortable
+               "targets": 3,
+               "sortable": false,
+               "render": function ( data, type, row ) {
+                  return '<a href="' + data + '">...</a>'
+               }
+             }
+            ],
+         })
+       })
+     </script>
+     <table id="data_table"></table>
+  {% else %}
     <p>No tasks.</p>
-{% endif %}
-<p class="add-new"><a href="{% url 'task_add' %}">Add a new task</a></p>
+  {% endif %}
+  <p class="add-new"><a href="{% url 'task_add' %}">Add a new task</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -1,37 +1,20 @@
-{% extends "workshops/_page.html" %}
+{% extends "workshops/_single_table_page.html" %}
 
-{% load breadcrumbs %}
-{% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All tasks'  %}
-{% endblock %}
+{% block column_definitions %}
+  "order": [[ 0, "asc" ]],
+  // Definitions of each column
+  "columnDefs": [
+    {
+      // The fourth column is a link to the task page.  Render the
+      // link.
+      "targets": 3,
+      "render": function ( data, type, row ) {
+         return '<a href="' + data + '">...</a>'
+      }
+    }
+   ],
+{% endblock column_definitions %}
 
-{% block content %}
-  {% if data %}
-     <script type="text/javascript" class="init">
-       $(document).ready(function() {
-         $('#data_table').DataTable({
-           "data": {{data|safe}},
-           "columns": {{columns|safe}},
-           "deferRender": true,
-           "order": [[ 0, "asc" ]],
-           // Definitions of each column
-           "columnDefs": [
-             {
-               // The fourth column is a link to the task page.  Render the
-               // link and stop the column from being sortable
-               "targets": 3,
-               "render": function ( data, type, row ) {
-                  return '<a href="' + data + '">...</a>'
-               }
-             }
-            ],
-         })
-       })
-     </script>
-     <table id="data_table"></table>
-  {% else %}
-    <p>No tasks.</p>
-  {% endif %}
+{% block add_new_link %}
   <p class="add-new"><a href="{% url 'task_add' %}">Add a new task</a></p>
-{% endblock %}
+{% endblock add_new_link %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -21,7 +21,6 @@
                // The fourth column is a link to the task page.  Render the
                // link and stop the column from being sortable
                "targets": 3,
-               "sortable": false,
                "render": function ( data, type, row ) {
                   return '<a href="' + data + '">...</a>'
                }

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -87,7 +87,7 @@ def all_sites(request):
       {"title": "Full name"},
       {"title": "Domain"},
       {"title": "Notes"},
-      {"title": "HIDDEN_COL_URL"},
+      {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False},
     ]
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Sites',
@@ -140,7 +140,7 @@ def all_airports(request):
       {"title": "Country"},
       {"title": "Latitude"},
       {"title": "Longitude"},
-      {"title": "HIDDEN_COL_URL"}
+      {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False}
     ]
 
     user_can_add = request.user.has_perm('edit')
@@ -189,7 +189,7 @@ def all_persons(request):
       {"title": "Last"},
       {"title": "Email"},
       {"title": " "},
-      {"title": "HIDDEN_COL_URL"}
+      {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False}
     ]
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Persons',
@@ -264,8 +264,8 @@ def all_events(request):
         {"title": "dates"},
         {"title": "Eventbrite"},
         {"title": "attendance"},
-        {"title": "HIDDEN_URL_SITE"},
-        {"title": "HIDDEN_URL_DOMAIN"},
+        {"title": "HIDDEN_URL_SITE", "visible": False, "searchable": False},
+        {"title": "HIDDEN_URL_DOMAIN",  "visible": False, "searchable": False},
     ]
 
     context = {'title' : 'All Events',
@@ -391,7 +391,7 @@ def all_cohorts(request):
     columns= [
       {"title": "Name"},
       {"title": "Start Date"},
-      {"title": "HIDDEN_COL_URL"}
+      {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False}
     ]
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Cohorts',
@@ -442,7 +442,7 @@ def all_badges(request):
       {"title": "Title"},
       {"title": "Criteria"},
       {"title": "Num. Awarded"},
-      {"title": "HIDDEN_COL_URL"}
+      {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False}
     ]
 
     user_can_add = request.user.has_perm('edit')

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -188,7 +188,7 @@ def all_persons(request):
       {"title": "Middle"},
       {"title": "Last"},
       {"title": "Email"},
-      {"title": " "},
+      {"title": " ", "orderable": False},
       {"title": "HIDDEN_COL_URL", "visible": False, "searchable": False}
     ]
     user_can_add = request.user.has_perm('edit')
@@ -333,7 +333,7 @@ def all_tasks(request):
      {"title": "Event"},
      {"title": "Person"},
      {"title": "Role"},
-     {"title": " "}
+     {"title": " ", "orderable": False}
     ]
 
     user_can_add = request.user.has_perm('edit')

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1,6 +1,7 @@
 import re
 import yaml
 import requests
+import json
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
@@ -25,6 +26,33 @@ from workshops.models import \
     Task, \
     Trainee
 
+'''A note on building sortable tables.  The way this works
+is that you have to build two variables, ``data`` and ``columns``.
+
+Columns is a list of dictionaries of column names, it takes the following form:
+
+```
+columns= [
+      {"title": "Col 1 title"},
+      {"title": "Col 1 title"},
+      {"title": "Col 1 title"}
+]
+``
+
+data is a list of lists, where each of the inner-lists represents a row of
+data, e.g.
+
+```
+data = [[row1col1, row1col2, row1col3],
+        [row2col1, row2col2, row2col3],
+        [row3col1, row3col2, row3col3]]
+```
+
+Pass these two variables into the template and follow one of the
+examples in all_*.html to render it out into a table using some
+Javascript config along with ``<table id="data_table"></table>``
+'''
+
 #------------------------------------------------------------
 
 ITEMS_PER_PAGE = 25
@@ -48,11 +76,23 @@ SITE_FIELDS = ['domain', 'fullname', 'country', 'notes']
 def all_sites(request):
     '''List all sites.'''
 
-    all_sites = Site.objects.order_by('domain')
-    sites = _get_pagination_items(request, all_sites)
+    all_sites = [[site.fullname, site.domain, site.notes,
+                  reverse('site_details', args=[site.domain])] for
+                  site in Site.objects.all()]
+
+    # Note that the column titled 'HIDDEN_COL_URL' is data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+      {"title": "Full name"},
+      {"title": "Domain"},
+      {"title": "Notes"},
+      {"title": "HIDDEN_COL_URL"},
+    ]
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Sites',
-               'all_sites' : sites,
+               'data' : json.dumps(all_sites),
+               'columns' : json.dumps(columns),
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_sites.html', context)
 
@@ -85,10 +125,28 @@ AIRPORT_FIELDS = ['iata', 'fullname', 'country', 'latitude', 'longitude']
 
 def all_airports(request):
     '''List all airports.'''
-    all_airports = Airport.objects.order_by('iata')
+
+    all_aps = [[ap.iata, ap.fullname,
+                ap.country, ap.latitude, ap.longitude,
+                reverse('airport_details', args=[ap.iata])] for
+                ap in Airport.objects.all()]
+
+    # Note that the column titled 'HIDDEN_COL_URL' is data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+      {"title": "IATA"},
+      {"title": "Full Name"},
+      {"title": "Country"},
+      {"title": "Latitude"},
+      {"title": "Longitude"},
+      {"title": "HIDDEN_COL_URL"}
+    ]
+
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Airports',
-               'all_airports' : all_airports,
+               'data' : json.dumps(all_aps),
+               'columns' : json.dumps(columns),
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_airports.html', context)
 
@@ -117,10 +175,27 @@ class AirportUpdate(UpdateView):
 def all_persons(request):
     '''List all persons.'''
 
-    all_persons = Person.objects.order_by('family', 'personal')
-    persons = _get_pagination_items(request, all_persons)
+    all_persons = [[person.personal, person.middle,
+                    person.family, person.email, person.id,
+                    reverse('person_details', args=[person.id])] for
+                    person in Person.objects.all()]
+
+    # Note that the column titled 'HIDDEN_COL_URL' is data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+      {"title": "First"},
+      {"title": "Middle"},
+      {"title": "Last"},
+      {"title": "Email"},
+      {"title": " "},
+      {"title": "HIDDEN_COL_URL"}
+    ]
+    user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Persons',
-               'all_persons' : persons}
+               'data' : json.dumps(all_persons),
+               'columns' : json.dumps(columns),
+               'user_can_add' : user_can_add}
     return render(request, 'workshops/all_persons.html', context)
 
 
@@ -151,12 +226,53 @@ class PersonUpdate(UpdateView):
 def all_events(request):
     '''List all events.'''
 
-    all_events = Event.objects.order_by('id')
-    events = _get_pagination_items(request, all_events)
+    events = Event.objects.all()
+
     for e in events:
         e.num_instructors = e.task_set.filter(role__name='instructor').count()
+        try:
+            start = e.start.strftime("%D")
+        except AttributeError:
+            start = "00/00/0000"
+
+        try:
+            end = e.end.strftime("%D")
+        except AttributeError:
+            end = "00/00/0000"
+
+        e.dates = " - ".join([start, end])
+
+    all_events = [[event.id, event.published, event.project.name,
+                   event.num_instructors, event.slug, event.url,
+                   event.site.fullname, event.dates, event.reg_key,
+                   event.attendance,
+                   reverse('event_details', args=[event.slug]),
+                   reverse('site_details', args=[event.site])] for
+                  event in events]
+
+    # Note that the columns titled 'HIDDEN_COL_*' are data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+        {"title": "ID"},
+        {"title": "published"},
+        {"title": "project"},
+        {"title": "instructors"},
+        {"title": "slug"},
+        {"title": "url"},
+        {"title": "site"},
+        {"title": "dates"},
+        {"title": "Eventbrite"},
+        {"title": "attendance"},
+        {"title": "HIDDEN_URL_SITE"},
+        {"title": "HIDDEN_URL_DOMAIN"},
+    ]
+
     context = {'title' : 'All Events',
-               'all_events' : events}
+               'data': json.dumps(all_events),
+               'columns': json.dumps(columns),
+               'all_events' : all_events}
+
     return render(request, 'workshops/all_events.html', context)
 
 
@@ -205,15 +321,25 @@ class EventUpdate(UpdateView):
 
 TASK_FIELDS = ['event', 'person', 'role']
 
-
 def all_tasks(request):
     '''List all tasks.'''
 
-    all_tasks = Task.objects.order_by('event', 'person', 'role')
-    tasks = _get_pagination_items(request, all_tasks)
+    all_tasks = [[t.event.slug, t.person.fullname(), t.role.name,
+                  reverse('task_details',
+                          args=[t.event.slug, t.person.id, t.role.name])] for
+                 t in Task.objects.all()]
+
+    columns= [
+     {"title": "Event"},
+     {"title": "Person"},
+     {"title": "Role"},
+     {"title": " "}
+    ]
+
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Tasks',
-               'all_tasks' : tasks,
+               'data' : json.dumps(all_tasks),
+               'columns': json.dumps(columns),
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_tasks.html', context)
 
@@ -254,10 +380,23 @@ COHORT_FIELDS = ['name', 'start', 'active', 'venue', 'qualifies']
 
 def all_cohorts(request):
     '''List all cohorts.'''
-    all_cohorts = Cohort.objects.order_by('start')
+
+    all_cohorts = [[cohort.name, cohort.start.strftime("%Y-%m-%d"),
+                    reverse('cohort_details', args=[cohort.name])] for
+                     cohort in Cohort.objects.all()]
+
+    # Note that the column titled 'HIDDEN_COL_URL' is data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+      {"title": "Name"},
+      {"title": "Start Date"},
+      {"title": "HIDDEN_COL_URL"}
+    ]
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Cohorts',
-               'all_cohorts' : all_cohorts,
+               'data' : json.dumps(all_cohorts),
+               'columns' : json.dumps(columns),
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_cohorts.html', context)
 
@@ -288,11 +427,28 @@ class CohortUpdate(UpdateView):
 def all_badges(request):
     '''List all badges.'''
 
-    all_badges = Badge.objects.order_by('name')
+    all_badges = Badge.objects.all()
     for b in all_badges:
         b.num_awarded = Award.objects.filter(badge_id=b.id).count()
+
+    all_badges = [[badge.title, badge.criteria,
+                   badge.num_awarded, reverse('badge_details', args=[badge.name])] for
+                  badge in all_badges]
+
+    # Note that the column titled 'HIDDEN_COL_URL' is data that is passed
+    # to the table and used to build a link in another column.  This column
+    # is not displayed to the user
+    columns= [
+      {"title": "Title"},
+      {"title": "Criteria"},
+      {"title": "Num. Awarded"},
+      {"title": "HIDDEN_COL_URL"}
+    ]
+
+    user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Badges',
-               'all_badges' : all_badges}
+               'data' : json.dumps(all_badges),
+               'columns' : json.dumps(columns)}
     return render(request, 'workshops/all_badges.html', context)
 
 


### PR DESCRIPTION
This pull request brings sortable [DataTables](http://www.datatables.net/) into amy.

![airport datatable](http://i.imgur.com/HzlYyMN.png)

![airport datatable filtered](http://i.imgur.com/lL825T3.png)

Given discussion in #129  I have implemented this initially only on the ``all_airports`` page, so that people can see how it works.  Assuming nobody has any big objections or issues, I'll go ahead and apply this change to all tables in a couple of days.  Until then, this pull request should be considered a work in progress.