### PR TITLE
Fix: '$' was missing in URL regex for task edit

### DIFF
--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r'^event/(?P<event_ident>[\w-]+)/validate/?$', views.validate_event, name='validate_event'),
 
     url(r'^tasks/?$', views.all_tasks, name='all_tasks'),
-    url(r'^task/(?P<task_id>\d+)/?', views.task_details, name='task_details'),
+    url(r'^task/(?P<task_id>\d+)/?$', views.task_details, name='task_details'),
     url(r'^task/(?P<task_id>\d+)/edit$', views.TaskUpdate.as_view(), name='task_edit'),
     url(r'^tasks/add/$', views.TaskCreate.as_view(), name='task_add'),
 


### PR DESCRIPTION
Missing '$' (matches end-of-line or something like that) made
task edit view render task detail view.