### PR TITLE
Fix fields in *_diff pages

### DIFF
--- a/workshops/templates/workshops/event_diff.html
+++ b/workshops/templates/workshops/event_diff.html
@@ -26,6 +26,10 @@
     <td>{% semantic_diff previous_version current_version 'organizer' %}</td>
   </tr>
   <tr>
+    <th>tags:</th>
+    <td>{% semantic_diff previous_version current_version 'tags' %}</td>
+  </tr>
+  <tr>
     <th>url:</th>
     <td>{% semantic_diff previous_version current_version 'url' %}</td>
   </tr>
@@ -34,16 +38,20 @@
     <td>{% semantic_diff previous_version current_version 'reg_key' %}</td>
   </tr>
   <tr>
-    <th>attendance:</th>
-    <td>{% semantic_diff previous_version current_version 'attendance' %}</td>
-  </tr>
-  <tr>
     <th>admin fee:</th>
     <td>{% semantic_diff previous_version current_version 'admin_fee' %}</td>
   </tr>
   <tr>
     <th>invoiced:</th>
     <td>{% semantic_diff previous_version current_version 'invoiced' %}</td>
+  </tr>
+  <tr>
+    <th>attendance:</th>
+    <td>{% semantic_diff previous_version current_version 'attendance' %}</td>
+  </tr>
+  <tr>
+    <th>notes:</th>
+    <td>{% semantic_diff previous_version current_version 'notes' %}</td>
   </tr>
 </table>
 {% endblock %}

--- a/workshops/templates/workshops/person_diff.html
+++ b/workshops/templates/workshops/person_diff.html
@@ -22,16 +22,16 @@
     <td>{% semantic_diff previous_version current_version 'family' %}</td>
   </tr>
   <tr>
+    <th>may contact:</th>
+    <td>{% semantic_diff previous_version current_version 'may_contact' %}</td>
+  </tr>
+  <tr>
     <th>email:</th>
     <td>{% semantic_diff previous_version current_version 'email' %}</td>
   </tr>
   <tr>
     <th>gender:</th>
     <td>{% semantic_diff previous_version current_version 'gender' %}</td>
-  </tr>
-  <tr>
-    <th>may contact:</th>
-    <td>{% semantic_diff previous_version current_version 'may_contact' %}</td>
   </tr>
   <tr>
     <th>airport:</th>


### PR DESCRIPTION
Fields were reordered in event_diff, person_diff pages to appear in the
same order as in EventForm and PersonForm.

Missing field 'notes' for Event was added.