### PR TITLE
Adding airport names to instructor search.

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -33,21 +33,19 @@ class InstructorsForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(InstructorsForm, self).clean()
-        iata = cleaned_data.get('airport')
+        airport = cleaned_data.get('airport')
         lat = cleaned_data.get('latitude')
         long = cleaned_data.get('longitude')
 
-        if iata is None:
+        if airport is None:
             if lat is None or long is None:
                 raise forms.ValidationError(
-                    'Must specify either an airport code or a '
-                    'latitude/longitude')
+                    'Must specify either an airport code or latitude/longitude')
         else:
             if lat is not None or long is not None:
                 raise forms.ValidationError(
                     'Cannot specify both an airport code and a '
                     'latitude/longitude. Pick one or the other')
-            airport = Airport.objects.get(iata=iata)
             cleaned_data['latitude'] = airport.latitude
             cleaned_data['longitude'] = airport.longitude
         return cleaned_data

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -41,7 +41,7 @@ class Airport(models.Model):
     longitude = models.FloatField()
 
     def __str__(self):
-        return self.iata
+        return '{0}: {1}'.format(self.iata, self.fullname)
 
     def get_absolute_url(self):
         return reverse('airport_details', args=[str(self.iata)])


### PR DESCRIPTION
Arliss requested that full airport names be displayed along with IATA codes when looking up instructors. This PR changes the way airport names are displayed so that the instructor search pulldown will do the right thing, then modifies the logic in the form's cleanup to match.