### PR TITLE
Turn off Django Admin completely

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -79,7 +79,6 @@ INSTALLED_APPS = (
     'workshops',
     # this should be after 'workshops' because templates in
     # 'templates/registration/' clash
-    'django.contrib.admin',
     'crispy_forms',
     'selectable',
     'django_countries',

--- a/amy/urls.py
+++ b/amy/urls.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 
 urlpatterns = patterns('',
     url(r'^workshops/', include('workshops.urls')),
-    url(r'^admin/', include(admin.site.urls)),
     # url(r'^account/', include('django.contrib.auth.urls')),
 
     # django views for authentication

--- a/workshops/admin.py
+++ b/workshops/admin.py
@@ -1,6 +1,0 @@
-from django.contrib import admin
-from workshops.models import Airport
-from workshops.models import Site
-
-admin.site.register(Airport)
-admin.site.register(Site)


### PR DESCRIPTION
Plus remove basic admin forms for workshops application.
We don't need them.

Resolves #41.