### PR TITLE
Fix: searching for "name lastname"

### DIFF
--- a/workshops/test/test_search.py
+++ b/workshops/test/test_search.py
@@ -28,22 +28,22 @@ class TestSearchSite(TestBase):
     def test_search_for_site_by_partial_name(self):
         response = self.client.post(reverse('search'),
                                     {'term' : 'Alpha',
-                                     'in_sites' : 'on'})
-        doc = self._check_status_code_and_parse(response, 200)
-        node = self._get_1(doc, ".//a[@class='searchresult']",
-                           'Expected exactly one search result')
-        assert node.text=='alpha.edu', \
-            'Wrong name "{0}" in search result'.format(node.text)
+                                     'in_sites' : 'on'},
+                                    follow=True)
+        assert response.status_code == 200
+        content = response.content.decode('utf-8')
+        # no way for us to check the url…
+        assert str(self.site_alpha) in content
 
     def test_search_for_site_by_full_domain(self):
         response = self.client.post(reverse('search'),
                                     {'term' : 'beta.com',
-                                     'in_sites' : 'on'})
-        doc = self._check_status_code_and_parse(response, 200)
-        node = self._get_1(doc, ".//a[@class='searchresult']",
-                           'Expected exactly one search result')
-        assert node.text=='beta.com', \
-            'Wrong name "{0}" in search result'.format(node.text)
+                                     'in_sites' : 'on'},
+                                    follow=True)
+        assert response.status_code == 200
+        content = response.content.decode('utf-8')
+        # no way for us to check the url…
+        assert str(self.site_beta) in content
 
     def test_search_for_site_with_multiple_matches(self):
         response = self.client.post(reverse('search'),

--- a/workshops/test/test_search.py
+++ b/workshops/test/test_search.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse
-from ..models import Site
+from ..models import Site, Person
 from .base import TestBase
 
 
@@ -55,4 +55,24 @@ class TestSearchSite(TestBase):
                             expected=2)
         texts = set([n.text for n in nodes])
         assert texts == {'alpha.edu', 'beta.com'}, \
+            'Wrong names {0} in search result'.format(texts)
+
+    def test_search_for_people_by_personal_family_names(self):
+        """Test if searching for two words yields people correctly."""
+        # let's add Hermione Granger to some site's notes
+        # this is required because of redirection if only 1 person matches
+        self.site_alpha.notes = 'Hermione Granger'
+        self.site_alpha.save()
+
+        response = self.client.post(reverse('search'), {
+            'term': 'Hermione Granger',
+            'in_sites': 'on',
+            'in_persons': 'on',
+        })
+        doc = self._check_status_code_and_parse(response, 200)
+        nodes = self._get_N(doc, ".//a[@class='searchresult']",
+                            'Expected two search results',
+                            expected=2)
+        texts = set([n.text for n in nodes])
+        assert texts == {str(self.site_alpha), str(self.hermione)}, \
             'Wrong names {0} in search result'.format(texts)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -970,6 +970,7 @@ def search(request):
         if form.is_valid():
             term = form.cleaned_data['term']
             tokens = re.split('\s+', term)
+            results = list()
 
             if form.cleaned_data['in_sites']:
                 sites = Site.objects.filter(
@@ -977,6 +978,8 @@ def search(request):
                     Q(fullname__contains=term) |
                     Q(notes__contains=term)) \
                     .order_by('fullname')
+                results += list(sites)
+
             if form.cleaned_data['in_events']:
                 events = Event.objects.filter(
                     Q(slug__contains=term) |
@@ -984,6 +987,8 @@ def search(request):
                     Q(site__domain__contains=term) |
                     Q(site__fullname__contains=term)) \
                     .order_by('-slug')
+                results += list(events)
+
             if form.cleaned_data['in_persons']:
                 # if user searches for two words, assume they mean a person
                 # name
@@ -1002,11 +1007,18 @@ def search(request):
                         Q(email__contains=term) |
                         Q(github__contains=term)) \
                         .order_by('family')
+                results += list(persons)
+
             if form.cleaned_data['in_airports']:
                 airports = Airport.objects.filter(
                     Q(iata__contains=term) |
                     Q(fullname__contains=term)) \
                     .order_by('iata')
+                results += list(airports)
+
+            # only 1 record found? Let's move to it immediately
+            if len(results) == 1:
+                return redirect(results[0].get_absolute_url())
 
     # if a GET (or any other method) we'll create a blank form
     else:


### PR DESCRIPTION
This fixes #319.

The fix: if the term can be tokenized to 2 words (for example: `"Piotr Banaszkiewicz"` → `["Piotr", "Banaszkiewicz"]`), then the search looks for people who have `personal=FIRSTTERM, family=SECONDTERM` or `personal=SECONDTERM, family=FIRSTTERM`.

Additional improvement was made to the search yielding only one record. In this case, user is redirected immediately to that result's details page.

WIP: missing tests.