### PR TITLE
Context views breadcrumbs

### DIFF
--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All airports' 'all_airports' %}
-    {% breadcrumb_active airport.fullname  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects airport %}
+    {% breadcrumb_active airport %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/airport_form.html
+++ b/workshops/templates/workshops/airport_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All airports' 'all_airports' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'airport_details' object.iata as object_url %}
-        {% breadcrumb object.fullname object_url %}
-        {% breadcrumb_active 'Edit airport'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New airport'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All airports'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All badges'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_cohorts.html
+++ b/workshops/templates/workshops/all_cohorts.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All cohorts'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All events'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All persons'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All sites'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'All tasks'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/badge.html
+++ b/workshops/templates/workshops/badge.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All badges' 'all_badges'  %}
-    {% breadcrumb_active badge.name  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects badge %}
+    {% breadcrumb_active badge %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/cohort.html
+++ b/workshops/templates/workshops/cohort.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All cohorts' 'all_cohorts' %}
-    {% breadcrumb_active cohort.name  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects cohort %}
+    {% breadcrumb_active cohort %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/cohort_form.html
+++ b/workshops/templates/workshops/cohort_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All cohorts' 'all_cohorts' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'cohort_details' object.name as object_url %}
-        {% breadcrumb object.name object_url %}
-        {% breadcrumb_active 'Edit cohort'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New cohort'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All events' 'all_events' %}
-    {% breadcrumb_active event.slug  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects event %}
+    {% breadcrumb_active event %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/event_form.html
+++ b/workshops/templates/workshops/event_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All events' 'all_events' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'event_details' object.id as object_url %}
-        {% breadcrumb object.id object_url %}
-        {% breadcrumb_active 'Edit event'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New event'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/export.html
+++ b/workshops/templates/workshops/export.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'Export'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/instructors.html
+++ b/workshops/templates/workshops/instructors.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'Instructors'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All persons' 'all_persons' %}
-    {% breadcrumb_active person  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects person %}
+    {% breadcrumb_active person %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/person_bulk_add_form.html
+++ b/workshops/templates/workshops/person_bulk_add_form.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Index' 'index'  %}
+    {% breadcrumb_main_page %}
     {% breadcrumb_url 'All persons' 'all_persons' %}
-    {% breadcrumb_active 'Bulk Add People'  %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Index' 'index'  %}
+    {% breadcrumb_main_page %}
     {% breadcrumb_url 'All persons' 'all_persons' %}
-    {% breadcrumb_active 'Process CSV File'  %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/person_form.html
+++ b/workshops/templates/workshops/person_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Index' 'index'  %}
-    {% breadcrumb_url 'All persons' 'all_persons' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'person_details' object.domain as object_url %}
-        {% breadcrumb object.domain object_url %}
-        {% breadcrumb_active 'Edit person'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New person'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/search.html
+++ b/workshops/templates/workshops/search.html
@@ -2,8 +2,8 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_active 'Text Search'  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/site.html
+++ b/workshops/templates/workshops/site.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All sites' 'all_sites' %}
-    {% breadcrumb_active site.domain  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects site %}
+    {% breadcrumb_active site %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/site_form.html
+++ b/workshops/templates/workshops/site_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All sites' 'all_sites' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'site_details' object.domain as object_url %}
-        {% breadcrumb object.domain object_url %}
-        {% breadcrumb_active 'Edit site'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New site'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/task.html
+++ b/workshops/templates/workshops/task.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All tasks' 'all_tasks' %}
-    {% breadcrumb_active task  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects task %}
+    {% breadcrumb_active task %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templates/workshops/task_form.html
+++ b/workshops/templates/workshops/task_form.html
@@ -2,14 +2,13 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All tasks' 'all_tasks' %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
     {% if object %}
-        {% url 'task_details' object.event.slug object.person.id task.role.name as object_url %}
-        {% breadcrumb "Task" object_url %}
-        {% breadcrumb_active 'Edit task'  %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
     {% else %}
-        {% breadcrumb_active 'New task'  %}
+        {% breadcrumb_new_object model %}
     {% endif %}
 {% endblock %}
 

--- a/workshops/templates/workshops/validate_event.html
+++ b/workshops/templates/workshops/validate_event.html
@@ -2,9 +2,9 @@
 
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_url 'Amy' 'index'  %}
-    {% breadcrumb_url 'All events' 'all_events' %}
-    {% breadcrumb_active event.slug  %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects event %}
+    {% breadcrumb_active event %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templatetags/breadcrumbs.py
+++ b/workshops/templatetags/breadcrumbs.py
@@ -1,132 +1,118 @@
 import logging
 
 from django import template
-from django.template import loader, Node, Variable
-from django.utils.encoding import smart_text
-from django.template.defaulttags import url
-from django.template import VariableDoesNotExist
+from django.utils.encoding import force_text
+from django.core.urlresolvers import reverse
 
 register = template.Library()
 _LOG = logging.getLogger(__name__)
 
 
-@register.tag
-def breadcrumb(parser, token):
+@register.simple_tag
+def breadcrumb(title, url):
     """
-    Renders the breadcrumb.
-    Examples:
-        {% breadcrumb "Title of breadcrumb" url_var %}
-        {% breadcrumb context_var  url_var %}
-        {% breadcrumb "Just the title" %}
-        {% breadcrumb just_context_var %}
-
-    Parameters:
-    -First parameter is the title of the crumb,
-    -Second (optional) parameter is the url variable to link to, produced by
-     url tag, i.e.:
-        {% url person_detail object.id as person_url %}
-        then:
-        {% breadcrumb person.name person_url %}
-
-    @author Andriy Drozdyuk
+    Create a simple anchor with provided text and already-resolved URL.
+    Example usage:
+        {% breadcrumb "Title of breadcrumb" resolved_url %}
     """
-    return BreadcrumbNode(token.split_contents()[1:])
+    return create_crumb(title, url)
 
 
-@register.tag
-def breadcrumb_url(parser, token):
+@register.simple_tag
+def breadcrumb_url(title, url_name):
     """
-    Same as breadcrumb
-    but instead of url context variable takes in all the
-    arguments URL tag takes.
-        {% breadcrumb "Title of breadcrumb" person_detail person.id %}
-        {% breadcrumb person.name person_detail person.id %}
+    Add non-active breadcrumb with specified title.  Second argument should be
+    a string name of URL that needs to be resolved.
+    Example usage:
+        {% breadcrumb_url "Title of breadcrumb" url_name %}
     """
-
-    bits = token.split_contents()
-    if len(bits) == 2:
-        return breadcrumb(parser, token)
-
-    # Extract our extra title parameter
-    title = bits.pop(1)
-    token.contents = ' '.join(bits)
-
-    url_node = url(parser, token)
-
-    return UrlBreadcrumbNode(title, url_node)
+    url = reverse(url_name)
+    return create_crumb(title, url)
 
 
 @register.simple_tag
 def breadcrumb_active(title):
     """
-    Same as breadcrumb, but adds "active" CSS class.  Only breadcrumb title is
-    supported.
+    Add active breadcrumb, but not in an anchor.
+    Example usage:
         {% breadcrumb_active "Title of breadcrumb" %}
     """
-    return create_crumb(title, active=True)
+    return create_crumb(title, url=None, active=True)
 
 
-class BreadcrumbNode(Node):
-    def __init__(self, vars):
-        """
-        First var is title, second var is url context variable
-        """
-        self.vars = list(map(Variable, vars))
-
-    def render(self, context):
-        title = self.vars[0].var
-
-        if title.find("'") == -1 and title.find('"') == -1:
-            try:
-                val = self.vars[0]
-                title = val.resolve(context)
-            except:
-                title = ''
-
-        else:
-            title = title.strip("'").strip('"')
-            title = smart_text(title)
-
-        url = None
-
-        if len(self.vars) > 1:
-            val = self.vars[1]
-            try:
-                url = val.resolve(context)
-            except VariableDoesNotExist:
-                _LOG.warning('URL does not exist {}'.format(val))
-                url = None
-
-        return create_crumb(title, url)
+@register.simple_tag
+def breadcrumb_index_all_objects(model):
+    """
+    Add breadcrumb linking to the listing of all objects of specific type.
+    This tag accepts both models or model instances as an argument.
+    Example usage:
+        {% breadcrumb_index_all_objects model %}
+        {% breadcrumb_index_all_objects person %}
+    """
+    plural = force_text(model._meta.verbose_name_plural)
+    title = 'All {}'.format(plural)
+    url_name = 'all_{}'.format(plural)
+    url = reverse(url_name)
+    return create_crumb(title, url)
 
 
-class UrlBreadcrumbNode(Node):
-    def __init__(self, title, url_node):
-        self.title = Variable(title)
-        self.url_node = url_node
+@register.simple_tag
+def breadcrumb_edit_object(obj):
+    """
+    Add an active breadcrumb with the title "Edit MODEL_NAME".
+    This tag accepts model instance as an argument.
+    Example usage:
+        {% breadcrumb_edit_object person %}
+    """
+    singular = force_text(obj._meta.verbose_name)
+    title = 'Edit {}'.format(singular)
+    return create_crumb(title, url=None, active=True)
 
-    def render(self, context):
-        title = self.title.var
 
-        if title.find("'") == -1 and title.find('"') == -1:
-            try:
-                val = self.title
-                title = val.resolve(context)
-            except:
-                title = ''
-        else:
-            title = title.strip("'").strip('"')
-            title = smart_text(title)
+@register.simple_tag
+def breadcrumb_new_object(model):
+    """
+    Add an active breadcrumb with the title "Add new MODEL_NAME".
+    This tag accepts model class as an argument.
+    Example usage:
+        {% breadcrumb_new_object person %}
+    """
+    singular = force_text(model._meta.verbose_name)
+    title = 'Add new {}'.format(singular)
+    return create_crumb(title, url=None, active=True)
 
-        url = self.url_node.render(context)
-        return create_crumb(title, url)
+
+@register.simple_tag
+def breadcrumb_object(obj):
+    """
+    Add non-active breadcrumb with the title "Add new MODEL_NAME".
+    This tag accepts model instance as an argument.
+    Example usage:
+        {% breadcrumb_object person %}
+    """
+    title = str(obj)
+    url = obj.get_absolute_url()
+    return create_crumb(title, url, active=False)
+
+
+@register.simple_tag
+def breadcrumb_main_page():
+    """
+    Special case of ``breadcrumb_url``.  In all templates there's always a link
+    to the main page so I wanted to save everyone thinking & writing by
+    introducing this helper tag.
+    Example usage:
+        {% breadcrumb_main_page %}
+    """
+    title = 'Amy'
+    url = reverse('index')
+    return create_crumb(title, url)
 
 
 def create_crumb(title, url=None, active=False):
     """
-    Helper function
+    Helper function that creates breadcrumb.
     """
-
     active_str = ""
     if active:
         active_str = ' class="active"'
@@ -135,6 +121,6 @@ def create_crumb(title, url=None, active=False):
     if url:
         inner_str = '<a href="%s">%s</a>' % (url, title)
 
-    crumb = "<li %s>%s</li>" % (active_str, inner_str)
+    crumb = "<li%s>%s</li>" % (active_str, inner_str)
 
     return crumb

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -5,8 +5,8 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
 
     url(r'^sites/?$', views.all_sites, name='all_sites'),
-    url(r'^site/(?P<site_domain>[\w\./-]+)/?$', views.site_details, name='site_details'),
-    url(r'^site/(?P<site_domain>[\w\./-]+)/edit$', views.SiteUpdate.as_view(), name='site_edit'),
+    url(r'^site/(?P<site_domain>[\w\.-]+)/?$', views.site_details, name='site_details'),
+    url(r'^site/(?P<site_domain>[\w\.-]+)/edit$', views.SiteUpdate.as_view(), name='site_edit'),
     url(r'^sites/add/$', views.SiteCreate.as_view(), name='site_add'),
 
     url(r'^airports/?$', views.all_airports, name='all_airports'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -64,6 +64,10 @@ class UpdateViewContext(UpdateView):
     def get_context_data(self, **kwargs):
         context = super(UpdateViewContext, self).get_context_data(**kwargs)
 
+        # self.model is available in UpdateView as the model class being
+        # used to update model instance
+        context['model'] = self.model
+
         # self.object is available in UpdateView as the object being currently
         # edited
         context['title'] = str(self.object)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -34,11 +34,10 @@ ITEMS_PER_PAGE = 25
 #------------------------------------------------------------
 
 
-class UpdateViewContext(UpdateView, ContextMixin):
+class UpdateViewContext(UpdateView):
     """
-    Class-based view inheriting ``UpdateView`` and ``ContextMixin``.  This
-    makes it possible to specify variables used in all AMY's update views,
-    for example: title.
+    Class-based view that extends default template context by adding proper
+    title.
     """
 
     def get_context_data(self, **kwargs):

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -6,7 +6,7 @@ import requests
 from django.contrib import messages
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
-from django.db.models import Count, Q
+from django.db.models import Count, Q, Model
 from django.shortcuts import redirect, render, get_object_or_404
 from django.views.generic.base import ContextMixin
 from django.views.generic.edit import CreateView, UpdateView
@@ -34,10 +34,31 @@ ITEMS_PER_PAGE = 25
 #------------------------------------------------------------
 
 
+class CreateViewContext(CreateView):
+    """
+    Class-based view for creating objects that extends default template context
+    by adding model class used in objects creation.
+    """
+
+    def get_context_data(self, **kwargs):
+        context = super(CreateViewContext, self).get_context_data(**kwargs)
+
+        # self.model is available in CreateView as the model class being
+        # used to create new model instance
+        context['model'] = self.model
+
+        if self.model and issubclass(self.model, Model):
+            context['title'] = 'New {}'.format(self.model._meta.verbose_name)
+        else:
+            context['title'] = 'New object'
+
+        return context
+
+
 class UpdateViewContext(UpdateView):
     """
-    Class-based view that extends default template context by adding proper
-    title.
+    Class-based view for updating objects that extends default template context
+    by adding proper page title.
     """
 
     def get_context_data(self, **kwargs):
@@ -211,7 +232,7 @@ def _upload_person_task_csv(request, uploaded_file):
     return persons_tasks
 
 
-class PersonCreate(CreateView):
+class PersonCreate(CreateViewContext):
     model = Person
     fields = '__all__'
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -108,12 +108,12 @@ def site_details(request, site_domain):
     return render(request, 'workshops/site.html', context)
 
 
-class SiteCreate(CreateView):
+class SiteCreate(CreateViewContext):
     model = Site
     fields = SITE_FIELDS
 
 
-class SiteUpdate(UpdateView):
+class SiteUpdate(UpdateViewContext):
     model = Site
     fields = SITE_FIELDS
     slug_field = 'domain'
@@ -142,12 +142,12 @@ def airport_details(request, airport_iata):
     return render(request, 'workshops/airport.html', context)
 
 
-class AirportCreate(CreateView):
+class AirportCreate(CreateViewContext):
     model = Airport
     fields = AIRPORT_FIELDS
 
 
-class AirportUpdate(UpdateView):
+class AirportUpdate(UpdateViewContext):
     model = Airport
     fields = AIRPORT_FIELDS
     slug_field = 'iata'
@@ -288,12 +288,12 @@ def validate_event(request, event_ident):
     return render(request, 'workshops/validate_event.html', context)
 
 
-class EventCreate(CreateView):
+class EventCreate(CreateViewContext):
     model = Event
     fields = '__all__'
 
 
-class EventUpdate(UpdateView):
+class EventUpdate(UpdateViewContext):
     model = Event
     fields = '__all__'
     pk_url_kwarg = 'event_ident'
@@ -323,12 +323,12 @@ def task_details(request, event_slug, person_id, role_name):
     return render(request, 'workshops/task.html', context)
 
 
-class TaskCreate(CreateView):
+class TaskCreate(CreateViewContext):
     model = Task
     fields = TASK_FIELDS
 
 
-class TaskUpdate(UpdateView):
+class TaskUpdate(UpdateViewContext):
     model = Task
     fields = TASK_FIELDS
     pk_url_kwarg = 'task_id'
@@ -369,12 +369,12 @@ def cohort_details(request, cohort_name):
     return render(request, 'workshops/cohort.html', context)
 
 
-class CohortCreate(CreateView):
+class CohortCreate(CreateViewContext):
     model = Cohort
     fields = COHORT_FIELDS
 
 
-class CohortUpdate(UpdateView):
+class CohortUpdate(UpdateViewContext):
     model = Cohort
     fields = COHORT_FIELDS
     slug_field = 'name'


### PR DESCRIPTION
It may seem not connected, but thanks to new `CreateViewContext` and `UpdateViewContext` I was able to repair breadcrumbs.

1. These new views were created because Django basic `CreateView` and `UpdateView` do not carry template variables we needed. And because every update/create view uses variables `title` and (from now) `model`, I made `CreateViewContext` and `UpdateViewContext` that set these variables.

2. Breadcrumbs were neglected and inconsistent across pages. I removed unnecessary template tags code, took a look at what breadcrumbs are used most of the time and come up with some. More in commit message 2b164aaa482fdaeed8e9f835345f8968435954c7

This fixes #142.

EDIT: Forgot to mention that I fixed some URL regexp bug preventing sites editing.