### PR TITLE
workshops/util.py: Expect a Unicode stream in upload_person_task_csv

### DIFF
--- a/workshops/templates/workshops/person_bulk_add_form.html
+++ b/workshops/templates/workshops/person_bulk_add_form.html
@@ -10,7 +10,8 @@
 {% block content %}
 {% load staticfiles %}
 <p><a href="{% url 'person_bulk_add_template' %}">BulkPersonAddTemplate.csv</a> is a blank template of a well-formed .CSV file.</p>
-<form action="" method="post" enctype="multipart/form-data">
+<form action="" method="post" enctype="multipart/form-data"
+      accept-charset="{{charset}}">
     {% csrf_token %}
     {{ form.as_p }}
     <input type="submit" value="Submit" />

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -35,18 +35,22 @@ def earth_distance(pos1, pos2):
     return arc * 6373
 
 
-def upload_person_task_csv(uploaded_file):
-    """
-    Read data from CSV and turn it into JSON-serializable list of dictionaries.
+def upload_person_task_csv(stream):
+    """Read people from CSV and return a JSON-serializable list of dicts.
+
+    The input `stream` should be a file-like object that returns
+    Unicode data.
+
     "Serializability" is required because we put this data into session.  See
     https://docs.djangoproject.com/en/1.7/topics/http/sessions/ for details.
 
     Also return a list of fields from Person.PERSON_UPLOAD_FIELDS for which
     no data was given.
+
     """
     persons_tasks = []
 
-    reader = csv.DictReader(uploaded_file)
+    reader = csv.DictReader(stream)
     empty_fields = []
     for row in reader:
         person_fields = {}

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -1,9 +1,6 @@
 # coding: utf-8
 from math import pi, sin, cos, acos
-from io import TextIOWrapper, StringIO
 import csv
-
-from django.conf import settings
 
 from .models import Event, Role, Person
 
@@ -38,7 +35,7 @@ def earth_distance(pos1, pos2):
     return arc * 6373
 
 
-def upload_person_task_csv(uploaded_file, encoding=None):
+def upload_person_task_csv(uploaded_file):
     """
     Read data from CSV and turn it into JSON-serializable list of dictionaries.
     "Serializability" is required because we put this data into session.  See
@@ -46,21 +43,8 @@ def upload_person_task_csv(uploaded_file, encoding=None):
 
     Also return a list of fields from Person.PERSON_UPLOAD_FIELDS for which
     no data was given.
-
-    :param string encoding: encoding used to encode incoming file. Defaults to
-                            ``django.conf.settings.DEFAULT_CHARSET``
     """
     persons_tasks = []
-
-    if not encoding:
-        encoding = settings.DEFAULT_CHARSET
-
-    # we provide uploaded_file as StringIO in our tests (test_util.py)
-    if not issubclass(StringIO, uploaded_file.__class__):
-        # Django provides uploaded files as byte file objects.  We need to wrap
-        # `uploaded_file` and provide it as a text file with specific encoding.
-        # This way we force users to upload UTF-8 encoded files.
-        uploaded_file = TextIOWrapper(uploaded_file.file, encoding=encoding)
 
     reader = csv.DictReader(uploaded_file)
     empty_fields = []


### PR DESCRIPTION
Instead of passing in an encoding and doing some issubclass stuff,
just require a Unicode stream in upload_person_task_csv.  In general,
decoding to Unicode as soon as possible and encoding to bytes as late
as possible makes for cleaner code (who better to know the proper
encoding than the first/last code that touches the content?).  We see
that here, with a simpler upload_person_task_csv implementation and
only a two more lines in person_bulk_add to wrap the incoming file in
a StreamReader.

The accept-charset business is a hack to work around shortcomings in
modern browsers.  For example, the data posted from my Firefox 24.8
looks like:

    Content-Type: multipart/form-data; boundary=---------------------------196554893016147250581211961313
    Content-Length: 477

    -----------------------------196554893016147250581211961313

    Content-Disposition: form-data; name="csrfmiddlewaretoken"

    D8gooO2bYBXwsVQndknbnHUkJbs9ZRHp

    -----------------------------196554893016147250581211961313

    Content-Disposition: form-data; name="file"; filename="BulkPersonAddTemplate.csv"
    Content-Type: text/csv

    personal,middle,family,email,event,role
    αβ,γδ,Ε,a@b.com,2015-02-05-esu,student

    -----------------------------196554893016147250581211961313--

It's setting a per-file Content-Type (yay!), but that Content-Type
doesn't have charset information (boo!).  It looks like [the Mozilla
folks tried to fix this][1], but [backed it out in 2007][2] because it
[broke][3] some [crummy parsers][4].

I see nothing in RFC 2388 that is file-specific, but [their only
Content-Type example does show a charset][5].  The only workable,
spec-compliant solution I can come up with is to explictly set
[accept-charset][6].  Otherwise, the user agent is supposed to use
some [wonky fallbacks][7] (although if `DEFAULT_CHARSET` was UTF-8,
those would end up as UTF-8 too).

The current approach is to respect the charset set by the user-agent
(which we can access via the [.charset property][8]).  If it doesn't
set one, we expect it to respect the form's accept-charset and use
`DEFAULT_CHARSET`.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=116346
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=116346#c79
[3]: https://bugzilla.mozilla.org/show_bug.cgi?id=116346#c74
[4]: https://bugzilla.mozilla.org/show_bug.cgi?id=392982#c45
[5]: https://tools.ietf.org/html/rfc2388#section-4.5
[6]: http://www.w3.org/TR/html5/forms.html#attr-form-accept-charset
[7]: http://www.w3.org/TR/html5/forms.html#multipart/form-data-encoding-algorithm
[8]: https://docs.djangoproject.com/en/1.7/ref/files/uploads/#django.core.files.uploadedfile.UploadedFile.charset