### PR TITLE
Buttons, links, validation, etc.

### DIFF
--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -56,9 +56,9 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                {% navbar_element "Add event" "event_add" %}
-                {% navbar_element "Add site" "site_add" %}
-                {% navbar_element "Add person" "person_add" %}
+                {% navbar_element "New event" "event_add" %}
+                {% navbar_element "New site" "site_add" %}
+                {% navbar_element "New person" "person_add" %}
               </ul>
             </li>
             <li class="dropdown">

--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -17,5 +17,5 @@
   <tr><td>longitude:</td><td>{{ airport.longitude }}</td></tr>
 </table>
 
-<p class="edit-object"><a href="{% url 'airport_edit' airport.iata %}">Edit this airport</a></p>
+<p class="edit-object"><a href="{% url 'airport_edit' airport.iata %}" class="btn btn-primary">Edit</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'airport_add' %}" class="btn btn-primary">Add a new airport</a></p>
+    <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
 {% if all_airports %}
     <table class="table table-striped">
         <tr>
@@ -25,7 +25,7 @@
 	</tr>
     {% endfor %}
     </table>
-    <p><a href="{% url 'airport_add' %}" class="btn btn-primary">Add a new airport</a></p>
+    <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
 {% else %}
     <p>No airports.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'event_add' %}" class="btn btn-primary">Add a new event</a></p>
+    <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
 {% if all_events %}
     <table class="table table-striped">
         <tr>
@@ -72,7 +72,7 @@
          {% endif %}
       </span>
     </div>
-    <p><a href="{% url 'event_add' %}" class="btn btn-primary">Add a new event</a></p>
+    <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
 {% else %}
     <p>No events.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'person_add' %}" class="btn btn-primary">Add a new person</a> <a href="{% url 'person_bulk_add' %}" class="btn btn-default">Add many people</a></p>
+    <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a> <a href="{% url 'person_bulk_add' %}" class="btn btn-default">Add many people</a></p>
 {% if all_persons %}
     <table class="table table-striped">
         <tr>
@@ -42,7 +42,7 @@
          {% endif %}
       </span>
     </div>
-    <p><a href="{% url 'person_add' %}" class="btn btn-primary">Add a new person</a> <a href="{% url 'person_bulk_add' %}" class="btn btn-default">Add many people</a></p>
+    <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a> <a href="{% url 'person_bulk_add' %}" class="btn btn-default">Add many people</a></p>
 {% else %}
     <p>No persons.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'site_add' %}" class="btn btn-primary">Add a new site</a></p>
+    <p><a href="{% url 'site_add' %}" class="btn btn-success">New site</a></p>
 {% if all_sites %}
     <table class="table table-striped">
         <tr>
@@ -38,7 +38,7 @@
          {% endif %}
       </span>
     </div>
-    <p><a href="{% url 'site_add' %}" class="btn btn-primary">Add a new site</a></p>
+    <p><a href="{% url 'site_add' %}" class="btn btn-success">New site</a></p>
 {% else %}
     <p>No sites.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <p><a href="{% url 'task_add' %}" class="btn btn-primary">Add a new task</a></p>
+    <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
 {% if all_tasks %}
     <table class="table table-striped">
         <tr>
@@ -40,7 +40,7 @@
          {% endif %}
       </span>
     </div>
-    <p><a href="{% url 'task_add' %}" class="btn btn-primary">Add a new task</a></p>
+    <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
 {% else %}
     <p>No tasks.</p>
 {% endif %}

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -13,7 +13,7 @@
   <tr><td>published:</td><td>{{ event.published|yesno }}</td></tr>
   <tr><td>tags:</td><td>{{ event.tags.all | join:", " }}</td></tr>
   <tr><td>slug:</td><td>{{ event.slug|default:"—" }}</td></tr>
-  <tr><td>url:</td><td>{% if event.url %}<a href="{{ event.url }}">{{ event.url }}</a>{% else %}—{% endif %}</td></tr>
+  <tr><td>url:</td><td>{% if event.url %}<a href="{{ event.url }}">{{ event.url }}</a>{% else %}—{% endif %} {% if event.url %}<a href="{% url 'validate_event' event.get_ident %}" class="btn btn-primary btn-xs pull-right" id="validate_event">validate event</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_event_url" href="#" data-toggle="popover" data-trigger="focus" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>">Error</a>{% endif %}</td></tr>
   <tr><td>site:</td><td><a href="{% url 'site_details' event.site.domain %}">{{ event.site }}</a></td></tr>
   <tr><td>start date:</td><td>{{ event.start|default:"—" }}</td></tr>
   <tr><td>end date: </td><td>{{ event.end|default:"—" }}</td></tr>
