### PR TITLE
Fix Event identification regex to include YYYY-MM format

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -232,12 +232,9 @@ class Event(models.Model):
         if re.match(r'^\d+$', ident):
             return Event.objects.get(id=ident)
 
-        # match event slug in format YYYY-MM-****
+        # match event slug in format YYYY-MM-**** (ie. this works for
+        # YYYY-MMMM-DD-**** too)
         if re.match(r'^\d{4}-\d{2}-.+$', ident):
-            return Event.objects.get(slug=ident)
-
-        # match event slug in format YYYY-MM-DD-****
-        if re.match(r'^\d{4}-\d{2}-\d{2}-.+$', ident):
             return Event.objects.get(slug=ident)
 
         raise ObjectDoesNotExist(ident)

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -228,9 +228,15 @@ class Event(models.Model):
         The real indicator is the 'published' flag.
         '''
 
+        # match event ID
         if re.match(r'^\d+$', ident):
             return Event.objects.get(id=ident)
 
+        # match event slug in format YYYY-MM-****
+        if re.match(r'^\d{4}-\d{2}-.+$', ident):
+            return Event.objects.get(slug=ident)
+
+        # match event slug in format YYYY-MM-DD-****
         if re.match(r'^\d{4}-\d{2}-\d{2}-.+$', ident):
             return Event.objects.get(slug=ident)
 


### PR DESCRIPTION
When fetching Event by identification text, which could be either event
ID or slug, format `'YYYY-MM-text'` was not correctly matched.  Both
`'YYYY-MM-DD-text'` and `'ID'` worked correctly, though.

This is now fixed.  Fetching Event by ident now checks these 3 formats
(in this order):

* `'ID'`

* `'YYYY-MM-****'`

* `'YYYY-MM-DD-****'`

This fixes #171 .