### PR TITLE
Undoing Py3 compatibility for StringIO in order to get tests to pass

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 import cgi
 from datetime import datetime
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
+from StringIO import StringIO
 from importlib import import_module
 
 from django.conf import settings

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -1,9 +1,6 @@
 # coding: utf-8
 import codecs
-try:
-    from io import StringIO
-except ImportError:
-    from cStringIO import StringIO
+from cStringIO import StringIO
 import csv
 from math import pi, sin, cos, acos
 


### PR DESCRIPTION
0dae639 changed the import of StringIO to be compatible with Py3 as well as Py2.7.  Problem is, tests of CSV upload fail with it in place.  Since we're deploying on Py2.7, I'm submitting a PR to undo this change - while we need Unicode support for CSV upload, (a) the rest of our code hasn't been tested Unicode-clean yet and (b) this is blocking work on auth.