### PR TITLE
Pagination error with filtering

### DIFF
--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -13,7 +13,7 @@ class EventFilter(django_filters.FilterSet):
             'organizer',
             'invoiced',
         ]
-        order_by = ['slug', '-slug', 'start', '-start', 'end', '-end']
+        order_by = ['-slug', 'slug', 'start', '-start', 'end', '-end']
 
 
 class SiteFilter(django_filters.FilterSet):

--- a/workshops/templates/pagination.html
+++ b/workshops/templates/pagination.html
@@ -1,0 +1,15 @@
+<div class="pagination">
+  <span class="step-links">
+     {% if objects.has_previous %}
+         <a href="?{{ prev_query.urlencode }}">previous</a>
+     {% endif %}
+
+     <span class="current">
+         Page {{ objects.number }} of {{ objects.paginator.num_pages }}.
+     </span>
+
+     {% if objects.has_next %}
+         <a href="?{{ next_query.urlencode }}">next</a>
+     {% endif %}
+  </span>
+</div>

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -1,6 +1,8 @@
 {% extends "workshops/_page_fluid.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
+
 {% block sidebar %}
     <h3>Filter</h3>
     {% crispy filter.form form_helper %}
@@ -31,21 +33,7 @@
         </tr>
     {% endfor %}
     </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_airports.has_previous %}
-             <a href="?page={{ all_airports.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_airports.number }} of {{ all_airports.paginator.num_pages }}.
-         </span>
-
-         {% if all_airports.has_next %}
-             <a href="?page={{ all_airports.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
+    {% pagination all_airports %}
     <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
 {% else %}
     <p>No airports.</p>

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -1,6 +1,8 @@
 {% extends "workshops/_page_fluid.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
+
 {% block sidebar %}
     <h3>Filter</h3>
     {% crispy filter.form form_helper %}
@@ -61,21 +63,7 @@
       </tr>
     {% endfor %}
     </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_events.has_previous %}
-             <a href="?page={{ all_events.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_events.number }} of {{ all_events.paginator.num_pages }}.
-         </span>
-
-         {% if all_events.has_next %}
-             <a href="?page={{ all_events.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
+    {% pagination all_events %}
     <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
 {% else %}
     <p>No events.</p>

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -1,6 +1,8 @@
 {% extends "workshops/_page_fluid.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
+
 {% block sidebar %}
     <h3>Filter</h3>
     {% crispy filter.form form_helper %}
@@ -29,21 +31,7 @@
       </tr>
     {% endfor %}
     </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_persons.has_previous %}
-             <a href="?page={{ all_persons.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_persons.number }} of {{ all_persons.paginator.num_pages }}.
-         </span>
-
-         {% if all_persons.has_next %}
-             <a href="?page={{ all_persons.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
+    {% pagination all_persons %}
     <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a></p>
 {% else %}
     <p>No persons.</p>

--- a/workshops/templates/workshops/all_sites.html
+++ b/workshops/templates/workshops/all_sites.html
@@ -1,6 +1,8 @@
 {% extends "workshops/_page_fluid.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
+
 {% block sidebar %}
     <h3>Filter</h3>
     {% crispy filter.form form_helper %}
@@ -29,21 +31,7 @@
         </tr>
     {% endfor %}
     </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_sites.has_previous %}
-             <a href="?page={{ all_sites.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_sites.number }} of {{ all_sites.paginator.num_pages }}.
-         </span>
-
-         {% if all_sites.has_next %}
-             <a href="?page={{ all_sites.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
+    {% pagination all_sites %}
     <p><a href="{% url 'site_add' %}" class="btn btn-success">New site</a></p>
 {% else %}
     <p>No sites.</p>

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -1,6 +1,8 @@
 {% extends "workshops/_page_fluid.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
+
 {% block sidebar %}
     <h3>Filter</h3>
     {% crispy filter.form form_helper %}
@@ -29,21 +31,7 @@
         </tr>
     {% endfor %}
     </table>
-    <div class="pagination">
-      <span class="step-links">
-         {% if all_tasks.has_previous %}
-             <a href="?page={{ all_tasks.previous_page_number }}">previous</a>
-         {% endif %}
-
-         <span class="current">
-             Page {{ all_tasks.number }} of {{ all_tasks.paginator.num_pages }}.
-         </span>
-
-         {% if all_tasks.has_next %}
-             <a href="?page={{ all_tasks.next_page_number }}">next</a>
-         {% endif %}
-      </span>
-    </div>
+    {% pagination all_tasks %}
     <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
 {% else %}
     <p>No tasks.</p>

--- a/workshops/templates/workshops/badge.html
+++ b/workshops/templates/workshops/badge.html
@@ -1,6 +1,7 @@
 {% extends "workshops/_page.html" %}
 
 {% load crispy_forms_tags %}
+{% load pagination %}
 
 {% block content %}
 <table class="table table-striped">
@@ -28,19 +29,7 @@
     </tr>
     {% endfor %}
   </table>
-  <div class="pagination">
-    <span class="step-links">
-      {% if awards.has_previous %}
-      <a href="?page={{ awards.previous_page_number }}">previous</a>
-      {% endif %}
-      <span class="current">
-        Page {{ awards.number }} of {{ awards.paginator.num_pages }}.
-      </span>
-      {% if awards.has_next %}
-      <a href="?page={{ awards.next_page_number }}">next</a>
-      {% endif %}
-    </span>
-  </div>
+  {% pagination awards %}
 {% else %}
 <p>None awarded.</p>
 {% endif %}

--- a/workshops/templatetags/pagination.py
+++ b/workshops/templatetags/pagination.py
@@ -1,0 +1,13 @@
+from django import template
+register = template.Library()
+
+
+@register.inclusion_tag('pagination.html', takes_context=True)
+def pagination(context, objects):
+    previous = context['request'].GET.copy()
+    next = context['request'].GET.copy()
+    if objects.has_previous():
+        previous['page'] = objects.previous_page_number()
+    if objects.has_next():
+        next['page'] = objects.next_page_number()
+    return {'objects': objects, 'prev_query': previous, 'next_query': next}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1050,29 +1050,27 @@ def _get_pagination_items(request, all_objects):
             items = int(items)
         except ValueError:
             items = ITEMS_PER_PAGE
+    else:
+        # Show everything.
+        items = all_objects.count()
 
     # Figure out where we are.
     page = request.GET.get('page')
 
-    # Show everything.
-    if items == 'all':
-        result = all_objects
-
     # Show selected items.
-    else:
-        paginator = Paginator(all_objects, items)
+    paginator = Paginator(all_objects, items)
 
-        # Select the sites.
-        try:
-            result = paginator.page(page)
+    # Select the sites.
+    try:
+        result = paginator.page(page)
 
-        # If page is not an integer, deliver first page.
-        except PageNotAnInteger:
-            result = paginator.page(1)
+    # If page is not an integer, deliver first page.
+    except PageNotAnInteger:
+        result = paginator.page(1)
 
-        # If page is out of range, deliver last page of results.
-        except EmptyPage:
-            result = paginator.page(paginator.num_pages)
+    # If page is out of range, deliver last page of results.
+    except EmptyPage:
+        result = paginator.page(paginator.num_pages)
 
     return result
 


### PR DESCRIPTION
Switching pages with pagination erased our filters from address, for example:

* page 1: `/workshops/events/?order=slug`
* page 2 should be: `/workshops/events/?order=slug&page=2`, but was: `/workshops/events/?page=2`

Additionally:
* a generic pagination template was used, so we're more DRY
* I decided to change ordering of events to DESC BY SLUG by default; I believe that was the order from before django-filters.