@@ -22,6 +22,35 @@
   <tr><td>admin fee:</td><td>{{ event.admin_fee|default_if_none:"—" }}</td></tr>
   <tr><td>fee paid:</td><td>{{ event.fee_paid|yesno:"yes,no,unknown" }}</td></tr>
 </table>
+
+{% if event.url %}
+<!-- Validation modal -->
+<div class="modal fade" id="validation_modal" tabindex="-1" role="dialog" aria-labelledby="validation_modal_label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="validation_modal_label">Validation</h4>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<script type="text/javascript">
+  $('#error_event_url').popover({placement: "left", html: true});
+  $('#validate_event').click(function() {
+    $('#validation_modal').modal();
+    return false;
+  });
+  $('#validation_modal').on('show.bs.modal', function() {
+    $('#validation_modal .modal-body').load("{% url 'validate_event' event.get_ident %} #validation")
+  });
+</script>
 {% if tasks %}
 <table class="table table-striped">
   <tr>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -8,6 +8,7 @@
 {% endblock %}
 
 {% block content %}
+<p class="edit-object"><a href="{% url 'event_edit' event.id %}" class="btn btn-primary">Edit</a></p>
 <table class="table table-striped">
   <tr><td>published:</td><td>{{ event.published|yesno }}</td></tr>
   <tr><td>tags:</td><td>{{ event.tags.all | join:", " }}</td></tr>
@@ -45,13 +46,9 @@
 {% else %}
 <p>No notes.</p>
 {% endif %}
-<p class="edit-object"><a href="{% url 'event_edit' event.id %}">Edit this event</a></p>
-<p class="delete-object"><a href="{% url 'event_delete' event.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")'>Delete this event</a></p>
-{% if event.url %}
-<p>... <a href="{% url 'validate_event' event.get_ident %}">validate event</a></p>
-{% else %}
-<p>cannot validate event without URL</p>
-{% endif %}
-<p>... <a href="{% url 'all_events' %}">all events</a></p>
-<p>... <a href="{% url 'index' %}">index</a></p>
+<div class="clearfix">
+  <p class="edit-object pull-left"><a href="{% url 'event_edit' event.id %}" class="btn btn-primary">Edit</a></p>
+  <p class="delete-object pull-right"><a href="{% url 'event_delete' event.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")' class="btn btn-danger">Delete event</a></p>
+</div>
+
 {% endblock %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -8,6 +8,7 @@
 {% endblock %}
 
 {% block content %}
+<p class="edit-object"><a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a></p>
 <table class="table table-striped">
   <tr><td>personal:</td><td id="personal">{{ person.personal|default:"—" }}</td></tr>
   <tr><td>middle:</td><td id="middle">{{ person.middle|default:"—" }}</td></tr>
@@ -43,5 +44,5 @@
 <p>No tasks.</p>
 {% endif %}
 
-<p class="edit-object"><a href="{% url 'person_edit' person.id %}">Edit this person</a></p>
+<p class="edit-object"><a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/site.html
+++ b/workshops/templates/workshops/site.html
@@ -9,6 +9,7 @@
 
 {% block content %}
 
+<p class="edit-object"><a href="{% url 'site_edit' site.domain %}" class="btn btn-primary">Edit</a></p>
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ site.fullname }}</td></tr>
   <tr><td>domain:</td><td><a href="http://{{ site.domain }}">{{ site.domain }}</a></td></tr>
@@ -47,5 +48,5 @@
 <p>No events.</p>
 {% endif %}
 
-<p class="edit-object"><a href="{% url 'site_edit' site.domain %}">Edit this site</a></p>
+<p class="edit-object"><a href="{% url 'site_edit' site.domain %}" class="btn btn-primary">Edit</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/task.html
+++ b/workshops/templates/workshops/task.html
@@ -15,5 +15,5 @@
   <tr><td>role:</td><td>{{ task.role }}</td></tr>
 </table>
 
-<p class="edit-object"><a href="{% url 'task_edit' task.id %}">Edit this task</a></p>
+<p class="edit-object"><a href="{% url 'task_edit' task.id %}" class="btn btn-primary">Edit</a></p>
 {% endblock %}

--- a/workshops/templates/workshops/validate_event.html
+++ b/workshops/templates/workshops/validate_event.html
@@ -8,18 +8,20 @@
 {% endblock %}
 
 {% block content %}
