### PR TITLE
Showing statistics graphically

### DIFF
--- a/workshops/templates/workshops/stats.html
+++ b/workshops/templates/workshops/stats.html
@@ -7,7 +7,5 @@
 {% endblock %}
 
 {% block content %}
-<p>
-  <img src="{{chart_url}}" alt="{{title}}" />
-</p>
+<p>chart: {{chart}}</p>
 {% endblock %}

--- a/workshops/templates/workshops/stats.html
+++ b/workshops/templates/workshops/stats.html
@@ -1,0 +1,13 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% block breadcrumbs %}
+    {% breadcrumb_url 'Amy' 'index'  %}
+    {% breadcrumb_active 'Stats'  %}
+{% endblock %}
+
+{% block content %}
+<p>
+  <img src="{{chart_url}}" alt="{{title}}" />
+</p>
+{% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -44,4 +44,6 @@ urlpatterns = [
     url(r'^search/?$', views.search, name='search'),
 
     url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
+
+    url(r'^stats/(?P<name>[\w\.-]+)/?$', views.stats, name='stats'),
 ]

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -45,5 +45,5 @@ urlpatterns = [
 
     url(r'^export/(?P<name>[\w\.-]+)/?$', views.export, name='export'),
 
-    url(r'^stats/(?P<name>[\w\.-]+)/?$', views.stats, name='stats'),
+    url(r'^chart/(?P<name>[\w\.-]+)/?$', views.chart, name='chart'),
 ]

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -487,6 +487,14 @@ def export(request, name):
 
 #------------------------------------------------------------
 
+def stats(request, name):
+    '''Display statistics.'''
+    context = {'title' : name,
+               'chart_url' : reverse('chart', args=[name])
+    return render(request, 'workshops/stats.html', context)
+
+#------------------------------------------------------------
+
 def _get_pagination_items(request, all_objects):
     '''Select paginated items.'''
 


### PR DESCRIPTION
This PR is a proof of concept showing how we can generate statistical charts on the fly using matplotlib. To try it out, go to http://127.0.0.1:8000/chart/enrolment or .../chart/workshops.  Before merging it, we must:

1.  Replace the raw SQL with Django ORM (I don't know how to calculate a cumulative sum using Django).
2.  Create views like `stats/enrolment` and `stats/workshops` which produce HTML pages that contain `img` elements that in turn cause these images to be generated (rather than just returning the image directly).