### PR TITLE
models.py: remove Person.slug

### DIFF
--- a/workshops/migrations/0003_remove_person_slug.py
+++ b/workshops/migrations/0003_remove_person_slug.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0002_auto_20150219_1305'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='person',
+            name='slug',
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -109,7 +109,6 @@ class Person(AbstractBaseUser, PermissionsMixin):
     github      = models.CharField(max_length=STR_MED, unique=True, null=True, blank=True)
     twitter     = models.CharField(max_length=STR_MED, unique=True, null=True, blank=True)
     url         = models.CharField(max_length=STR_LONG, null=True, blank=True)
-    slug        = models.CharField(max_length=STR_LONG, null=True, blank=True)
     username    = models.CharField(max_length=STR_MED, unique=True)
 
     USERNAME_FIELD = 'username'

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -82,7 +82,7 @@ class TestBase(TestCase):
             personal='Hermione', middle=None, family='Granger',
             email='hermione@granger.co.uk', gender='F', may_contact=True,
             airport=self.airport_0_0, github='herself', twitter='herself',
-            url='http://hermione.org', slug='granger.h', username="granger.h")
+            url='http://hermione.org', username="granger.h")
 
         Award.objects.create(person=self.hermione,
                              badge=self.instructor,
@@ -94,7 +94,7 @@ class TestBase(TestCase):
             personal='Harry', middle=None, family='Potter',
             email='harry@hogwarts.edu', gender='M', may_contact=True,
             airport=self.airport_0_50, github='hpotter', twitter=None,
-            url=None, slug='potter.h', username="potter.h")
+            url=None, username="potter.h")
 
         Award.objects.create(person=self.harry,
                              badge=self.instructor,
@@ -105,8 +105,7 @@ class TestBase(TestCase):
             personal='Ron', middle=None, family='Weasley',
             email='rweasley@ministry.gov.uk', gender='M', may_contact=False,
             airport=self.airport_50_100, github=None, twitter=None,
-            url='http://geocities.com/ron_weas', slug='weasley.ron',
-            username="weasley.ron")
+            url='http://geocities.com/ron_weas', username="weasley.ron")
 
         Award.objects.create(person=self.ron,
                              badge=self.instructor,

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -618,7 +618,9 @@ def _export_badges():
     result = {}
     for badge in Badge.objects.all():
         persons = Person.objects.filter(award__badge_id=badge.id)
-        result[badge.name] = [{"user" : p.slug, "name" : p.get_full_name()} for p in persons]
+        result[badge.name] = [
+            {"user": p.username, "name": p.get_full_name()} for p in persons
+        ]
     return result
 
 


### PR DESCRIPTION
Person.slug was replaced with Person.username.

This PR is based on @gvwilson work done in #205, but instead of making `Person.username` blank, `Person.username` stays the way it was previously (unique, non-nullable, non-blankable).