### PR TITLE
Award badges from person-edit view

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms import HiddenInput
-from django.forms.models import modelform_factory
+from django.forms import formset_factory
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
@@ -251,3 +251,18 @@ class BadgeAwardForm(forms.ModelForm):
         fields = '__all__'
         widgets = {'badge': HiddenInput}
 
+
+class PersonAwardForm(forms.ModelForm):
+
+    event = selectable.AutoCompleteSelectField(
+        lookup_class=lookups.EventLookup,
+        label='Event',
+        required=False,
+        help_text=AUTOCOMPLETE_HELP_TEXT,
+        widget=selectable.AutoComboboxSelectWidget,
+    )
+
+    class Meta:
+        model = Award
+        fields = '__all__'
+        widgets = {'person': HiddenInput}

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -401,7 +401,10 @@ class Badge(models.Model):
     criteria   = models.CharField(max_length=STR_LONG)
 
     def __str__(self):
-        return self.name
+        return self.title
+
+    def get_absolute_url(self):
+        return reverse('badge_details', args=[self.name])
 
 #------------------------------------------------------------
 

--- a/workshops/templates/workshops/person_edit_form.html
+++ b/workshops/templates/workshops/person_edit_form.html
@@ -1,0 +1,60 @@
+{% extends "workshops/_page.html" %}
+
+{% load breadcrumbs %}
+{% load crispy_forms_tags %}
+{% load selectable_tags %}
+
+{% block breadcrumbs %}
+    {% breadcrumb_main_page %}
+    {% breadcrumb_index_all_objects model %}
+    {% if object %}
+        {% breadcrumb_object object %}
+        {% breadcrumb_edit_object object %}
+    {% else %}
+        {% breadcrumb_new_object model %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    {% crispy person_form form_helper %}
+
+    <h2 id="awards">Awards</h2>
+    {% if awards %}
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>badge</th>
+                <th>awarded</th>
+                <th>event</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for award in awards %}
+            <tr>
+                <td><a href="{{ award.badge.get_absolute_url }}">{{ award.badge.title }}</a></td>
+                <td>{{ award.awarded }}</td>
+                <td>{% if award.event %}<a href="{{ award.event.get_absolute_url }}">{{ award.event }}</a>{% else %}—{% endif %}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No awards</p>
+    {% endif %}
+    <h3>Add awards</h3>
+
+    {% crispy award_form form_helper %}
+{% endblock %}
+
+{% block extrajs %}
+{{ person_form.media }}
+{{ award_form.media }}
+<script type="text/javascript">
+    $(document).ready(function() {
+        $("#id_award-awarded").datepicker({
+            format: "yyyy-mm-dd",
+            todayHighlight: true
+        });
+    });
+</script>
+{% endblock extrajs %}

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -242,16 +242,23 @@ class TestBase(TestCase):
         else:
             return ",".join([x.attrib['value'] for x in selections])
 
-    def _get_initial_form(self, which, *args):
-        '''Get a form to start testing with.'''
-        url = reverse(which, args=[str(a) for a in args])
+    def _get_initial_form_index(self, form_index, url, *args):
+        '''Get a form to start testing with.
+
+        If form_index is None, only 1 form is expected. Otherwise,
+        forms[form_index] is returned from all matching forms.'''
+        url = reverse(url, args=[str(a) for a in args])
         response = self.client.get(url)
         doc = self._check_status_code_and_parse(response, 200)
         self._save_html(response.content.decode("utf-8"))
-        values = self._get_form_data(doc)
+        values = self._get_form_data(doc, form_index)
         return url, values
 
-    def _get_form_data(self, doc):
+    def _get_initial_form(self, url, *args):
+        '''Get first and only form on the page.'''
+        return self._get_initial_form_index(None, url, *args)
+
+    def _get_form_data(self, doc, which_form=None):
         '''Extract form data from page.'''
         # Now there's almost always an additional search form available on the
         # page, so we should fetch the one that does not have role="search".
@@ -259,8 +266,15 @@ class TestBase(TestCase):
         # very limited.  Instead, I added a whole bunch of `role="form"` to
         # specific forms in create/update pages - we can match
         # `form[@role='form']` easily.
-        form = self._get_1(doc, ".//form[@role='form']",
-                           'expected one form in page')
+        if which_form is not None:
+            # some pages have two forms that match this query, so we need to
+            # specify which one do we use
+            forms = self._get_N(doc, ".//form[@role='form']",
+                                'expected multiple forms in page')
+            form = forms[which_form]
+        else:
+            form = self._get_1(doc, ".//form[@role='form']",
+                               'expected one form in page')
 
         inputs = dict([(i.attrib['name'], i.attrib.get('value', None))
                        for i in form.findall(".//input[@type='text']")])

