### PR TITLE
'Organizer' field of Event is optional.

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -133,7 +133,7 @@ class EventForm(forms.ModelForm):
     organizer = selectable.AutoCompleteSelectField(
         lookup_class=lookups.SiteLookup,
         label='Organizer',
-        required=True,
+        required=False,
         help_text=AUTOCOMPLETE_HELP_TEXT,
         widget=selectable.AutoComboboxSelectWidget,
     )


### PR DESCRIPTION
The `Event` model allows the `organizer` field to be NULL, but the form wasn't allowing it to be empty.  This PR fixes that by allowing `organizer` to be left empty in the event creation form.

This fixes #330.