### PR TITLE
Cleaning up the interface a bit.

### DIFF
--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -59,6 +59,7 @@
                 {% navbar_element "Add event" "event_add" %}
                 {% navbar_element "Add site" "site_add" %}
                 {% navbar_element "Add person" "person_add" %}
+		{% navbar_element "Add airport" "airport_add" %}
               </ul>
             </li>
             <li class="dropdown">

--- a/workshops/templates/base_without_navbar.html
+++ b/workshops/templates/base_without_navbar.html
@@ -19,7 +19,6 @@
   <body>
     {% block navbar %}{% endblock %}
     <div class="container">
-      {% if title %}<h1>{{ title }}</h1>{% endif %}
       <ol class="breadcrumb">{% block breadcrumbs %}{% endblock %}</ol>
       {% if messages %}
       <ul class="messages">

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'airport_add' %}" class="btn btn-primary">Add a new airport</a></p>
 {% if all_airports %}
     <table class="table table-striped">
         <tr>

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'event_add' %}" class="btn btn-primary">Add a new event</a></p>
 {% if all_events %}
     <table class="table table-striped">
         <tr>

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'person_add' %}" class="btn btn-primary">Add a new person</a> <a href="{% url 'person_bulk_add' %}" class="btn btn-default">Add many people</a></p>
 {% if all_persons %}
     <table class="table table-striped">
         <tr>

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'site_add' %}" class="btn btn-primary">Add a new site</a></p>
 {% if all_sites %}
     <table class="table table-striped">
         <tr>

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'task_add' %}" class="btn btn-primary">Add a new task</a></p>
 {% if all_tasks %}
     <table class="table table-striped">
         <tr>


### PR DESCRIPTION
1.  Buttons to add things are redundant now that we have a pull-down 'add' menu.
2.  Breadcrumbs show page titles, so separate page titles are redundant.