### PR TITLE
Trying to award badges

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -406,3 +406,6 @@ class Award(models.Model):
 
     def __str__(self):
         return '{0}/{1}/{2}/{3}'.format(self.person, self.badge, self.awarded, self.event)
+
+    def get_absolute_url(self):
+        return reverse('award_details', kwargs={'award_id': self.id})

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -26,7 +26,7 @@
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">More <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 {% navbar_element "Tasks" "all_tasks" %}
-                {% navbar_element "Badges" "all_badges" %}
+                {% navbar_element "Awards" "all_awards" %}
                 {% navbar_element "Airports" "all_airports" %}
                 <li class="divider"></li>
                 {% navbar_element "Bulk add persons" "person_bulk_add" %}

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -59,6 +59,7 @@
                 {% navbar_element "Add event" "event_add" %}
                 {% navbar_element "Add site" "site_add" %}
                 {% navbar_element "Add person" "person_add" %}
+                {% navbar_element "Add award" "award_add" %}
               </ul>
             </li>
             <li class="dropdown">

--- a/workshops/templates/workshops/all_awards.html
+++ b/workshops/templates/workshops/all_awards.html
@@ -3,36 +3,37 @@
 {% load breadcrumbs %}
 {% block breadcrumbs %}
     {% breadcrumb_main_page %}
-    {% breadcrumb_index_all_objects badge %}
-    {% breadcrumb_active badge %}
+    {% breadcrumb_active title %}
 {% endblock %}
 
 {% block content %}
-{% if awards %}
+{% if all_awards %}
   <table class="table table-striped">
     <tr>
-	<th>person</th>
-	<th>awarded</th>
-	<th>event</th>
+      <th>badge</th>
+      <th>awarded</th>
+      <th>person</th>
+      <th>event</th>
     </tr>
-    {% for a in awards %}
+    {% for a in all_awards %}
     <tr>
-      <td><a href="{% url 'person_details' a.person.id %}">{{ a.person }}</a></td>
+      <td>{{ a.badge }}</td>
       <td>{{ a.awarded }}</td>
+      <td><a href="{% url 'person_details' a.person.id %}">{{ a.person }}</a></td>
       <td>{{ a.event|default:"—" }}</td>
     </tr>
     {% endfor %}
   </table>
   <div class="pagination">
     <span class="step-links">
-      {% if awards.has_previous %}
-      <a href="?page={{ awards.previous_page_number }}">previous</a>
+      {% if all_awards.has_previous %}
+      <a href="?page={{ all_awards.previous_page_number }}">previous</a>
       {% endif %}
       <span class="current">
-        Page {{ awards.number }} of {{ awards.paginator.num_pages }}.
+        Page {{ all_awards.number }} of {{ all_awards.paginator.num_pages }}.
       </span>
-      {% if awards.has_next %}
-      <a href="?page={{ awards.next_page_number }}">next</a>
+      {% if all_awards.has_next %}
+      <a href="?page={{ all_awards.next_page_number }}">next</a>
       {% endif %}
     </span>
   </div>

--- a/workshops/templates/workshops/all_badges.html
+++ b/workshops/templates/workshops/all_badges.html
@@ -16,7 +16,7 @@
   </tr>
   {% for badge in all_badges %}
   <tr>
-    <td><a href="{% url 'all_awards' badge.name %}">{{ badge.name }}</a></td>
+    <td>{{ badge.name }}</td>
     <td>{{ badge.title }}</td>
     <td>{{ badge.criteria }}</td>
     <td>{{ badge.num_awarded }}</td>

