### PR TITLE
Renaming Event.fee_paid to Event.invoiced.

### DIFF
--- a/workshops/migrations/0007_auto_20150530_0537.py
+++ b/workshops/migrations/0007_auto_20150530_0537.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0006_merge'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='event',
+            old_name='fee_paid',
+            new_name='invoiced',
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -225,12 +225,12 @@ class EventQuerySet(models.query.QuerySet):
 
         return self.filter(published=False)
 
-    def unpaid_events(self):
-        '''Return a queryset for events that owe money.
+    def uninvoiced_events(self):
+        '''Return a queryset for events that have not yet been invoiced.
 
-        These are events that have an admin fee, are not marked as paid, and have occurred.'''
+        These are events that have an admin fee, are not marked as invoiced, and have occurred.'''
 
-        return self.past_events().filter(admin_fee__gt=0).exclude(fee_paid=True)
+        return self.past_events().filter(admin_fee__gt=0).exclude(invoiced=True)
 
 class EventManager(models.Manager):
     '''A custom manager which is essentially a proxy for EventQuerySet'''
@@ -256,8 +256,8 @@ class EventManager(models.Manager):
     def unpublished_events(self):
         return self.get_queryset().unpublished_events()
 
-    def unpaid_events(self):
-        return self.get_queryset().unpaid_events()
+    def uninvoiced_events(self):
+        return self.get_queryset().uninvoiced_events()
 
 class Event(models.Model):
     '''Represent a single event.'''
@@ -273,7 +273,7 @@ class Event(models.Model):
     reg_key    = models.CharField(max_length=STR_REG_KEY, null=True, blank=True)
     attendance = models.IntegerField(null=True, blank=True)
     admin_fee  = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
-    fee_paid   = models.NullBooleanField(default=False, blank=True)
+    invoiced   = models.NullBooleanField(default=False, blank=True)
     notes      = models.TextField(default="", blank=True)
     deleted = models.BooleanField(default=False)
 

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -22,7 +22,7 @@
 	    <th>Eventbrite</th>
 	    <th>attendance</th>
 	    <th>admin fee</th>
-	    <th>fee paid</th>
+	    <th>invoiced</th>
 	</tr>
     {% for event in all_events %}
         <tr>
@@ -53,7 +53,7 @@
 	    <td>{{ event.reg_key|default:"—" }}</td>
 	    <td>{{ event.attendance|default_if_none:"—" }}</td>
 	    <td>{{ event.admin_fee|default_if_none:"—" }}</td>
-	    <td>{{ event.fee_paid|yesno:"yes,no,unknown" }}</td>
+	    <td>{{ event.invoiced|yesno:"yes,no,unknown" }}</td>
 	</tr>
     {% endfor %}
     </table>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -20,7 +20,7 @@
   <tr><td>Eventbrite key:</td><td>{{ event.reg_key|default:"—" }}</td></tr>
   <tr><td>attendance:</td><td>{{ event.attendance|default_if_none:"—" }}</td></tr>
   <tr><td>admin fee:</td><td>{{ event.admin_fee|default_if_none:"—" }}</td></tr>
-  <tr><td>fee paid:</td><td>{{ event.fee_paid|yesno:"yes,no,unknown" }}</td></tr>
+  <tr><td>invoiced:</td><td>{{ event.invoiced|yesno:"yes,no,unknown" }}</td></tr>
 </table>
 
 {% if event.url %}

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -19,9 +19,9 @@
     </table>
   </div>
   <div class="col-xs-3">
-    <h3>Unpaid</h3>
+    <h3>Uninvoiced</h3>
     <table class="table table-striped">
-    {% for event in unpaid_events %}
+    {% for event in uninvoiced_events %}
     <tr>
       <td><a href="{{ event.get_absolute_url }}">{{ event.get_ident }}</a></td>
     </tr>

--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -34,13 +34,13 @@ class TestEvent(TestBase):
                                  slug='{0}-upcoming'.format(date_string),
                                  site=test_site,
                                  admin_fee=100,
