### PR TITLE
Continuous integration and coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ htmlerror
 *~
 *.pyc
 db.sqlite3
-*.sublime-project
-*.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ htmlerror
 *~
 *.pyc
 db.sqlite3
+
+# coverage reports
+.coverage
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 3.4
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+script:
+  coverage run --source=amy,workshops manage.py test
+after_success:
+  coveralls


### PR DESCRIPTION
This PR adds files required for testing on [Travis-CI](https://travis-ci.org/) server as well as measuring coverage through [coveralls.io](https://coveralls.io/).

The `.travis.yml` file was assembled from these instructions:

* http://docs.travis-ci.com/user/languages/python/
* https://github.com/coagulant/coveralls-python

Similarly looking files are supporting development of other open source projects (for example: [Tornado](https://github.com/tornadoweb/tornado/blob/master/.travis.yml), [Slumber](https://github.com/samgiles/slumber/blob/master/.travis.yml)).

This PR addresses #166.