### PR TITLE
Two links for event

### DIFF
--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -1,5 +1,7 @@
 {% extends "workshops/_page.html" %}
 
+{% load links %}
+
 {% block content %}
 <p class="edit-object"><a href="{% url 'event_edit' event.id %}" class="btn btn-primary">Edit</a></p>
 <table class="table table-striped">
@@ -10,7 +12,10 @@
   <tr><td>site:</td><td><a href="{% url 'site_details' event.site.domain %}">{{ event.site }}</a></td></tr>
   <tr><td>organizer:</td><td>{% if event.organizer %}<a href="{{ event.organizer.get_absolute_url }}">{{ event.organizer }}</a>{% else %}—{% endif %}</td></tr>
   <tr><td>tags:</td><td>{{ event.tags.all | join:", " }}</td></tr>
-  <tr><td>url:</td><td>{% if event.url %}<a href="{{ event.url }}">{{ event.url }}</a>{% else %}—{% endif %} {% if event.url %}<a href="{% url 'validate_event' event.get_ident %}" class="btn btn-primary btn-xs pull-right" id="validate_event">validate event</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_event_url" href="#" data-toggle="popover" data-trigger="focus" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>">Error</a>{% endif %}</td></tr>
+  {% format_link_to_repository event.url as repo_link %}
+  {% format_link_to_website event.url as website_link %}
+  <tr><td>Website URL:</td><td>{{ website_link|default:"—"|urlize }}</td></tr>
+  <tr><td>Repository URL:</td><td>{{ repo_link|default:"—"|urlize }} {% if repo_link %}<a href="{% url 'validate_event' event.get_ident %}" class="btn btn-primary btn-xs pull-right" id="validate_event">validate event</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_event_url" href="#" data-toggle="popover" data-trigger="focus" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>">Error</a>{% endif %}</td></tr>
   <tr><td>Eventbrite key:</td><td>{{ event.reg_key|default:"—" }}</td></tr>
   <tr><td>attendance:</td><td>{{ event.attendance|default_if_none:"—" }}</td></tr>
   <tr><td>admin fee:</td><td>{{ event.admin_fee|default_if_none:"—" }}</td></tr>

--- a/workshops/templatetags/links.py
+++ b/workshops/templatetags/links.py
@@ -1,0 +1,49 @@
+import re
+
+from django import template
+
+register = template.Library()
+
+REPO_REGEXP = re.compile(r'https://github\.com/(?P<name>\w+)/(?P<repo>\S+)/?')
+REPO_SCHEMA = 'https://github.com/{name}/{repo}/'
+WEBSITE_REGEXP = re.compile(
+    r'http://(?P<name>\w+)\.github\.(io|com)/(?P<repo>\S+)/?'
+)
+WEBSITE_SCHEMA = 'http://{name}.github.io/{repo}/'
+
+
+@register.assignment_tag(takes_context=True)
+def format_link_to_repository(context, link):
+    """
+    Use: {% format_link_to_repository event.url as repo_link %}
+    Then: {{ repo_link|urlize|default_if_none:"—" }}
+    """
+    print(context['request'])
+    if not link:
+        return link
+    elif REPO_REGEXP.match(link):
+        return link
+    else:
+        try:
+            repository = WEBSITE_REGEXP.findall(link)[0]
+            return REPO_SCHEMA.format(name=repository[0], repo=repository[-1])
+        except IndexError:
+            return link
+
+
+@register.assignment_tag
+def format_link_to_website(link):
+    """
+    Use: {% format_link_to_website event.url as website_link %}
+    Then: {{ website_link|urlize|default_if_none:"—" }}
+    """
+    if not link:
+        return link
+    elif WEBSITE_REGEXP.match(link):
+        return link
+    else:
+        try:
+            site = REPO_REGEXP.findall(link)[0]
+            return WEBSITE_SCHEMA.format(name=site[0], repo=site[-1])
+        except IndexError:
+            return link


### PR DESCRIPTION
Display two links for an event:
* a website link (ie. http://user.github.io/repo)
* a repo link (ie. https://github.com/user/repo)

Resolves #325.