### PR TITLE
Regularizing use of names 'badge' and 'award'.

### DIFF
--- a/workshops/templates/workshops/all_awards.html
+++ b/workshops/templates/workshops/all_awards.html
@@ -8,14 +8,14 @@
 {% endblock %}
 
 {% block content %}
-{% if all_awards %}
+{% if awards %}
   <table class="table table-striped">
     <tr>
 	<th>person</th>
 	<th>awarded</th>
 	<th>event</th>
     </tr>
-    {% for a in all_awards %}
+    {% for a in awards %}
     <tr>
       <td><a href="{% url 'person_details' a.person.id %}">{{ a.person }}</a></td>
       <td>{{ a.awarded }}</td>
@@ -25,14 +25,14 @@
   </table>
   <div class="pagination">
     <span class="step-links">
-      {% if all_awards.has_previous %}
-      <a href="?page={{ all_awards.previous_page_number }}">previous</a>
+      {% if awards.has_previous %}
+      <a href="?page={{ awards.previous_page_number }}">previous</a>
       {% endif %}
       <span class="current">
-        Page {{ all_awards.number }} of {{ all_awards.paginator.num_pages }}.
+        Page {{ awards.number }} of {{ awards.paginator.num_pages }}.
       </span>
-      {% if all_awards.has_next %}
-      <a href="?page={{ all_awards.next_page_number }}">next</a>
+      {% if awards.has_next %}
+      <a href="?page={{ awards.next_page_number }}">next</a>
       {% endif %}
     </span>
   </div>

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -16,7 +16,7 @@
   </tr>
   {% for badge in all_badges %}
   <tr>
-    <td><a href="{% url 'badge_details' badge.name %}">{{ badge.name }}</a></td>
+    <td><a href="{% url 'all_awards' badge.name %}">{{ badge.name }}</a></td>
     <td>{{ badge.title }}</td>
     <td>{{ badge.criteria }}</td>
     <td>{{ badge.num_awarded }}</td>

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -36,7 +36,8 @@ urlpatterns = [
     url(r'^tasks/add/$', views.TaskCreate.as_view(), name='task_add'),
 
     url(r'^badges/?$', views.all_badges, name='all_badges'),
-    url(r'^badge/(?P<badge_name>[\w\.-]+)/?$', views.badge_details, name='badge_details'),
+
+    url(r'^awards/(?P<badge_name>[\w\.-]+)/?$', views.all_awards, name='all_awards'),
 
     url(r'^instructors/?$', views.instructors, name='instructors'),
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -565,17 +565,21 @@ def all_badges(request):
     return render(request, 'workshops/all_badges.html', context)
 
 
+#------------------------------------------------------------
+
+
 @login_required
-def badge_details(request, badge_name):
-    '''Show who has a particular badge.'''
+def all_awards(request, badge_name):
+    '''Show who has been awarded a particular badge.'''
 
     badge = Badge.objects.get(name=badge_name)
-    all_awards = Award.objects.filter(badge_id=badge.id)
-    awards = _get_pagination_items(request, all_awards)
+    awards = Award.objects.filter(badge_id=badge.id)
+    awards = _get_pagination_items(request, awards)
     context = {'title' : 'Badge {0}'.format(badge.title),
                'badge' : badge,
-               'all_awards' : awards}
-    return render(request, 'workshops/badge.html', context)
+               'awards' : awards}
+    return render(request, 'workshops/all_awards.html', context)
+
 
 #------------------------------------------------------------
 


### PR DESCRIPTION
The "all badges" page displays all the badges we can hand out.  However, the "badge details" page was displaying particular awards, not the details of the kind of badge (such as the criteria).  This inconsistent naming became a stumbling block when I wanted to add a new form to let us award a badge (e.g., give someone an instructor badge).  This PR changes things so that the "all badges" page links to pages showing who has been awarded particular badges.  Once this is merged, we can add another form that will allow for creation of new awards (i.e., assignment of badges to persons).