### PR TITLE
Protect awards when deleting events

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -425,7 +425,8 @@ class Award(models.Model):
     person     = models.ForeignKey(Person)
     badge      = models.ForeignKey(Badge)
     awarded    = models.DateField()
-    event      = models.ForeignKey(Event, null=True, blank=True)
+    event      = models.ForeignKey(Event, null=True, blank=True,
+                                   on_delete=models.PROTECT)
 
     class Meta:
         unique_together = ("person", "badge", )

--- a/workshops/templates/workshops/failed_to_delete.html
+++ b/workshops/templates/workshops/failed_to_delete.html
@@ -1,23 +1,27 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
-<p>{{ object }} can't be deleted, because it's referenced by:</p>
+<p>
+    {% if object.get_absolute_url %}
+    <a href="{{ object.get_absolute_url }}">{{ object }}</a>
+    {% else %}
+    {{ object }}
+    {% endif %}
+    can't be deleted, because it's referenced by:</p>
 
 <dl>
 {% for key, items in refs.items %}
-    {% if items.count %}
-        <dt>{{ key }}:</dt>
+    <dt>{{ key }}:</dt>
 
-        {% for item in items.all %}
-        <dd>
-            {% if item.get_absolute_url %}
-            <a href="{{ item.get_absolute_url }}">{{ item }}</a>
-            {% else %}
-            {{ item }}
-            {% endif %}
-        </dd>
-        {% endfor %}
-    {% endif %}
+    {% for item in items %}
+    <dd>
+        {% if item.get_absolute_url %}
+        <a href="{{ item.get_absolute_url }}">{{ item }}</a>
+        {% else %}
+        {{ item }}
+        {% endif %}
+    </dd>
+    {% endfor %}
 {% endfor %}
 </dl>
 


### PR DESCRIPTION
This fixes #383.

There's one small issue: we prevent events from deletion when there are some awards related. The thing is that we can't delete awards, we have no award-details page nor award-delete view.

@gvwilson what would you like to have? I think we need to add both award-detail page and award-delete view.