### PR TITLE
Displaying more information about unpublished workshops

### DIFF
--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -18,6 +18,16 @@
     {% endfor %}
     </table>
   </div>
+  <div class="col-xs-3">
+    <h3>Unpaid</h3>
+    <table class="table table-striped">
+    {% for event in unpaid_events %}
+    <tr>
+      <td><a href="{{ event.get_absolute_url }}">{{ event.slug }}</a></td>
+    </tr>
+    {% endfor %}
+    </table>
+  </div>
   <div class="col-xs-6">
     <h3>Unpublished</h3>
     <table class="table table-striped">
@@ -30,12 +40,12 @@
       </tr>
       {% for event in unpublished_events %}
       <tr>
-        <td>
+        <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
           {{ event.num_instructors }}
         </td>
-	<td>
-	  {% if event.start %}&#10004;{% endif %}
-	</td>
+        <td>
+          {% if event.start %}&#10004;{% endif %}
+        </td>
         <td>
           <a href="{{ event.get_absolute_url }}">
             {{ event.id }}
@@ -46,21 +56,17 @@
             {{ event.site }}
           </a>
         </td>
-        <td>
-          {% if event.slug %}{{ event.slug }}{% endif %}
+        <td {% if not event.slug %}class="warning"{% endif %}>
+          {% if not event.slug %}
+          —
+          {% else %}
+          <a href="{% url 'event_details' event.get_ident %}">
+            {{ event.get_ident }}
+          </a>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}
-    </table>
-  </div>
-  <div class="col-xs-3">
-    <h3>Unpaid</h3>
-    <table class="table table-striped">
-    {% for event in unpaid_events %}
-    <tr>
-      <td><a href="{{ event.get_absolute_url }}">{{ event.slug }}</a></td>
-    </tr>
-    {% endfor %}
     </table>
   </div>
 </div>

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -8,8 +8,8 @@
 {% include "amy-logo.html" %}
 
 <div class="row">
-  <div class="col-xs-4">
-    <h3>Upcoming events</h3>
+  <div class="col-xs-3">
+    <h3>Upcoming</h3>
     <table class="table table-striped">
     {% for event in upcoming_events %}
     <tr>
@@ -18,24 +18,43 @@
     {% endfor %}
     </table>
   </div>
-  <div class="col-xs-4">
-    <h3>Unpublished events</h3>
+  <div class="col-xs-6">
+    <h3>Unpublished</h3>
     <table class="table table-striped">
-    {% for event in unpublished_events %}
-    <tr>
-      <td>
-        <a href="{{ event.get_absolute_url }}">
-          {{ event.id }}
-          {% if event.site %}@ {{ event.site.domain }}{% endif %}
-          {% if event.slug %}: {{ event.slug }}{% endif %}
-        </a>
-      </td>
-    </tr>
-    {% endfor %}
+      <tr>
+        <th>#I</th>
+        <th>dates</th>
+        <th>ID</th>
+        <th>domain</th>
+        <th>slug</th>
+      </tr>
+      {% for event in unpublished_events %}
+      <tr>
+        <td>
+          {{ event.num_instructors }}
+        </td>
+	<td>
+	  {% if event.start %}&#10004;{% endif %}
+	</td>
+        <td>
+          <a href="{{ event.get_absolute_url }}">
+            {{ event.id }}
+          </a>
+        </td>
+        <td>
+          <a href="{% url 'site_details' event.site.domain %}">
+            {{ event.site }}
+          </a>
+        </td>
+        <td>
+          {% if event.slug %}{{ event.slug }}{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
     </table>
   </div>
-  <div class="col-xs-4">
-    <h3>Unpaid events</h3>
+  <div class="col-xs-3">
+    <h3>Unpaid</h3>
     <table class="table table-striped">
     {% for event in unpaid_events %}
     <tr>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -114,10 +114,12 @@ def index(request):
     upcoming_events = Event.objects.upcoming_events()
     unpublished_events = Event.objects.unpublished_events()
     unpaid_events = Event.objects.unpaid_events()
+    for e in unpublished_events:
+        e.num_instructors = e.task_set.filter(role__name='instructor').count()
     context = {'title': None,
                'upcoming_events': upcoming_events,
-               'unpublished_events': unpublished_events,
-               'unpaid_events': unpaid_events}
+               'unpaid_events': unpaid_events,
+               'unpublished_events': unpublished_events}
     return render(request, 'workshops/index.html', context)
 
 #------------------------------------------------------------


### PR DESCRIPTION
1.  Add number of instructors and a flag showing whether dates are known to dashboard display of unpublished workshops.
2.  Moving the widened display to the side.