### PR TITLE
Display person's username

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -256,7 +256,7 @@ class PersonForm(forms.ModelForm):
         # don't display the 'password', 'user_permissions',
         # 'groups' or 'is_superuser' fields
         # + reorder fields
-        fields = ['personal', 'middle', 'family', 'username', 'may_contact',
+        fields = ['username', 'personal', 'middle', 'family', 'may_contact',
                   'email', 'gender', 'airport', 'github', 'twitter', 'url',
                   'notes', ]
 

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -9,6 +9,7 @@
   </div>
 </div>
 <table class="table table-striped">
+  <tr><td>username:</td><td id="username">{{ person.username|default:"—" }}</td></tr>
   <tr><td>personal:</td><td id="personal">{{ person.personal|default:"—" }}</td></tr>
   <tr><td>middle:</td><td id="middle">{{ person.middle|default:"—" }}</td></tr>
   <tr><td>family:</td><td id="family">{{ person.family|default:"—" }}</td></tr>


### PR DESCRIPTION
Username was missing on person details page.  This commit adds it on top
of the table with details.