-                                 fee_paid=False,
+                                 invoiced=False,
                                  published=published)
             published = not published
 
         # Create one new event for each day from 10 days ago to
-        # 3 days ago, half paid, all published.
-        fee_paid = True
+        # 3 days ago, half invoiced, all published.
+        invoiced = True
         for t in range(3, 11):
             event_start = today + timedelta(days=-t)
             date_string = event_start.strftime('%Y-%m-%d')
@@ -48,13 +48,13 @@ class TestEvent(TestBase):
                                  slug='{0}-past'.format(date_string),
                                  site=test_site,
                                  admin_fee=100,
-                                 fee_paid=fee_paid,
+                                 invoiced=invoiced,
                                  published=True)
-            fee_paid = not fee_paid
+            invoiced = not invoiced
 
         # Create an event that started yesterday and ends tomorrow
-        # with no fee, and without specifying whether the fee has been
-        # paid
+        # with no fee, and without specifying whether they've been
+        # invoiced.
         event_start = today + timedelta(days=-1)
         event_end = today + timedelta(days=1)
         Event.objects.create(start=event_start,
@@ -65,7 +65,7 @@ class TestEvent(TestBase):
                              published=True)
 
         # Create an event that ends today with no fee, and without
-        # specifying whether the fee has been paid
+        # specifying whether the fee has been invoiced.
         event_start = today + timedelta(days=-1)
         event_end = today
         Event.objects.create(start=event_start,
@@ -76,7 +76,7 @@ class TestEvent(TestBase):
                              published=True)
 
         # Create an event that starts today with a fee, and without
-        # specifying whether the fee has been paid
+        # specifying whether the fee has been invoiced.
         event_start = today
         event_end = today + timedelta(days=1)
         Event.objects.create(start=event_start,
@@ -87,24 +87,24 @@ class TestEvent(TestBase):
                              published=True)
 
         # Record some statistics about events.
-        self.num_unpaid_events = 0
+        self.num_uninvoiced_events = 0
         self.num_upcoming = 0
         for e in Event.objects.all():
-            if e.published and (e.admin_fee > 0) and (not e.fee_paid) and (e.start < today):
-                self.num_unpaid_events += 1
+            if e.published and (e.admin_fee > 0) and (not e.invoiced) and (e.start < today):
+                self.num_uninvoiced_events += 1
             if e.published and (e.start > today):
                 self.num_upcoming += 1
 
-    def test_get_unpaid_events(self):
+    def test_get_uninvoiced_events(self):
         """Test that the events manager can find events that owe money"""
 
-        unpaid_events = Event.objects.unpaid_events()
+        uninvoiced_events = Event.objects.uninvoiced_events()
 
         # There should be as many as there are strictly future events.
-        assert len(unpaid_events) == self.num_unpaid_events
+        assert len(uninvoiced_events) == self.num_uninvoiced_events
 
-        # Check that events with a fee of zero are not in the list of unpaid events.
-        assert not any([x for x in unpaid_events if x.admin_fee == 0])
+        # Check that events with a fee of zero are not in the list of uninvoiced events.
+        assert not any([x for x in uninvoiced_events if x.admin_fee == 0])
 
     def test_get_future_events(self):
         """Test that the events manager can find upcoming events"""

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -112,10 +112,10 @@ def index(request):
     '''Home page.'''
     upcoming_events = Event.objects.upcoming_events()
     unpublished_events = Event.objects.unpublished_events()
-    unpaid_events = Event.objects.unpaid_events()
+    uninvoiced_events = Event.objects.uninvoiced_events()
     context = {'title': None,
                'upcoming_events': upcoming_events,
-               'unpaid_events': unpaid_events,
+               'uninvoiced_events': uninvoiced_events,
                'unpublished_events': unpublished_events}
     return render(request, 'workshops/index.html', context)
 


### PR DESCRIPTION
It isn't Amy's job to track whether money has arrived - that's the job of NumFOCUS's accounting system.  Instead, we should track whether an invoice has been sent, i.e., have we handed responsibility off to NumFOCUS.  This change of name makes those semantics clearer.