### PR TITLE
Mark events and tasks as deleted

### DIFF
--- a/workshops/migrations/0005_auto_20150506_0848.py
+++ b/workshops/migrations/0005_auto_20150506_0848.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0004_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='deleted',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='task',
+            name='deleted',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -233,7 +233,8 @@ class EventManager(models.Manager):
 
     # Attach our custom query set to the manager
     def get_queryset(self):
-        return EventQuerySet(self.model, using=self._db)
+        """Fetch only existing events (ie. not deleted)."""
+        return EventQuerySet(self.model, using=self._db).filter(deleted=False)
 
     # Proxy methods so we can call our custom filters from the manager
     # without explicitly creating an EventQuerySet first - see
@@ -267,6 +268,7 @@ class Event(models.Model):
     admin_fee  = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
     fee_paid   = models.NullBooleanField(default=False, blank=True)
     notes      = models.TextField(default="", blank=True)
+    deleted = models.BooleanField(default=False)
 
     class Meta:
         ordering = ('-start', )
@@ -325,12 +327,21 @@ class Role(models.Model):
 
 #------------------------------------------------------------
 
+
+class TaskManager(models.Manager):
+    def get_queryset(self):
+        """Fetch only existing tasks (ie. not deleted)."""
+        return super().get_queryset().filter(deleted=False)
+
 class Task(models.Model):
     '''Represent who did what at events.'''
 
     event      = models.ForeignKey(Event)
     person     = models.ForeignKey(Person)
     role       = models.ForeignKey(Role)
+    deleted = models.BooleanField(default=False)
+
+    objects = TaskManager()
 
     class Meta:
         unique_together = ("event", "person", "role")

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -46,6 +46,7 @@
 <p>No notes.</p>
 {% endif %}
 <p class="edit-object"><a href="{% url 'event_edit' event.id %}">Edit this event</a></p>
+<p class="delete-object"><a href="{% url 'event_delete' event.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")'>Delete this event</a></p>
 {% if event.url %}
 <p>... <a href="{% url 'validate_event' event.slug %}">validate event</a></p>
 {% else %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^events/?$', views.all_events, name='all_events'),
     url(r'^event/(?P<event_ident>[\w-]+)/?$', views.event_details, name='event_details'),
     url(r'^event/(?P<event_ident>[\w-]+)/edit$', views.event_edit, name='event_edit'),
+    url(r'^event/(?P<event_ident>[\w-]+)/delete$', views.event_delete, name='event_delete'),
     url(r'^events/add/$', views.EventCreate.as_view(), name='event_add'),
     url(r'^event/(?P<event_ident>[\w-]+)/validate/?$', views.validate_event, name='validate_event'),
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -488,6 +488,23 @@ def event_edit(request, event_ident):
                'form_helper': bootstrap_helper_without_form}
     return render(request, 'workshops/event_edit_form.html', context)
 
+
+@login_required
+def event_delete(request, event_ident):
+    """Mark event as deleted.
+
+    Additionally mark tasks pointing at that event as deleted, too."""
+    try:
+        event = Event.get_by_ident(event_ident)
+        tasks = event.task_set
+    except ObjectDoesNotExist:
+        raise Http404("No event found matching the query.")
+
+    tasks.update(deleted=True)
+    event.deleted = True
+    event.save()
+    return redirect(reverse('all_events'))
+
 #------------------------------------------------------------
 
 TASK_FIELDS = ['event', 'person', 'role']
@@ -519,7 +536,8 @@ def task_details(request, task_id):
 def task_delete(request, task_id):
     '''Delete a task. This is used on the event edit page'''
     t = Task.objects.get(pk=task_id)
-    t.delete()
+    t.deleted = True
+    t.save()
     return redirect(event_edit, t.event.id)
 
 


### PR DESCRIPTION
This PR changes the way events and tasks are deleted: they're marked as deleted (`object.deleted=True`) instead of being removed from the database for real.

It was achieved by adding a filter to default query sets for both models.

A downside of this solution is that we can still delete an event/task by:

```python
task.delete()
event.delete()
Task.objects.filter(…).delete()
Event.objects.filter(…).delete()
```

These commands will result in objects being removed from the database.