### PR TITLE
Nicer pagination bar

### DIFF
--- a/workshops/templates/pagination.html
+++ b/workshops/templates/pagination.html
@@ -17,7 +17,7 @@
          {% endif %}
 
          {% if current_query.urlencode != '' %}
-           <a href="?page={{ i }}&{{ current_query.urlencode }}">{{ i }}</a>
+           <a href="?page={{ i }}&amp;{{ current_query.urlencode }}">{{ i }}</a>
          {% else %}
            <a href="?page={{ i }}">{{ i }}</a>
          {% endif %}

--- a/workshops/templates/pagination.html
+++ b/workshops/templates/pagination.html
@@ -1,15 +1,32 @@
-<div class="pagination">
-  <span class="step-links">
+<nav>
+  <ul class="pagination">
      {% if objects.has_previous %}
-         <a href="?{{ prev_query.urlencode }}">previous</a>
+       <li>
+         <a href="?{{ prev_query.urlencode }}" aria-label="Previous">
+           <span aria-hidden="true">&laquo;</span>
+         </a>
+       </li>
      {% endif %}
 
-     <span class="current">
-         Page {{ objects.number }} of {{ objects.paginator.num_pages }}.
-     </span>
+     {% for i in objects.paginator.page_range %}
+       {% if i > objects.number|add:"-10" and i < objects.number|add:"11" %}
+         {% if objects.number == i %}
+           <li class="active">
+         {% else %}
+           <li>
+         {% endif %}
+         <a href="?page={{ i }}">{{ i }}</a>
+       </li>
+       {% endif %}
+     {% endfor %}
 
      {% if objects.has_next %}
-         <a href="?{{ next_query.urlencode }}">next</a>
+       <li>
+         <a href="?{{ next_query.urlencode }}" aria-label="Next">
+           <span aria-label="true">&raquo;</span>
+         </a>
+       </li>
+
      {% endif %}
-  </span>
-</div>
+  </ul>
+</nav>

--- a/workshops/templates/pagination.html
+++ b/workshops/templates/pagination.html
@@ -15,8 +15,14 @@
          {% else %}
            <li>
          {% endif %}
-         <a href="?page={{ i }}">{{ i }}</a>
-       </li>
+
+         {% if current_query.urlencode != '' %}
+           <a href="?page={{ i }}&{{ current_query.urlencode }}">{{ i }}</a>
+         {% else %}
+           <a href="?page={{ i }}">{{ i }}</a>
+         {% endif %}
+
+           </li>
        {% endif %}
      {% endfor %}
 

--- a/workshops/templatetags/pagination.py
+++ b/workshops/templatetags/pagination.py
@@ -6,8 +6,13 @@ register = template.Library()
 def pagination(context, objects):
     previous = context['request'].GET.copy()
     next = context['request'].GET.copy()
+    current = context['request'].GET.copy()
+    if 'page' in current:
+        del current['page']
+
     if objects.has_previous():
         previous['page'] = objects.previous_page_number()
     if objects.has_next():
         next['page'] = objects.next_page_number()
-    return {'objects': objects, 'prev_query': previous, 'next_query': next}
+    return {'objects': objects, 'prev_query': previous, 'next_query': next,
+            'current_query': current}


### PR DESCRIPTION
Applied simple modifications to the template `pagination.html`. There will be
shown up to 20 pagination links in cases where there are too many to show.
The pagination bar will show the closest 10 links (before and after) to the
current page.

These screen-shots show how it looks before and after the patch.

![a](https://cloud.githubusercontent.com/assets/710117/8268277/7e51d5a6-1788-11e5-9627-91d444f9ecb9.png)