### PR TITLE
TaskManager methods for roles lookup

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -330,6 +330,19 @@ class TaskManager(models.Manager):
         """Fetch only existing tasks (ie. not deleted)."""
         return super().get_queryset().filter(deleted=False)
 
+    def instructors(self):
+        """Fetch tasks with role 'instructor'."""
+        return self.get_queryset().filter(role__name="instructor")
+
+    def learners(self):
+        """Fetch tasks with role 'learner'."""
+        return self.get_queryset().filter(role__name="learner")
+
+    def helpers(self):
+        """Fetch tasks with role 'helper'."""
+        return self.get_queryset().filter(role__name="helper")
+
+
 class Task(models.Model):
     '''Represent who did what at events.'''
 

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -29,9 +29,9 @@
 	    <td>{{ event.id }}</td>
 	    <td>{{ event.published }}</td>
 	    <td>{{ event.tags.all | join:", " }}</td>
-	    <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
-	      {{ event.num_instructors }}
-	    </td>
+        {% with num_instructors=event.task_set.instructors.count %}
+        <td {% if num_instructors == 0 %}class="warning"{% endif %}>{{ num_instructors }}</td>
+        {% endwith %}
 	    <td {% if not event.slug %}class="warning"{% endif %}>
 	      {% if not event.slug %}
 	        —

--- a/workshops/templates/workshops/debrief.html
+++ b/workshops/templates/workshops/debrief.html
@@ -29,8 +29,8 @@
 	</tr>
     {% for task in all_tasks %}
         <tr>
-            <td>{{ task.event }}</td>
-            <td>{{ task.person }}</a></td>
+            <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
+            <td><a href="{{ task.person.get_absolute_url }}">{{ task.person }}</a> (taught {{ task.person.task_set.instructors.count }} times)</a></td>
 	    <td><a href="{% url 'task_details' task.id %}">...</a></td>
 	</tr>
     {% endfor %}

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -40,9 +40,11 @@
       </tr>
       {% for event in unpublished_events %}
       <tr>
-        <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
-          {{ event.num_instructors }}
+        {% with num_instructors=event.task_set.instructors.count %}
+        <td {% if num_instructors == 0 %}class="warning"{% endif %}>
+          {{ num_instructors }}
         </td>
+        {% endwith %}
         <td>
           {% if event.start %}✓{% endif %}
         </td>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -113,8 +113,6 @@ def index(request):
     upcoming_events = Event.objects.upcoming_events()
     unpublished_events = Event.objects.unpublished_events()
     unpaid_events = Event.objects.unpaid_events()
-    for e in unpublished_events:
-        e.num_instructors = e.task_set.filter(role__name='instructor').count()
     context = {'title': None,
                'upcoming_events': upcoming_events,
                'unpaid_events': unpaid_events,
@@ -409,8 +407,6 @@ def all_events(request):
 
     all_events = Event.objects.all()
     events = _get_pagination_items(request, all_events)
-    for e in events:
-        e.num_instructors = e.task_set.filter(role__name='instructor').count()
     context = {'title' : 'All Events',
                'all_events' : events}
     return render(request, 'workshops/all_events.html', context)
@@ -602,8 +598,7 @@ def instructors(request):
 
             # Add metadata which we will eventually filter by
             for p in persons:
-                p.num_taught = \
-                    p.task_set.filter(role__name='instructor').count()
+                p.num_taught = p.task_set.instructors().count()
 
             # Sort by location.
             loc = (form.cleaned_data['latitude'],


### PR DESCRIPTION
Hi,

I've added some methods to `TaskManager`, so that we can easily filter by the role name.

This for example makes easier for us to calculate the number of instructors per event - we don't have to run a loop for that. One eyesore less.

Additionally I updated `/debrief/` so that it provides a more verbose output: links to event/person detail pages, number of workshops a person has taught. This should fix #214.