### PR TITLE
Remove Unicode Py2 shenanigans

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 import cgi
 from datetime import datetime
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 from importlib import import_module
 
 from django.conf import settings

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -2,6 +2,7 @@
 from math import pi, sin, cos, acos
 from io import TextIOWrapper, StringIO
 import csv
+
 from .models import Event, Role, Person
 
 

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -3,6 +3,8 @@ from math import pi, sin, cos, acos
 from io import TextIOWrapper, StringIO
 import csv
 
+from django.conf import settings
+
 from .models import Event, Role, Person
 
 
@@ -36,7 +38,7 @@ def earth_distance(pos1, pos2):
     return arc * 6373
 
 
-def upload_person_task_csv(uploaded_file, encoding="utf-8"):
+def upload_person_task_csv(uploaded_file, encoding=None):
     """
     Read data from CSV and turn it into JSON-serializable list of dictionaries.
     "Serializability" is required because we put this data into session.  See
@@ -44,8 +46,14 @@ def upload_person_task_csv(uploaded_file, encoding="utf-8"):
 
     Also return a list of fields from Person.PERSON_UPLOAD_FIELDS for which
     no data was given.
+
+    :param string encoding: encoding used to encode incoming file. Defaults to
+                            ``django.conf.settings.DEFAULT_CHARSET``
     """
     persons_tasks = []
+
+    if not encoding:
+        encoding = settings.DEFAULT_CHARSET
 
     # we provide uploaded_file as StringIO in our tests (test_util.py)
     if not issubclass(StringIO, uploaded_file.__class__):

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -1,45 +1,8 @@
 # coding: utf-8
-import codecs
-try:
-    from io import StringIO
-except ImportError:
-    from cStringIO import StringIO
-import csv
 from math import pi, sin, cos, acos
-
+from io import TextIOWrapper, StringIO
+import csv
 from .models import Event, Role, Person
-
-
-class UnicodeWriter:
-    """
-    A CSV writer which will write rows to CSV file "f",
-    which is encoded in the given encoding.
-
-    https://docs.python.org/2/library/csv.html#examples
-    """
-
-    def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
-        # Redirect output to a queue
-        self.queue = StringIO()
-        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
-        self.stream = f
-        self.encoder = codecs.getincrementalencoder(encoding)()
-
-    def writerow(self, row):
-        self.writer.writerow([s.encode("utf-8") for s in row])
-        # Fetch UTF-8 output from the queue ...
-        data = self.queue.getvalue()
-        data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
-        data = self.encoder.encode(data)
-        # write to the target stream
-        self.stream.write(data)
-        # empty queue
-        self.queue.truncate(0)
-
-    def writerows(self, rows):
-        for row in rows:
-            self.writerow(row)
 
 
 def earth_distance(pos1, pos2):
@@ -72,7 +35,7 @@ def earth_distance(pos1, pos2):
     return arc * 6373
 
 
-def upload_person_task_csv(uploaded_file):
+def upload_person_task_csv(uploaded_file, encoding="utf-8"):
     """
     Read data from CSV and turn it into JSON-serializable list of dictionaries.
     "Serializability" is required because we put this data into session.  See
@@ -82,10 +45,18 @@ def upload_person_task_csv(uploaded_file):
     no data was given.
     """
     persons_tasks = []
+
+    # we provide uploaded_file as StringIO in our tests (test_util.py)
+    if not issubclass(StringIO, uploaded_file.__class__):
+        # Django provides uploaded files as byte file objects.  We need to wrap
+        # `uploaded_file` and provide it as a text file with specific encoding.
+        # This way we force users to upload UTF-8 encoded files.
+        uploaded_file = TextIOWrapper(uploaded_file.file, encoding=encoding)
+
     reader = csv.DictReader(uploaded_file)
     empty_fields = []
     for row in reader:
-        person_fields= {}
+        person_fields = {}
         for col in Person.PERSON_UPLOAD_FIELDS:
             try:
                 person_fields[col] = row[col].strip()


### PR DESCRIPTION
This commit removes conditional StringIO import in a few source files as
well as fixes uploading unicode CSV-files.

Conditional import
==================

To support both Py2 and Py3 we had conditional imports:

```python
try:
	from io import StringIO
except ImportError:
	from cStringIO import StringIO
```

By moving to Py3-only we can drop these imports in favor of nice and
simple `from io import StringIO`.

Unicode issues with uploaded CSV files
======================================

By moving to Py3, it appeared that Django serves uploaded files as byte
files, not text files.  This forces us to encode upcoming files into
UTF-8 text files (which `TextIOWrapper` does).

`UnicodeWriter` removal
=======================

Helper class `UnicodeWriter` was required to make unicode CSV files,
because `csv` module from Python 2.x standard library couldn't handle
unicode files.

With migration to Python 3.x we can get rid of it, because now `csv`
module fully supports unicode files.