-{% if not page %}
-<p>No valid URL in event record.</p>
-{% else %}
-  <p>Validating {{ page }}</p>
-  {% if error_messages %}
-    {% for message in error_messages %}
-    <p>{{ message }}</p>
-    {% endfor %}
+<div id="validation">
+  {% if not page %}
+  <p>No valid URL in event record.</p>
   {% else %}
-    <p>No errors</p>
+    <p>Validating {{ page }}</p>
+    {% if error_messages %}
+      {% for message in error_messages %}
+      <p>{{ message }}</p>
+      {% endfor %}
+    {% else %}
+      <p>No errors</p>
+    {% endif %}
   {% endif %}
-{% endif %}
+</div>
 <p>... <a href="{% url 'event_details' event.get_ident %}">return to event</a></p>
 <p>... <a href="{% url 'all_events' %}">all events</a></p>
 <p>... <a href="{% url 'index' %}">index</a></p>

--- a/workshops/templates/workshops/validate_event.html
+++ b/workshops/templates/workshops/validate_event.html
@@ -12,17 +12,18 @@
   {% if not page %}
   <p>No valid URL in event record.</p>
   {% else %}
-    <p>Validating {{ page }}</p>
     {% if error_messages %}
-      {% for message in error_messages %}
-      <p>{{ message }}</p>
-      {% endfor %}
+      <div class="alert alert-danger" role="alert"><strong>Errors found!</strong> Fix errors below:</div>
+      <ul>
+        {% for message in error_messages %}
+        <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
     {% else %}
-      <p>No errors</p>
+      <div class="alert alert-success" role="alert"><strong>Everythings fine</strong> No errors found.</div>
     {% endif %}
+    <p>Validated file: <a href="{{ page }}">{{ page }}</a></p>
   {% endif %}
 </div>
-<p>... <a href="{% url 'event_details' event.get_ident %}">return to event</a></p>
-<p>... <a href="{% url 'all_events' %}">all events</a></p>
-<p>... <a href="{% url 'index' %}">index</a></p>
+<p><a href="{% url 'event_details' event.get_ident %}" class="btn btn-primary">return to event</a></p>
 {% endblock %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -440,11 +440,16 @@ def validate_event(request, event_ident):
         github_url = event.url
     if github_url is not None:
         page_url = github_url.replace('github.com', 'raw.githubusercontent.com').rstrip('/') + '/gh-pages/index.html'
-        response = requests.get(page_url)
-        if response.status_code != 200:
-            error_messages.append('Request for {0} returned status code {1}'.format(page_url, response.status_code))
-        else:
-            error_messages = check_file(page_url, response.text)
+
+        try:
+            response = requests.get(page_url)
+
+            if response.status_code != 200:
+                error_messages.append('Request for {0} returned status code {1}'.format(page_url, response.status_code))
+            else:
+                error_messages = check_file(page_url, response.text)
+        except requests.ConnectionError:
+            error_messages = ["Network connection error.", ]
     context = {'title' : 'Validate Event {0}'.format(event),
                'event' : event,
                'page' : page_url,


### PR DESCRIPTION
This PR addresses #296 and #297.

I've only done work for event-related pages. If they're okay, I'll complete other pages, too.

### Screenshots

"New object" button was changed (green color, no "Add a" text):
![screenshot from 2015-05-24 19 38 34](https://cloud.githubusercontent.com/assets/72821/7788866/e9ecbf02-024c-11e5-9657-8ccf16b16cbd.png)

------

Event details page now contains "Edit" and "Delete event" buttons:
![screenshot from 2015-05-24 19 45 38](https://cloud.githubusercontent.com/assets/72821/7788898/920aefd8-024d-11e5-87c8-91d9c3b6789e.png)

------

Events without URL show "Error" button with explanation:
![screenshot from 2015-05-24 19 38 54](https://cloud.githubusercontent.com/assets/72821/7788877/2d691cd0-024d-11e5-8e8c-761ba23ac3cc.png)

![screenshot from 2015-05-24 19 39 05](https://cloud.githubusercontent.com/assets/72821/7788884/50b0e4a2-024d-11e5-93f4-1a6086a5eee3.png)

------

Events with URL show "Validate" button that opens a modal window with validation results inside:
![screenshot from 2015-05-24 19 39 53](https://cloud.githubusercontent.com/assets/72821/7788899/baae3328-024d-11e5-9fcd-137cb6e9b844.png)

![screenshot from 2015-05-24 19 41 04](https://cloud.githubusercontent.com/assets/72821/7788900/bc6d50c2-024d-11e5-862a-bc86c09a1861.png)


### Known issues

Validation on fake URL triggers 500 Server Error.
