### PR TITLE
Fix: make Event.slug unique

### DIFF
--- a/workshops/migrations/0027_auto_20150714_1143.py
+++ b/workshops/migrations/0027_auto_20150714_1143.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0026_add_missing_airports'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='slug',
+            field=models.CharField(unique=True, null=True, blank=True, max_length=100),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -292,7 +292,7 @@ class Event(models.Model):
     start      = models.DateField(null=True, blank=True,
                                   help_text='Setting this and url "publishes" the event.')
     end        = models.DateField(null=True, blank=True)
-    slug       = models.CharField(max_length=STR_LONG, null=True, blank=True)
+    slug       = models.CharField(max_length=STR_LONG, null=True, blank=True, unique=True)
     url        = models.CharField(max_length=STR_LONG, unique=True, null=True, blank=True,
                                   help_text='Setting this and startdate "publishes" the event.')
     reg_key    = models.CharField(max_length=STR_REG_KEY, null=True, blank=True, verbose_name="Eventbrite key")
@@ -331,6 +331,7 @@ class Event(models.Model):
             return Event.objects.get(slug=ident)
 
     def save(self, *args, **kwargs):
+        self.slug = self.slug or None
         self.url = self.url or None
         super(Event, self).save(*args, **kwargs)
 


### PR DESCRIPTION
1. Event.slug has unique=True
2. Proper migration is introduced
3. Event.save() is altered to save empty slugs as NULLs
4. Test for saving events with non-unique slugs
5. Test for saving events with empty slugs

This fixes #427. This is a general bug, not related to #426 (but discovered by @gvwilson when testing that PR).