### PR TITLE
Use django-countries

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'crispy_forms',
     'selectable',
+    'django_countries',
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/amy/settings.py
+++ b/amy/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 import json
 
+from django.utils.translation import ugettext_lazy as _
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
@@ -151,3 +153,8 @@ LOGIN_REDIRECT_URL = '/workshops/'
 
 # here's where @login_required redirects to:
 LOGIN_URL = '/account/login/'
+
+# explicitely add European Union as a country
+COUNTRIES_OVERRIDE = {
+    'EU': _('European Union'),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML
 requests>=2.0
 django-crispy-forms>=1.4.0
 django-selectable>=0.9.0,<1.0
+django-countries==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ PyYAML
 requests>=2.0
 django-crispy-forms>=1.4.0
 django-selectable>=0.9.0,<1.0
-django-countries==3.3
+django-countries>=3.3,<4.0

--- a/workshops/migrations/0007_migrate_countries_to_2char_iso31661.py
+++ b/workshops/migrations/0007_migrate_countries_to_2char_iso31661.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django_countries import countries
+
+
+def migrate_to_2char_country_names(apps, schema_editor):
+    Site = apps.get_model("workshops", "Site")
+    Airport = apps.get_model("workshops", "Airport")
+
+    # hard-coded list of mappings that fail to convert
+    mapping = {
+        'United-States': 'US',
+        'United-Kingdom': 'GB',
+        'European-Union': 'EU',
+        None: None
+    }
+
+    for site in Site.objects.all():
+        country = site.country
+        if country in mapping:
+            site.country = mapping[country]
+        else:
+            country = country.replace('-', ' ')
+            site.country = countries.by_name(country)
+        site.save()
+
+    for airport in Airport.objects.all():
+        country = airport.country
+        if country in mapping:
+            airport.country = mapping[country]
+        else:
+            country = country.replace('-', ' ')
+            airport.country = countries.by_name(country)
+        airport.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0006_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_to_2char_country_names),
+    ]

--- a/workshops/migrations/0008_auto_20150522_1304.py
+++ b/workshops/migrations/0008_auto_20150522_1304.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_countries.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0007_migrate_countries_to_2char_iso31661'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='airport',
+            name='country',
+            field=django_countries.fields.CountryField(max_length=2),
+        ),
+        migrations.AlterField(
+            model_name='site',
+            name='country',
+            field=django_countries.fields.CountryField(max_length=2, null=True),
+        ),
+    ]

--- a/workshops/migrations/0010_merge.py
+++ b/workshops/migrations/0010_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0009_merge'),
+        ('workshops', '0008_auto_20150522_1304'),
+    ]
+
+    operations = [
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -8,6 +8,8 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
 
+from django_countries.fields import CountryField
+
 #------------------------------------------------------------
 
 STR_SHORT   =  10         # length of short strings
@@ -22,7 +24,7 @@ class Site(models.Model):
 
     domain     = models.CharField(max_length=STR_LONG, unique=True)
     fullname   = models.CharField(max_length=STR_LONG, unique=True)
-    country    = models.CharField(max_length=STR_LONG, null=True)
+    country    = CountryField(null=True)
     notes      = models.TextField(default="", blank=True)
 
     def __str__(self):
@@ -38,7 +40,7 @@ class Airport(models.Model):
 
     iata      = models.CharField(max_length=STR_SHORT, unique=True)
     fullname  = models.CharField(max_length=STR_LONG, unique=True)
-    country   = models.CharField(max_length=STR_LONG)
+    country   = CountryField()
     latitude  = models.FloatField()
     longitude = models.FloatField()
 

--- a/workshops/static/css/amy.css
+++ b/workshops/static/css/amy.css
@@ -9,6 +9,13 @@ table td.editable span {
     display: block;
 }
 
+/* move country flag in tables a few pixels up */
+.country-flag {
+    width: 16px;
+    height: 11px;
+    margin-top: -4px;
+}
+
 /* Padding below the event edit form */
 form[role="form"] {
     margin-bottom: 50px;

--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -12,7 +12,7 @@
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ airport.fullname }}</td></tr>
   <tr><td>iata:</td><td><a href="http://{{ airport.iata }}">{{ airport.iata }}</a></td></tr>
-  <tr><td>country:</td><td>{{ airport.country.name }} <img src="{{ airport.country.flag }}" alt="{{ airport.country }}" /></td></tr>
+  <tr><td>country:</td><td>{{ airport.country.name }} <img src="{{ airport.country.flag }}" alt="{{ airport.country }}" class="country-flag" /></td></tr>
   <tr><td>latitude:</td><td>{{ airport.latitude }}</td></tr>
   <tr><td>longitude:</td><td>{{ airport.longitude }}</td></tr>
 </table>

--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -12,7 +12,7 @@
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ airport.fullname }}</td></tr>
   <tr><td>iata:</td><td><a href="http://{{ airport.iata }}">{{ airport.iata }}</a></td></tr>
-  <tr><td>country:</td><td>{{ airport.country }}</td></tr>
+  <tr><td>country:</td><td>{{ airport.country.name }} <img src="{{ airport.country.flag }}" alt="{{ airport.country }}" /></td></tr>
   <tr><td>latitude:</td><td>{{ airport.latitude }}</td></tr>
   <tr><td>longitude:</td><td>{{ airport.longitude }}</td></tr>
 </table>

--- a/workshops/templates/workshops/site.html
+++ b/workshops/templates/workshops/site.html
@@ -13,7 +13,7 @@
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ site.fullname }}</td></tr>
   <tr><td>domain:</td><td><a href="http://{{ site.domain }}">{{ site.domain }}</a></td></tr>
-  <tr><td>country:</td><td>{{ site.country.name|default:"—" }} <img src="{{ site.country.flag }}" alt="{{ site.country }}" /></td></tr>
+  <tr><td>country:</td><td>{{ site.country.name|default:"—" }} <img src="{{ site.country.flag }}" alt="{{ site.country }}" class="country-flag" /></td></tr>
 </table>
 
 {% if site.notes %}

--- a/workshops/templates/workshops/site.html
+++ b/workshops/templates/workshops/site.html
@@ -13,7 +13,7 @@
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ site.fullname }}</td></tr>
   <tr><td>domain:</td><td><a href="http://{{ site.domain }}">{{ site.domain }}</a></td></tr>
-  <tr><td>country:</td><td>{{ site.country|default:"—" }}</td></tr>
+  <tr><td>country:</td><td>{{ site.country.name|default:"—" }} <img src="{{ site.country.flag }}" alt="{{ site.country }}" /></td></tr>
 </table>
 
 {% if site.notes %}


### PR DESCRIPTION
This solves #62.

Features:

* Data migration for old country fields (Site.country, Airport.country: shorten country names to [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)). Not all countries can be migrated this way, but I used production database to get list of the countries and provided a mapping for them myself.
* "Normal" migration.
* Display of country flags in site/airport detail pages.
* Minor style fixes.