### PR TITLE
More Python 3 fixes for the test suite

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 # this probably needs refactored for py3
 from datetime import datetime
-from StringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 from importlib import import_module
 
 from django.conf import settings

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# this probably needs refactored for py3
+import cgi
 from datetime import datetime
 try:
     from io import StringIO
@@ -204,4 +204,7 @@ class BulkUploadUsersViewTestCase(CSVBulkUploadTestBase):
         }
         rv = self.client.post(reverse('person_bulk_add_confirmation'), payload)
         self.assertEqual(rv.status_code, 200)
-        self.assertNotIn("foobar", rv.content)
+        _, params = cgi.parse_header(rv['content-type'])
+        charset = params['charset']
+        content = rv.content.decode(charset)
+        self.assertNotIn('foobar', content)

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 import codecs
-import cStringIO
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
 import csv
 from math import pi, sin, cos, acos
 
@@ -17,7 +20,7 @@ class UnicodeWriter:
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
+        self.queue = StringIO()
         self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
         self.stream = f
         self.encoder = codecs.getincrementalencoder(encoding)()


### PR DESCRIPTION
Fix Python 3 incompatibilities that have landed since #140.  After
this series,

  $ python3.4 manage.py test

passes again.