### PR TITLE
Fix py2 depend

### DIFF
--- a/workshops/check.py
+++ b/workshops/check.py
@@ -138,7 +138,7 @@ def look_for_fixme(func):
     '''Decorator to fail test if text argument starts with "FIXME".'''
     def inner(arg):
         if (arg is not None) and \
-           isinstance(arg, basestring) and \
+           isinstance(arg, str) and \
            arg.lstrip().startswith('FIXME'):
             return False
         return func(arg)


### PR DESCRIPTION
Since basestring has been deprecated in Python3, I changed the use of ```basestring``` to ```str``` in the decorator ```look_for_fixme``` at ```workshops/checks.py```. Please review.