### PR TITLE
Trying to get a list of workshops that owe us money

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -227,6 +227,16 @@ class EventQuerySet(models.query.QuerySet):
 
         return self.filter(published=False)
 
+    def unpaid_events(self):
+        '''Return a queryset for events that owe money.'''
+
+        # All events that have a non-zero admin fee.
+        queryset = self.filter(admin_fee__ne=0)
+
+        # Of those, all those whose paid status is not 'Yes' (i.e., is 'No' or NULL).
+        queryset = queryset.filter(fee_paid__ne=True)
+
+        return queryset
 
 class EventManager(models.Manager):
     '''A custom manager which is essentially a proxy for EventQuerySet'''

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -230,13 +230,8 @@ class EventQuerySet(models.query.QuerySet):
     def unpaid_events(self):
         '''Return a queryset for events that owe money.'''
 
-        # All events that have a non-zero admin fee.
-        queryset = self.filter(admin_fee__ne=0)
-
-        # Of those, all those whose paid status is not 'Yes' (i.e., is 'No' or NULL).
-        queryset = queryset.filter(fee_paid__ne=True)
-
-        return queryset
+        # All events that have an admin fee but are not marked as paid.
+        return self.filter(admin_fee__gt=0).exclude(fee_paid=True)
 
 class EventManager(models.Manager):
     '''A custom manager which is essentially a proxy for EventQuerySet'''
@@ -260,6 +255,9 @@ class EventManager(models.Manager):
 
     def unpublished_events(self):
         return self.get_queryset().unpublished_events()
+
+    def unpaid_events(self):
+        return self.get_queryset().unpaid_events()
 
 class Event(models.Model):
     '''Represent a single event.'''

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -34,7 +34,7 @@
     {% endfor %}
     </table>
   </div>
-  <div class="col-sx-4">
+  <div class="col-xs-4">
     <h3>Unpaid events</h3>
     <table class="table table-striped">
     {% for event in unpaid_events %}

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -8,7 +8,7 @@
 {% include "amy-logo.html" %}
 
 <div class="row">
-  <div class="col-xs-6">
+  <div class="col-xs-4">
     <h3>Upcoming events</h3>
     <table class="table table-striped">
     {% for event in upcoming_events %}
@@ -18,7 +18,7 @@
     {% endfor %}
     </table>
   </div>
-  <div class="col-xs-6">
+  <div class="col-xs-4">
     <h3>Unpublished events</h3>
     <table class="table table-striped">
     {% for event in unpublished_events %}
@@ -30,6 +30,16 @@
           {% if event.slug %}: {{ event.slug }}{% endif %}
         </a>
       </td>
+    </tr>
+    {% endfor %}
+    </table>
+  </div>
+  <div class="col-sx-4">
+    <h3>Unpaid events</h3>
+    <table class="table table-striped">
+    {% for event in unpaid_events %}
+    <tr>
+      <td><a href="{{ event.get_absolute_url }}">{{ event.slug }}</a></td>
     </tr>
     {% endfor %}
     </table>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -113,9 +113,11 @@ def index(request):
     '''Home page.'''
     upcoming_events = Event.objects.upcoming_events()
     unpublished_events = Event.objects.unpublished_events()
+    unpaid_events = Event.objects.unpaid_events()
     context = {'title': None,
                'upcoming_events': upcoming_events,
-               'unpublished_events': unpublished_events}
+               'unpublished_events': unpublished_events,
+               'unpaid_events': unpaid_events}
     return render(request, 'workshops/index.html', context)
 
 #------------------------------------------------------------


### PR DESCRIPTION
The aim of this PR is to show a third column on the dashboard page listing all the workshops that owe us an admin fee. The test for these workshops is:

* admin_fee > 0
* fee_paid != True (i.e., is either False or unknown (NULL))

EventQuerySet.unpaid_events is supposed to return this set, but it isn't working.  The test I conducted is to modify the standard (fake) test data like this:

~~~
update workshops_event set admin_fee = 1500 where id=344;
update workshops_event set admin_fee = 1500 where id=343;
update workshops_event set fee_paid = 0 where id=343;
~~~

and then check with:

~~~
select * from workshops_event where admin_fee > 0.0;

343|1|2015-07-02|2015-07-03|2015-07-02-UQ|https://github.com/bio-swc-bne/2015-07-02-UQ|||1500|0|||241
344|1|2015-07-13|2015-07-14|2015-07-13-amos|https://github.com/damienirving/2015-07-13-amos|||1500||||241
~~~

so there are two workshops that should show up, but none do.  The most likely explanation is that the custom query set is wrong - help!