### PR TITLE
Switch from 'Amy' to 'AMY'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Amy is an open source project, and we welcome contributions of all
+AMY is an open source project, and we welcome contributions of all
 kinds.  By contributing, you are agreeing that Software Carpentry may
 redistribute your work under [this license][license].  You also agree
 to abide by our [contributor code of conduct][conduct].
@@ -15,7 +15,7 @@ If you would like to know what we need help with, please see the
 *   New functionality should be accompanied by unit tests where feasible.
 *   All dates should be formatted as YYYY-MM-DD.
 
-The Amy logo was made using the Bradley Hand font from LibreOffice.
+The AMY logo was made using the Bradley Hand font from LibreOffice.
 
 [conduct]: CONDUCT.md
 [issues]: https://github.com/swcarpentry/amy/issues

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![](https://travis-ci.org/swcarpentry/amy.svg?branch=master)
 
-Amy is a web-based workshop administration application for [Software
+AMY is a web-based workshop administration application for [Software
 Carpentry][swc] and related projects.  Its target audience is workshop
 coordinators, most of whon are non-programmers, who need to keep track
 of what workshops are being arranged, when they're supposed to occur,
 who's teaching what, and so on.
 
-Amy is built using [Django][django], with a bit of Javascript and
+AMY is built using [Django][django], with a bit of Javascript and
 other things thrown in.  If you would like to help, please read:
 
 *   the setup instructions below,
@@ -36,10 +36,10 @@ before starting work on new features.
     ~~~
 
     If you're experienced Python programmer, feel free to create a
-    Python3-compatible [virtualenv][virtualenv] for Amy and install
+    Python3-compatible [virtualenv][virtualenv] for AMY and install
     dependencies from `requirements.txt`.
 
-3.  Install [Bower][bower], the tool that manages Amy's JavaScript and CSS dependencies:
+3.  Install [Bower][bower], the tool that manages AMY's JavaScript and CSS dependencies:
 
     ~~~
     $ sudo npm install -g bower
@@ -69,7 +69,7 @@ before starting work on new features.
     $ make serve
     ~~~
 
-    **Note**:  this also installs front-end dependencies for Amy, such as jQuery or Bootstrap.
+    **Note**:  this also installs front-end dependencies for AMY, such as jQuery or Bootstrap.
 
 7.  Open <http://localhost:8000/workshops/> in your browser and start clicking.
 
@@ -117,7 +117,7 @@ before starting work on new features.
     $ python3 manage.py migrate
     ~~~~
 
-4.  Enjoy your new version of Amy:
+4.  Enjoy your new version of AMY:
 
     ~~~
     $ make serve

--- a/workshops/static/css/amy.css
+++ b/workshops/static/css/amy.css
@@ -1,4 +1,4 @@
-/* Styles for Amy */
+/* Styles for AMY */
 
 .warning {
     background-color: #F04040;

--- a/workshops/templates/account/logged_out.html
+++ b/workshops/templates/account/logged_out.html
@@ -9,6 +9,6 @@
 {% block content %}
 {% include "amy-logo.html" %}
 
-<p>Thanks for spending some quality time with Amy today.</p>
+<p>Thanks for working with AMY today.</p>
 
 {% endblock %}

--- a/workshops/templates/amy-logo.html
+++ b/workshops/templates/amy-logo.html
@@ -1,2 +1,2 @@
 {% load static %}
-<a href="https://github.com/swcarpentry/amy"><img src="{% static 'amy-logo.png' %}" alt="Amy Logo" /></a>
+<a href="https://github.com/swcarpentry/amy"><img src="{% static 'amy-logo.png' %}" alt="AMY Logo" /></a>

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -12,7 +12,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{% url "index" %}">Amy</a>
+          <a class="navbar-brand" href="{% url "index" %}">AMY</a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/workshops/templates/base_without_navbar.html
+++ b/workshops/templates/base_without_navbar.html
@@ -14,7 +14,7 @@
     <script src="{% static 'jquery-ui/jquery-ui.min.js' %}"></script>
     <script src="{% static 'bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}"></script>
 
-    <title>Amy{% if title %}: {{ title }}{% endif %}</title>
+    <title>AMY{% if title %}: {{ title }}{% endif %}</title>
   </head>
   <body>
     {% block navbar %}{% endblock %}
@@ -34,7 +34,7 @@
     <div class="container">
       <div class="row">
         <div class="footer">
-          Powered by <a href="https://github.com/swcarpentry/amy">Amy</a>
+          Powered by <a href="https://github.com/swcarpentry/amy">AMY</a>
           version {{workshops_version}}
           {% if workshops_git_hash %}
             (<a href="https://github.com/swcarpentry/amy/commit/{{workshops_git_hash}}">{{workshops_git_short_hash}}</a>

--- a/workshops/templates/workshops/index.html
+++ b/workshops/templates/workshops/index.html
@@ -1,7 +1,7 @@
 {% extends "workshops/_page.html" %}
 {% load breadcrumbs %}
 {% block breadcrumbs %}
-    {% breadcrumb_active 'Amy'  %}
+    {% breadcrumb_active 'AMY'  %}
 {% endblock %}
 
 {% block content %}

--- a/workshops/templatetags/breadcrumbs.py
+++ b/workshops/templatetags/breadcrumbs.py
@@ -105,7 +105,7 @@ def breadcrumb_main_page():
     Example usage:
         {% breadcrumb_main_page %}
     '''
-    title = 'Amy'
+    title = 'AMY'
     url = reverse('index')
     return create_crumb(title, url)
 

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -22,7 +22,7 @@ from ..models import \
 
 
 class TestBase(TestCase):
-    '''Base class for Amy test cases.'''
+    '''Base class for AMY test cases.'''
 
     ERR_DIR = 'htmlerror' # where to save error HTML files
 


### PR DESCRIPTION
We're switching from 'Amy' to 'AMY' to distinguish between real people and this project.

I think we have a consensus to leave 'amy' as the name for the eventual packages (PyPI / NPM), and 'AMY' for the project.

This resolves #328.