### PR TITLE
Add Event.slots, Event.applicants

### DIFF
--- a/workshops/migrations/0011_auto_20150610_0609.py
+++ b/workshops/migrations/0011_auto_20150610_0609.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0010_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='applicants',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='slots',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -280,7 +280,21 @@ class Event(models.Model):
     slug       = models.CharField(max_length=STR_LONG, null=True, blank=True)
     url        = models.CharField(max_length=STR_LONG, unique=True, null=True, blank=True)
     reg_key    = models.CharField(max_length=STR_REG_KEY, null=True, blank=True)
-    attendance = models.IntegerField(null=True, blank=True)
+    attendance = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Number of people who appeared on the workshop",
+    )
+    slots = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Number of available seats",
+    )
+    applicants = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Number of people who applied for the workshop",
+    )
     admin_fee  = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True)
     invoiced   = models.NullBooleanField(default=False, blank=True)
     notes      = models.TextField(default="", blank=True)

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -12,6 +12,8 @@
   <tr><td>end date: </td><td>{{ event.end|default:"—" }}</td></tr>
   <tr><td>Eventbrite key:</td><td>{{ event.reg_key|default:"—" }}</td></tr>
   <tr><td>attendance:</td><td>{{ event.attendance|default_if_none:"—" }}</td></tr>
+  <tr><td>slots:</td><td>{{ event.slots|default_if_none:"—" }}</td></tr>
+  <tr><td>applicants:</td><td>{{ event.applicants|default_if_none:"—" }}</td></tr>
   <tr><td>admin fee:</td><td>{{ event.admin_fee|default_if_none:"—" }}</td></tr>
   <tr><td>invoiced:</td><td>{{ event.invoiced|yesno:"yes,no,unknown" }}</td></tr>
 </table>


### PR DESCRIPTION
Additionally, help_text was added to Event.attendance, Event.slots,
Event.applicants to help admins understand role of each of these fields:

* Event.attendance: number of people who turned out to the workshop
* Event.slots: number of slots available for people
* Event.applicants: number of people who applied for the workshop.

For example, we can have a workshops for maximum of 40 people.
42 people registers, and only 36 comes to the workshop.  So
attendance=36, slots=40, and applicants=42.

This solves #64.