### PR TITLE
Exporting YAML needed by main web site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# How to run Python.
+PYTHON = python3
+
 # Where original data lives.
 SRC_DIR = ~/s/admin
 
@@ -28,21 +31,21 @@ commands : Makefile
 
 ## test         : run all tests.
 test :
-	python3 manage.py test
+	${PYTHON} manage.py test
 
 ## migrations   : create/apply migrations
 migrations :
-	python3 manage.py makemigrations
-	python3 manage.py migrate
+	${PYTHON} manage.py makemigrations
+	${PYTHON} manage.py migrate
 
 ## import       : import and save legacy data
 import :
-	python3 migrater.py ${SRC_DB} ${APP_DB}
+	${PYTHON} migrater.py ${SRC_DB} ${APP_DB}
 	${QUERY} .dump > ${APP_SQL}
 
 ## import-real  : import real legacy data
 import-real :
-	python3 migrater.py ${SRC_DB} ${APP_DB} real
+	${PYTHON} migrater.py ${SRC_DB} ${APP_DB} real
 
 ## database     : re-make database using saved data
 database :
@@ -51,7 +54,15 @@ database :
 
 ## superuser    : make a super-user in the database
 superuser :
-	python3 manage.py create_superuser
+	@${PYTHON} manage.py create_superuser
+
+## airports     : display YAML for airports
+airports :
+	@${PYTHON} manage.py export_airports
+
+## badges       : display YAML for badges
+badges :
+	@${PYTHON} manage.py export_badges
 
 ## schema       : display the database schema
 schema :
@@ -59,7 +70,7 @@ schema :
 
 ## notes        : load old notes
 notes :
-	python3 notes-importer.py ${APP_DB} ${SRC_EVENTS} ${SRC_SITES}
+	${PYTHON} notes-importer.py ${APP_DB} ${SRC_EVENTS} ${SRC_SITES}
 
 ## bower_components	: install front-end dependencies using Bower
 bower_components : bower.json
@@ -68,7 +79,7 @@ bower_components : bower.json
 
 ## serve        : run a server
 serve : bower_components
-	python3 manage.py runserver
+	${PYTHON} manage.py runserver
 
 ## clean        : clean up.
 clean :

--- a/workshops/management/commands/export_airports.py
+++ b/workshops/management/commands/export_airports.py
@@ -1,0 +1,10 @@
+import yaml
+from django.core.management.base import BaseCommand, CommandError
+from workshops.views import _export_instructors
+
+class Command(BaseCommand):
+    args = 'no arguments'
+    help = 'Display YAML for airports.'
+
+    def handle(self, *args, **options):
+        print(yaml.dump(_export_instructors()).rstrip())

--- a/workshops/management/commands/export_badges.py
+++ b/workshops/management/commands/export_badges.py
@@ -1,0 +1,10 @@
+import yaml
+from django.core.management.base import BaseCommand, CommandError
+from workshops.views import _export_badges
+
+class Command(BaseCommand):
+    args = 'no arguments'
+    help = 'Display YAML for badges.'
+
+    def handle(self, *args, **options):
+        print(yaml.dump(_export_badges()).rstrip())

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2,7 +2,6 @@ import csv
 import datetime
 import io
 import re
-import yaml
 
 import requests
 
@@ -717,11 +716,17 @@ def _export_badges():
 
 def _export_instructors():
     '''Collect instructor airport locations as YAML.'''
-    # Exclude airports with no instructors, and add the number of instructors per airport
-    airports = Airport.objects.exclude(person=None).annotate(num_persons=Count('person'))
+
+    # Get all the people associated with an airport.
+    def _get_people(airport):
+        return [[p.username, p.get_full_name()]
+                for p in Person.objects.filter(airport=airport)]
+
+    # Exclude airports with no instructors, then create a list of dicts.
+    airports = Airport.objects.exclude(person=None)
     return [{'airport' : str(a.fullname),
              'latlng' : '{0},{1}'.format(a.latitude, a.longitude),
-             'count'  : a.num_persons}
+             'who'  : _get_people(a)}
             for a in airports]
 
 


### PR DESCRIPTION
1.  Update code used to export YAML for instructors-by-airport to be what the main website's map now needs.
2.  Add management command to export YAML for airports from the command line.
3.  Add management command to export YAML for badges from the command line.
4.  Add Makefile targets to run those commands.
5.  Create a variable in the Makefile to specify what Python we're running.