--- a/workshops/templates/workshops/award.html
+++ b/workshops/templates/workshops/award.html
@@ -1,0 +1,19 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% block breadcrumbs %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects award %}
+    {% breadcrumb_active award %}
+{% endblock %}
+
+{% block content %}
+
+<table class="table table-striped">
+  <tr><td>person:</td><td>{{ award.person }}</td></tr>
+  <tr><td>badge:</td><td>{{ award.badge }}</td></tr>
+  <tr><td>awarded:</td><td>{{ award.awarded }}</td></tr>
+  <tr><td>event:</td><td>{{ award.event }}</td></tr>
+</table>
+
+{% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
 
     url(r'^badges/?$', views.all_badges, name='all_badges'),
 
+    url(r'^awards/add/$', views.AwardCreate.as_view(), name='award_add'),
     url(r'^awards/(?P<badge_name>[\w\.-]+)/?$', views.all_awards, name='all_awards'),
 
     url(r'^instructors/?$', views.instructors, name='instructors'),

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -37,8 +37,8 @@ urlpatterns = [
 
     url(r'^badges/?$', views.all_badges, name='all_badges'),
 
+    url(r'^awards/?$', views.all_awards, name='all_awards'),
     url(r'^awards/add/$', views.AwardCreate.as_view(), name='award_add'),
-    url(r'^awards/(?P<badge_name>[\w\.-]+)/?$', views.all_awards, name='all_awards'),
 
     url(r'^instructors/?$', views.instructors, name='instructors'),
 

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r'^badges/?$', views.all_badges, name='all_badges'),
 
     url(r'^awards/?$', views.all_awards, name='all_awards'),
+    url(r'^award/(?P<award_id>\d+)/?$', views.award_details, name='award_details'),
     url(r'^awards/add/$', views.AwardCreate.as_view(), name='award_add'),
 
     url(r'^instructors/?$', views.instructors, name='instructors'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -559,6 +559,7 @@ class TaskUpdate(LoginRequiredMixin, UpdateViewContext):
 
 #------------------------------------------------------------
 
+
 @login_required
 def all_badges(request):
     '''List all badges.'''
@@ -578,16 +579,14 @@ AWARD_FIELDS = ['person', 'badge', 'awarded', 'event']
 
 
 @login_required
-def all_awards(request, badge_name):
-    '''Show everyone who has been awarded a particular badge.'''
+def all_awards(request):
+    '''Show all awards of badges to anyone.'''
 
-    badge = Badge.objects.get(name=badge_name)
-    awards = Award.objects.filter(badge_id=badge.id)
+    awards = Award.objects.order_by('badge', '-awarded', 'person', 'event')
     awards = _get_pagination_items(request, awards)
     user_can_add = request.user.has_perm('edit')
-    context = {'title' : 'Badge {0}'.format(badge.title),
-               'badge' : badge,
-               'awards' : awards,
+    context = {'title' : 'All Awards',
+               'all_awards' : awards,
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_awards.html', context)
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -591,6 +591,15 @@ def all_awards(request):
     return render(request, 'workshops/all_awards.html', context)
 
 
+@login_required
+def award_details(request, award_id):
+    '''List details of a particular award.'''
+    award = Award.objects.get(pk=award_id)
+    context = {'title' : 'Award {0}'.format(award),
+               'award' : award}
+    return render(request, 'workshops/award.html', context)
+
+
 class AwardCreate(LoginRequiredMixin, CreateViewContext):
     model = Award
     fields = AWARD_FIELDS

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -128,8 +128,8 @@ SITE_FIELDS = ['domain', 'fullname', 'country', 'notes']
 def all_sites(request):
     '''List all sites.'''
 
-    all_sites = Site.objects.order_by('domain')
-    sites = _get_pagination_items(request, all_sites)
+    sites = Site.objects.order_by('domain')
+    sites = _get_pagination_items(request, sites)
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Sites',
                'all_sites' : sites,
@@ -169,10 +169,10 @@ AIRPORT_FIELDS = ['iata', 'fullname', 'country', 'latitude', 'longitude']
 @login_required
 def all_airports(request):
     '''List all airports.'''
-    all_airports = Airport.objects.order_by('iata')
+    airports = Airport.objects.order_by('iata')
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Airports',
-               'all_airports' : all_airports,
+               'all_airports' : airports,
                'user_can_add' : user_can_add}
     return render(request, 'workshops/all_airports.html', context)
 
@@ -213,8 +213,8 @@ PERSON_FIELDS = [
 def all_persons(request):
     '''List all persons.'''
 
-    all_persons = Person.objects.order_by('family', 'personal')
-    persons = _get_pagination_items(request, all_persons)
+    persons = Person.objects.order_by('family', 'personal')
+    persons = _get_pagination_items(request, persons)
     context = {'title' : 'All Persons',
                'all_persons' : persons}
     return render(request, 'workshops/all_persons.html', context)
@@ -411,8 +411,8 @@ class PersonUpdate(LoginRequiredMixin, UpdateViewContext):
 def all_events(request):
     '''List all events.'''
 
-    all_events = Event.objects.all()
-    events = _get_pagination_items(request, all_events)
+    events = Event.objects.all()
+    events = _get_pagination_items(request, events)
     context = {'title' : 'All Events',
                'all_events' : events}
     return render(request, 'workshops/all_events.html', context)
@@ -517,8 +517,8 @@ TASK_FIELDS = ['event', 'person', 'role']
 def all_tasks(request):
     '''List all tasks.'''
 
-    all_tasks = Task.objects.order_by('event', 'person', 'role')
-    tasks = _get_pagination_items(request, all_tasks)
+    tasks = Task.objects.order_by('event', 'person', 'role')
+    tasks = _get_pagination_items(request, tasks)
     user_can_add = request.user.has_perm('edit')
     context = {'title' : 'All Tasks',
                'all_tasks' : tasks,
@@ -563,28 +563,39 @@ class TaskUpdate(LoginRequiredMixin, UpdateViewContext):
 def all_badges(request):
     '''List all badges.'''
 
-    all_badges = Badge.objects.order_by('name')
-    for b in all_badges:
+    badges = Badge.objects.order_by('name')
+    for b in badges:
         b.num_awarded = Award.objects.filter(badge_id=b.id).count()
     context = {'title' : 'All Badges',
-               'all_badges' : all_badges}
+               'all_badges' : badges}
     return render(request, 'workshops/all_badges.html', context)
 
 
 #------------------------------------------------------------
 
 
+AWARD_FIELDS = ['person', 'badge', 'awarded', 'event']
+
+
 @login_required
 def all_awards(request, badge_name):
-    '''Show who has been awarded a particular badge.'''
+    '''Show everyone who has been awarded a particular badge.'''
 
     badge = Badge.objects.get(name=badge_name)
     awards = Award.objects.filter(badge_id=badge.id)
     awards = _get_pagination_items(request, awards)
+    user_can_add = request.user.has_perm('edit')
     context = {'title' : 'Badge {0}'.format(badge.title),
                'badge' : badge,
-               'awards' : awards}
+               'awards' : awards,
+               'user_can_add' : user_can_add}
     return render(request, 'workshops/all_awards.html', context)
+
+
+class AwardCreate(LoginRequiredMixin, CreateViewContext):
+    model = Award
+    fields = AWARD_FIELDS
+    template_name = 'workshops/generic_form.html'
 
 
 #------------------------------------------------------------


### PR DESCRIPTION
* The URL for the page that displays instructor badges is `awards/instructor`
* This is very similar in structure to `awards/add`, which identifies the page for adding a new badge, but we can avoid ambiguity by putting `awards/add` ahead of the regexp-based URL for displaying particular awards.  (This problem doesn't come up with things like tasks because we display them all mixed together rather than trying to segregate by type.)
* However, `awards/add` invokes the `AwardCreate` class...
* ...which uses `breadcrumb_index_all_objects` from line 45 of `workshops/templatetags/breadcrumbs.py`, which expects to be able to look up the "display all" page as `all_whatever`...
* ...which doesn't work because `all_awards` needs a badge name.

We *could* modify `all_awards` to allow an empty badge name, and just display all awards, but that looks pretty messy - and we're going to want to modify `all_tasks` to display particular kinds of tasks (e.g., only show me instructors, only show me learners), so we should come up with a generic solution.

@wking @pbanaszkiewicz any suggestions?