### PR TITLE
Improving pattern-matching and error reporting in bulk upload.

### DIFF
--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -51,7 +51,6 @@
                 {% endfor %}
                 </ul>
             {% else %}
-                {{ entry.errors|default_if_none:"&mdash;" }}
             {% endif %}
             </td>
         {% endwith %}

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -50,7 +50,6 @@
                     <li>{{ error }}</li>
                 {% endfor %}
                 </ul>
-            {% else %}
             {% endif %}
             </td>
         {% endwith %}

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -170,9 +170,10 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
         has_errors = verify_upload_person_task(bad_data)
         self.assertTrue(has_errors)
         errors = bad_data[0]['errors']
-        self.assertEqual(len(errors), 1)
-        self.assertTrue("Personal, middle or family name of existing user"
-                        " don't match" in errors[0])
+        self.assertEqual(len(errors), 3)
+        self.assertTrue('personal' in errors[0])
+        self.assertTrue('middle' in errors[1])
+        self.assertTrue('family' in errors[2])
 
     def test_verify_existing_user_has_workshop_role_provided(self):
         bad_data = [


### PR DESCRIPTION
1.  Report exactly which name field failed to match.
2.  Show blanks when there are no errors (rather than dashes).
3.  Modify pattern matching to match empty string in uploaded data vs. null in database to avoid spurious errors.