--- a/workshops/test/test_person.py
+++ b/workshops/test/test_person.py
@@ -31,11 +31,12 @@ class TestPerson(TestBase):
         self._test_edit_person_email(self.spiderman)
 
     def test_edit_person_empty_family_name(self):
-        url, values = self._get_initial_form('person_edit', self.ironman.id)
-        assert 'family' in values, \
+        url, values = self._get_initial_form_index(0, 'person_edit',
+                                                   self.ironman.id)
+        assert 'person-family' in values, \
             'No family name in initial form'
 
-        values['family'] = '' # family name cannot be empty
+        values['person-family'] = '' # family name cannot be empty
         response = self.client.post(url, values)
         assert response.status_code == 200, \
             'Expected error page with status 200, got status {0}'.format(response.status_code)
@@ -45,19 +46,19 @@ class TestPerson(TestBase):
             'Expected error messages in response page'
 
     def _test_edit_person_email(self, person):
-        url, values = self._get_initial_form('person_edit', person.id)
-        assert 'email' in values, \
+        url, values = self._get_initial_form_index(0, 'person_edit', person.id)
+        assert 'person-email' in values, \
             'No email address in initial form'
 
         new_email = 'new@new.new'
         assert person.email != new_email, \
             'Would be unable to tell if email had changed'
-        values['email'] = new_email
+        values['person-email'] = new_email
 
-        if values['airport_1'] is None:
-            values['airport_1'] = ''
-        if values['airport_0'] is None:
-            values['airport_0'] = ''
+        if values['person-airport_1'] is None:
+            values['person-airport_1'] = ''
+        if values['person-airport_0'] is None:
+            values['person-airport_0'] = ''
 
         # Django redirects when edit works.
         response = self.client.post(url, values)
@@ -135,12 +136,13 @@ class TestPerson(TestBase):
         assert note in content
 
     def test_edit_person_notes(self):
-        url, values = self._get_initial_form('person_edit', self.hermione.id)
+        url, values = self._get_initial_form_index(0, 'person_edit',
+                                                   self.hermione.id)
 
-        assert 'notes' in values, 'Notes not present in initial form'
+        assert 'person-notes' in values, 'Notes not present in initial form'
 
         note = 'Hermione is a very good student.'
-        values['notes'] = note
+        values['person-notes'] = note
 
         # Django redirects when edit works.
         response = self.client.post(url, values)

--- a/workshops/test/test_person.py
+++ b/workshops/test/test_person.py
@@ -156,6 +156,26 @@ class TestPerson(TestBase):
             self._check_status_code_and_parse(response, 200)
             assert False, 'expected 302 redirect after post'
 
+    def test_person_award_badge(self):
+        # make sure person has no awards
+        assert not self.spiderman.award_set.all()
+
+        # add new award
+        url, values = self._get_initial_form_index(1, 'person_edit',
+                                                   self.spiderman.id)
+        assert 'award-badge' in values
+
+        values['award-badge'] = self.instructor.pk
+        values['award-event_1'] = ''
+        rv = self.client.post(url, data=values)
+        assert rv.status_code == 302, \
+            'After awarding a badge we should be redirected to the same page, got {} instead'.format(rv.status_code)
+        # we actually can't test if it redirects to the same url…
+
+        # make sure the award was recorded in the database
+        self.spiderman.refresh_from_db()
+        assert self.instructor == self.spiderman.award_set.all()[0].badge
+
     def test_edit_person_permissions(self):
         "Make sure we can set up user permissions correctly."
 

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
 
     url(r'^persons/?$', views.all_persons, name='all_persons'),
     url(r'^person/(?P<person_id>[\w\.-]+)/?$', views.person_details, name='person_details'),
-    url(r'^person/(?P<person_id>[\w\.-]+)/edit$', views.PersonUpdate.as_view(), name='person_edit'),
+    url(r'^person/(?P<person_id>[\w\.-]+)/edit$', views.person_edit, name='person_edit'),
     url(r'^person/(?P<person_id>[\w\.-]+)/permissions$', views.PersonPermissions.as_view(), name='person_permissions'),
     url(r'^person/(?P<person_id>[\w\.-]+)/password$', views.person_password, name='person_password'),
     url(r'^persons/add/$', views.PersonCreate.as_view(), name='person_add'),


### PR DESCRIPTION
This is a little bit alternative to #110, and somewhat more limited in options, as it only allows us to add one badge per request from the person-edit view.

However, in here we use two crispy forms that integrate easily and visually appeal, + we have tests in place.