### PR TITLE
Fix missing import (django.db.Model) in views

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.db import IntegrityError, transaction
-from django.db.models import Count, Q
+from django.db.models import Count, Q, Model
 from django.shortcuts import redirect, render, get_object_or_404
 from django.views.generic.base import ContextMixin
 from django.views.generic.edit import CreateView, UpdateView


### PR DESCRIPTION
This fixes NameError exception "global name 'Model' is not defined".
Exception occured in `CreateViewContext` class-based view.

This must have been my fault when I introduced `CreateViewContext` class
view.