### PR TITLE
Fix: success/error messages hovered by filter control

### DIFF
--- a/workshops/templates/base_without_navbar.html
+++ b/workshops/templates/base_without_navbar.html
@@ -21,16 +21,20 @@
     <div class="container{% block fluid2 %}{% endblock %}">
       {% block title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
       {% for message in messages %}
-      <div class="alert {{ message.tags }}">
-        {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
-        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span><span class="sr-only">Error:</span>
-        {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
-        <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning:</span>
-        {% elif message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
-        <span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span><span class="sr-only">Success:</span>
-        {% endif %}
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
-        {{ message }}
+      <div class="row">
+        <div class="{% block fluid-messages %}col-sm-12{% endblock %}">
+          <div class="alert {{ message.tags }}">
+            {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span><span class="sr-only">Error:</span>
+            {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
+            <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning:</span>
+            {% elif message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
+            <span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span><span class="sr-only">Success:</span>
+            {% endif %}
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+            {{ message }}
+          </div>
+        </div>
       </div>
       {% endfor %}
       {% block content %}{% endblock %}

--- a/workshops/templates/workshops/_page_fluid.html
+++ b/workshops/templates/workshops/_page_fluid.html
@@ -3,6 +3,7 @@
 {% block fluid1 %}-fluid{% endblock %}
 {% block fluid2 %}-fluid{% endblock %}
 {% block fluid3 %}-fluid{% endblock %}
+{% block fluid-messages %}col-sm-10 col-sm-offset-2{% endblock %}
 
 {% block title %}{% endblock %}
 {% block content %}
@@ -10,7 +11,7 @@
     <div class="col-sm-2 col-md-2 sidebar">
     {% block sidebar %}{% endblock %}
     </div>
-    <div class="col-sm-10 col-md-10 col-sm-offset-3 col-md-offset-2 main">
+    <div class="col-sm-10 col-md-10 col-sm-offset-2 col-md-offset-2 main">
     {% if title %}<h1>{{ title }}</h1>{% endif %}
     {% block content-fluid %}{% endblock %}
     </div>


### PR DESCRIPTION
A left-side offset was added to the messages on fluid layouts.