### PR TITLE
Import location data for historical workshops

### DIFF
--- a/workshops/management/commands/import_archived_workshops.py
+++ b/workshops/management/commands/import_archived_workshops.py
@@ -1,0 +1,77 @@
+from collections import namedtuple
+
+from django.core.management.base import BaseCommand, CommandError
+from yaml import load
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+from workshops.models import Event
+
+
+class Command(BaseCommand):
+    help = 'Import location and contact data from historical workshops.'
+
+    # only one entry has this issue
+    TRANSLATE_COUNTRY = {
+        'UNITED STATES': 'US',
+    }
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'filename', help='YAML archive of past workshops',
+        )
+        parser.add_argument(
+            '--overwrite', action='store_true', default=False,
+            help='Overwrite values in non-empty fields [default: skip]',
+        )
+
+    def compare_and_update(self, event, workshop, overwrite=False):
+        fields = workshop._fields
+
+        for field in fields:
+            L = getattr(event, field)
+            R = getattr(workshop, field)
+            if R:
+                if overwrite or not L:
+                    # update only if there's a new value (R) and we agreed to
+                    # overwrite existing value OR there's a new value (R) and
+                    # previous value is empty
+                    setattr(event, field, R)
+        event.save()
+
+    def handle(self, *args, **options):
+        filename = options['filename']
+        overwrite = options['overwrite']
+
+        with open(filename, 'r') as f:
+            data = load(f, Loader=Loader)
+
+        Workshop = namedtuple(
+            'Workshop',
+            ['slug', 'contact', 'country', 'venue', 'address', 'latitude',
+             'longitude']
+        )
+
+        data = [
+            Workshop(
+                slug=D.get('slug'), contact=D.get('contact'),
+                country=D.get('country', '').upper(),
+                venue=D.get('venue'), address=D.get('address'),
+                latitude=(D.get('latlng') or ',').split(',')[0],
+                longitude=(D.get('latlng') or ',').split(',')[1],
+            )
+            for D in data
+        ]
+
+        for workshop in data:
+            try:
+                event = Event.objects.get(slug=workshop.slug)
+                country_repl = self.TRANSLATE_COUNTRY.get(workshop.country)
+                if country_repl:
+                    workshop = workshop._replace(country=country_repl)
+                self.compare_and_update(event, workshop, overwrite)
+            except Event.DoesNotExist:
+                self.stderr.write('Historical event {} does not exist in the'
+                                  ' database'.format(workshop.slug))

--- a/workshops/management/commands/import_archived_workshops.py
+++ b/workshops/management/commands/import_archived_workshops.py
@@ -57,7 +57,10 @@ class Command(BaseCommand):
         data = [
             Workshop(
                 slug=D.get('slug'), contact=D.get('contact'),
-                country=D.get('country', '').upper(),
+                # `D.get('sth') or ''` is a trick to always get string, even
+                # if `D['sth'] == None`
+                # (this cannot be done with `D.get('sth', '')`)
+                country=(D.get('country') or '').upper(),
                 venue=D.get('venue'), address=D.get('address'),
                 latitude=(D.get('latlng') or ',').split(',')[0],
                 longitude=(D.get('latlng') or ',').split(',')[1],


### PR DESCRIPTION
The data is gathered from swcarpentry/site archives
(`config/archive.yml`).

This new management command also updates 'contact' field.

The command was needed because I introduced location fields to the AMY in v0.7, but no-one should update them manually…