### PR TITLE
Fix: template rev. URL error for events w/o slug

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -114,3 +114,4 @@ class DebriefForm(forms.Form):
 EventForm = modelform_factory(Event, fields="__all__")
 TaskForm = modelform_factory(Task, fields="__all__",
                              widgets={'event': HiddenInput})
+

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -297,24 +297,13 @@ class Event(models.Model):
     def get_by_ident(ident):
         '''
         Select event that matches given identifier.
-
-        If the event identifier is purely numeric, it's an ID (and
-        probably indicates a pending event whose details are still being
-        negotiated).  If it contains dashes, it's probably a
-        YYYY-MM-DD-site slug, and indicates an event whose dates are firm.
-        The real indicator is the 'published' flag.
+        If ident is an int, search for matching primary-key;
+        otherwise get matching slug. May throw DoesNotExist error.
         '''
-
-        # match event ID
-        if re.match(r'^\d+$', ident):
-            return Event.objects.get(id=ident)
-
-        # match event slug in format YYYY-MM-**** (ie. this works for
-        # YYYY-MM-DD-**** too)
-        if re.match(r'^\d{4}-\d{2}-.+$', ident):
+        try:
+            return Event.objects.get(pk=int(ident))
+        except ValueError:
             return Event.objects.get(slug=ident)
-
-        raise ObjectDoesNotExist(ident)
 
     def save(self, *args, **kwargs):
         self.url = self.url or None

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -36,8 +36,8 @@
 	      {% if not event.slug %}
 	        —
 	      {% else %}
-	        <a href="{% url 'event_details' event.slug %}">
-		  {{ event.slug }}
+	        <a href="{% url 'event_details' event.get_ident %}">
+		  {{ event.get_ident }}
 	        </a>
 	      {% endif %}
 	    </td>

--- a/workshops/templates/workshops/search.html
+++ b/workshops/templates/workshops/search.html
@@ -29,7 +29,7 @@
       {% if events %}
       <ul>
 	{% for e in events %}
-	<li><a class="searchresult" href="{% url 'event_details' e.slug %}">{{ e.slug }}</a></li>
+	<li><a class="searchresult" href="{% url 'event_details' e.get_ident %}">{{ e.get_ident }}</a></li>
 	{% endfor %}
       </ul>
       {% endif %}

--- a/workshops/templates/workshops/site.html
+++ b/workshops/templates/workshops/site.html
@@ -38,7 +38,7 @@
     <td>{{ e.tags.all | join:", " }}</td>
     <td>{{ e.start }}</td>
     <td>{{ e.end }}</td>
-    <td><a href="{% url 'event_details' e.slug %}">{{ e.slug }}</a></td>
+    <td><a href="{% url 'event_details' e.get_ident %}">{{ e.get_ident }}</a></td>
     <td><a href="{{ e.url }}">{{ e.url }}</a></td>
   </tr>
   {% endfor %}

--- a/workshops/templates/workshops/validate_event.html
+++ b/workshops/templates/workshops/validate_event.html
@@ -20,7 +20,7 @@
     <p>No errors</p>
   {% endif %}
 {% endif %}
-<p>... <a href="{% url 'event_details' event.slug %}">return to event</a></p>
+<p>... <a href="{% url 'event_details' event.get_ident %}">return to event</a></p>
 <p>... <a href="{% url 'all_events' %}">all events</a></p>
 <p>... <a href="{% url 'index' %}">index</a></p>
 {% endblock %}


### PR DESCRIPTION
In rare occasion when events don't have any deatils about them,
especially the slug, we should display event details using
`event.get_ident` as it returns either slug or ID.

Ref #257 