### PR TITLE
Makefile: fix git log, git describe commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ bower_components : bower.json
 workshops/git_version.py :
 	if test -d .git; \
 	then \
-		git log -1 --date short --pretty=format:"HASH = '%H'%nSHORT_HASH = '%h'%nDATE = '%cd'%n" >$@; \
-		if (git describe --dirty | grep dirty >/dev/null); \
+		git log -1 --date=short --format="HASH = '%H'%nSHORT_HASH = '%h'%nDATE = '%cd'%n" >$@; \
+		if (git describe --dirty 2>/dev/null | grep dirty >/dev/null); \
 		then \
 			echo 'DIRTY = True' >>$@; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ bower_components : bower.json
 
 ## git_version  : store details about the current commit and tree state.
 workshops/git_version.py :
-	if test -d .git; \
+	@if test -d .git; \
 	then \
 		git log -1 --date=short --format="HASH = '%H'%nSHORT_HASH = '%h'%nDATE = '%cd'%n" >$@; \
 		if (git describe --dirty 2>/dev/null | grep dirty >/dev/null); \


### PR DESCRIPTION
git log:
* added "=", so that "--date" is now "--date=short". This was causing
  errors on Small Orange (git version 1.7.1)
* switched "--pretty=format:" to shorter "--format="

git describe:
* send stderr to /dev/null

Fixes #278.