### PR TITLE
Permissions

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = (
     'workshops',
     # this should be after 'workshops' because templates in
     # 'templates/registration/' clash
+    'django.contrib.admin',
     'crispy_forms',
     'selectable',
     'django_countries',

--- a/amy/urls.py
+++ b/amy/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 urlpatterns = patterns('',
+    url(r'^workshops/admin/', include(admin.site.urls)),
     url(r'^workshops/', include('workshops.urls')),
     # url(r'^account/', include('django.contrib.auth.urls')),
 

--- a/workshops/migrations/0039_add_permission_groups.py
+++ b/workshops/migrations/0039_add_permission_groups.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import Permission, Group
+from django.contrib.contenttypes.models import ContentType
+from django.db import models, migrations
+
+from workshops.models import (
+    Airport, Award, Badge, Event, Host, KnowledgeDomain, Lesson, Person,
+    Qualification, Role, Tag, Task,
+)
+
+
+def add_permission_groups(apps, schema_editor):
+    # create 'administrators' group with all permissions for CRUD
+    auth_ct = ContentType.objects.get_for_models(Permission, Group)
+    workshops_ct = ContentType.objects.get_for_models(
+        Airport, Award, Badge, Event, Host, KnowledgeDomain, Lesson, Person,
+        Qualification, Role, Tag, Task,
+    )
+    auth_ct.update(workshops_ct)
+    permissions = Permission.objects.filter(content_type__in=auth_ct.values())
+
+    group = Group.objects.create(name='administrators')
+    group.permissions = permissions
+    group.save()
+
+    # create 'steering committee' group, but don't grant any permissions (cause
+    # read-only access doesn't require any)
+    Group.objects.create(name='steering committee')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0038_auto_20150809_0534'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_permission_groups),
+    ]

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -29,8 +29,12 @@
                 {% navbar_element "Badges" "all_badges" %}
                 {% navbar_element "Airports" "all_airports" %}
                 <li class="divider"></li>
+                {% if perms.workshops.add_person %}
                 {% navbar_element "Bulk add persons" "person_bulk_add" %}
+                {% endif %}
+                {% if perms.workshops.add_person and perms.workshops.delete_person %}
                 {% navbar_element "Merge persons" "person_merge" %}
+                {% endif %}
                 {% navbar_element "Find instructors" "instructors" %}
                 {% navbar_element "Debrief" "debrief" %}
                 <li class="divider"></li>
@@ -64,17 +68,29 @@
           </form>
 
           <ul class="nav navbar-nav navbar-right">
+            {% if perms.workshops.add_event or perms.workshops.add_host or perms.workshops.add_person or perms.workshops.add_airport %}
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
+                {% if perms.workshops.add_event %}
                 {% navbar_element "New event" "event_add" %}
+                {% endif %}
+                {% if perms.workshops.add_host %}
                 {% navbar_element "New host" "host_add" %}
+                {% endif %}
+                {% if perms.workshops.add_person %}
                 {% navbar_element "New person" "person_add" %}
+                {% endif %}
+                {% if perms.workshops.add_airport %}
                 {% navbar_element "New airport" "airport_add" %}
+                {% endif %}
                 <li class="divider"></li>
+                {% if perms.workshops.add_person %}
                 {% navbar_element "Bulk add people" "person_bulk_add" %}
+                {% endif %}
               </ul>
             </li>
+            {% endif %}
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Hi, {{ user.get_short_name }} <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -29,12 +29,8 @@
                 {% navbar_element "Badges" "all_badges" %}
                 {% navbar_element "Airports" "all_airports" %}
                 <li class="divider"></li>
-                {% if perms.workshops.add_person %}
-                {% navbar_element "Bulk add persons" "person_bulk_add" %}
-                {% endif %}
-                {% if perms.workshops.add_person and perms.workshops.delete_person %}
-                {% navbar_element "Merge persons" "person_merge" %}
-                {% endif %}
+                {% navbar_element_permed "Bulk add persons" "person_bulk_add" "workshops.add_person" %}
+                {% navbar_element_permed "Merge persons" "person_merge" "workshops.delete_person" %}
                 {% navbar_element "Find instructors" "instructors" %}
                 {% navbar_element "Debrief" "debrief" %}
                 <li class="divider"></li>
@@ -68,29 +64,17 @@
           </form>
 
           <ul class="nav navbar-nav navbar-right">
-            {% if perms.workshops.add_event or perms.workshops.add_host or perms.workshops.add_person or perms.workshops.add_airport %}
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                {% if perms.workshops.add_event %}
-                {% navbar_element "New event" "event_add" %}
-                {% endif %}
-                {% if perms.workshops.add_host %}
-                {% navbar_element "New host" "host_add" %}
-                {% endif %}
-                {% if perms.workshops.add_person %}
-                {% navbar_element "New person" "person_add" %}
-                {% endif %}
-                {% if perms.workshops.add_airport %}
-                {% navbar_element "New airport" "airport_add" %}
-                {% endif %}
+                {% navbar_element_permed "New event" "event_add" "workshops.add_event" %}
+                {% navbar_element_permed "New host" "host_add" "workshops.add_host" %}
+                {% navbar_element_permed "New person" "person_add" "workshops.add_person" %}
+                {% navbar_element_permed "New airport" "airport_add" "workshops.add_airport" %}
                 <li class="divider"></li>
-                {% if perms.workshops.add_person %}
-                {% navbar_element "Bulk add people" "person_bulk_add" %}
-                {% endif %}
+                {% navbar_element_permed "Bulk add people" "person_bulk_add" "workshops.add_person" %}
               </ul>
             </li>
-            {% endif %}
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Hi, {{ user.get_short_name }} <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">

--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -13,9 +13,13 @@
 <div class="clearfix">
   {% if perms.workshops.change_airport %}
   <p class="edit-object pull-left"><a href="{% url 'airport_edit' airport.iata %}" class=" btn btn-primary">Edit</a></p>
+  {% else %}
+  <p class="edit-object pull-left"><a href="{% url 'airport_edit' airport.iata %}" class=" btn btn-primary disabled">Edit</a></p>
   {% endif %}
   {% if perms.workshops.delete_airport %}
   <p class="delete-object pull-right"><a href="{% url 'airport_delete' airport.iata %}" onclick='return confirm("Are you sure you wish to remove \"{{ airport }}\"?")' class="btn btn-danger">Delete airport</a></p>
+  {% else %}
+  <p class="delete-object pull-right"><a href="{% url 'airport_delete' airport.iata %}" class="btn btn-danger disabled">Delete airport</a></p>
   {% endif %}
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -11,7 +11,11 @@
 </table>
 
 <div class="clearfix">
+  {% if perms.workshops.change_airport %}
   <p class="edit-object pull-left"><a href="{% url 'airport_edit' airport.iata %}" class=" btn btn-primary">Edit</a></p>
+  {% endif %}
+  {% if perms.workshops.delete_airport %}
   <p class="delete-object pull-right"><a href="{% url 'airport_delete' airport.iata %}" onclick='return confirm("Are you sure you wish to remove \"{{ airport }}\"?")' class="btn btn-danger">Delete airport</a></p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -11,6 +11,8 @@
 {% block content-fluid %}
     {% if perms.workshops.add_airport %}
     <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
+    {% else %}
+    <p><a href="{% url 'airport_add' %}" class="btn btn-success disabled">New airport</a></p>
     {% endif %}
 {% if all_airports %}
     <table class="table table-striped">
@@ -40,6 +42,8 @@
     {% pagination all_airports %}
     {% if perms.workshops.add_airport %}
     <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
+    {% else %}
+    <p><a href="{% url 'airport_add' %}" class="btn btn-success disabled">New airport</a></p>
     {% endif %}
 {% else %}
     <p>No airports.</p>

--- a/workshops/templates/workshops/all_airports.html
+++ b/workshops/templates/workshops/all_airports.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content-fluid %}
+    {% if perms.workshops.add_airport %}
     <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
+    {% endif %}
 {% if all_airports %}
     <table class="table table-striped">
         <tr>
@@ -28,13 +30,17 @@
             <td>
                 <a href="{% url 'airport_details' airport.iata %}" title="View {{ airport }}"><span class="glyphicon glyphicon-info-sign"></span></a>
                 &nbsp;
+                {% if perms.workshops.change_airport %}
                 <a href="{% url 'airport_edit' airport.iata %}" title="Edit {{ airport }}"><span class="glyphicon glyphicon-pencil"></span></a>
+                {% endif %}
             </td>
         </tr>
     {% endfor %}
     </table>
     {% pagination all_airports %}
+    {% if perms.workshops.add_airport %}
     <p><a href="{% url 'airport_add' %}" class="btn btn-success">New airport</a></p>
+    {% endif %}
 {% else %}
     <p>No airports.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content-fluid %}
+  {% if perms.workshops.add_event %}
     <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
+  {% endif %}
 {% if all_events %}
     <table class="table table-striped">
       <tr>
@@ -56,13 +58,17 @@
         <td>
           <a href="{% url 'event_details' event.get_ident %}" title="View {{ event.get_ident }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;
+          {% if perms.workshops.edit_event %}
           <a href="{% url 'event_edit' event.get_ident %}" title="Edit {{ event.get_ident }}"><span class="glyphicon glyphicon-pencil"></span></a>
+          {% endif %}
         </td>
       </tr>
     {% endfor %}
     </table>
     {% pagination all_events %}
+    {% if perms.workshops.add_event %}
     <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
+    {% endif %}
 {% else %}
     <p>No events.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -11,6 +11,8 @@
 {% block content-fluid %}
   {% if perms.workshops.add_event %}
     <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
+  {% else %}
+    <p><a href="{% url 'event_add' %}" class="btn btn-success disabled">New event</a></p>
   {% endif %}
 {% if all_events %}
     <table class="table table-striped">
@@ -68,6 +70,8 @@
     {% pagination all_events %}
     {% if perms.workshops.add_event %}
     <p><a href="{% url 'event_add' %}" class="btn btn-success">New event</a></p>
+    {% else %}
+    <p><a href="{% url 'event_add' %}" class="btn btn-success disabled">New event</a></p>
     {% endif %}
 {% else %}
     <p>No events.</p>

--- a/workshops/templates/workshops/all_hosts.html
+++ b/workshops/templates/workshops/all_hosts.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content-fluid %}
+    {% if perms.workshops.add_host %}
     <p><a href="{% url 'host_add' %}" class="btn btn-success">New host</a></p>
+    {% endif %}
 {% if all_hosts %}
     <table class="table table-striped">
         <tr>
@@ -26,13 +28,17 @@
             <td>
                 <a href="{% url 'host_details' host.domain %}" title="View {{ host.fullname }}"><span class="glyphicon glyphicon-info-sign"></span></a>
                 &nbsp;
+                {% if perms.workshops.change_host %}
                 <a href="{% url 'host_edit' host.domain %}" title="Edit {{ host.fullname }}"><span class="glyphicon glyphicon-pencil"></span></a>
+                {% endif %}
             </td>
         </tr>
     {% endfor %}
     </table>
     {% pagination all_hosts %}
+    {% if perms.workshops.add_host %}
     <p><a href="{% url 'host_add' %}" class="btn btn-success">New host</a></p>
+    {% endif %}
 {% else %}
     <p>No hosts.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_hosts.html
+++ b/workshops/templates/workshops/all_hosts.html
@@ -11,6 +11,8 @@
 {% block content-fluid %}
     {% if perms.workshops.add_host %}
     <p><a href="{% url 'host_add' %}" class="btn btn-success">New host</a></p>
+    {% else %}
+    <p><a href="{% url 'host_add' %}" class="btn btn-success disabled">New host</a></p>
     {% endif %}
 {% if all_hosts %}
     <table class="table table-striped">
@@ -38,6 +40,8 @@
     {% pagination all_hosts %}
     {% if perms.workshops.add_host %}
     <p><a href="{% url 'host_add' %}" class="btn btn-success">New host</a></p>
+    {% else %}
+    <p><a href="{% url 'host_add' %}" class="btn btn-success disabled">New host</a></p>
     {% endif %}
 {% else %}
     <p>No hosts.</p>

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -11,6 +11,8 @@
 {% block content-fluid %}
   {% if perms.workshops.add_person %}
     <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a></p>
+    {% else %}
+    <p><a href="{% url 'person_add' %}" class="btn btn-success disabled">New person</a></p>
   {% endif %}
 {% if all_persons %}
     <table class="table table-striped">
@@ -38,6 +40,8 @@
     {% pagination all_persons %}
     {% if perms.workshops.add_person %}
     <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a></p>
+    {% else %}
+    <p><a href="{% url 'person_add' %}" class="btn btn-success disabled">New person</a></p>
     {% endif %}
 {% else %}
     <p>No persons.</p>

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content-fluid %}
+  {% if perms.workshops.add_person %}
     <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a></p>
+  {% endif %}
 {% if all_persons %}
     <table class="table table-striped">
       <tr>
@@ -26,13 +28,17 @@
         <td>
           <a href="{% url 'person_details' person.pk %}" title="View {{ person.get_full_name }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;
+          {% if perms.workshops.change_person %}
           <a href="{% url 'person_edit' person.pk %}" title="Edit {{ person.get_full_name }}"><span class="glyphicon glyphicon-pencil"></span></a>
+          {% endif %}
         </td>
       </tr>
     {% endfor %}
     </table>
     {% pagination all_persons %}
+    {% if perms.workshops.add_person %}
     <p><a href="{% url 'person_add' %}" class="btn btn-success">New person</a></p>
+    {% endif %}
 {% else %}
     <p>No persons.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content-fluid %}
+    {% if perms.workshops.add_task %}
     <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
+    {% endif %}
 {% if all_tasks %}
     <table class="table table-striped">
         <tr>
@@ -26,13 +28,17 @@
             <td>
                 <a href="{% url 'task_details' task.id %}" title="View {{ task }}"><span class="glyphicon glyphicon-info-sign"></span></a>
                 &nbsp;
+                {% if perms.workshops.change_task %}
                 <a href="{% url 'task_edit' task.id %}" title="Edit {{ task }}"><span class="glyphicon glyphicon-pencil"></span></a>
+                {% endif %}
             </td>
         </tr>
     {% endfor %}
     </table>
     {% pagination all_tasks %}
+    {% if perms.workshops.add_task %}
     <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
+    {% endif %}
 {% else %}
     <p>No tasks.</p>
 {% endif %}

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -11,6 +11,8 @@
 {% block content-fluid %}
     {% if perms.workshops.add_task %}
     <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
+    {% else %}
+    <p><a href="{% url 'task_add' %}" class="btn btn-success disabled">New task</a></p>
     {% endif %}
 {% if all_tasks %}
     <table class="table table-striped">
@@ -38,6 +40,8 @@
     {% pagination all_tasks %}
     {% if perms.workshops.add_task %}
     <p><a href="{% url 'task_add' %}" class="btn btn-success">New task</a></p>
+    {% else %}
+    <p><a href="{% url 'task_add' %}" class="btn btn-success disabled">New task</a></p>
     {% endif %}
 {% else %}
     <p>No tasks.</p>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -3,7 +3,9 @@
 {% load links %}
 
 {% block content %}
-<p class="edit-object"><a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a></p>
+<p class="edit-object">
+  {% if perms.workshops.change_event %}<a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>{% endif %}
+</p>
 <table class="table table-striped">
   <tr><td>slug:</td><td colspan="2">{{ event.slug|default:"—" }}</td></tr>
   <tr><td>start date:</td><td colspan="2">{{ event.start|default:"—" }}</td></tr>
@@ -69,8 +71,12 @@
 <p>No notes.</p>
 {% endif %}
 <div class="clearfix">
-  <p class="edit-object pull-left"><a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a></p>
-  <p class="delete-object pull-right"><a href="{% url 'event_delete' event.get_ident %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")' class="btn btn-danger">Delete event</a></p>
+  <p class="edit-object pull-left">
+    {% if perms.workshops.change_event %}<a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>{% endif %}
+  </p>
+  <p class="delete-object pull-right">
+    {% if perms.workshops.change_event %}<a href="{% url 'event_delete' event.get_ident %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")' class="btn btn-danger">Delete event</a>{% endif %}
+  </p>
 </div>
 
 {% endblock %}

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -4,7 +4,11 @@
 
 {% block content %}
 <p class="edit-object">
-  {% if perms.workshops.change_event %}<a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>{% endif %}
+  {% if perms.workshops.change_event %}
+  <a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>
+  {% else %}
+  <a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary disabled">Edit</a>
+  {% endif %}
 </p>
 <table class="table table-striped">
   <tr><td>slug:</td><td colspan="2">{{ event.slug|default:"—" }}</td></tr>
@@ -72,10 +76,18 @@
 {% endif %}
 <div class="clearfix">
   <p class="edit-object pull-left">
-    {% if perms.workshops.change_event %}<a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>{% endif %}
+    {% if perms.workshops.change_event %}
+    <a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary">Edit</a>
+    {% else %}
+    <a href="{% url 'event_edit' event.get_ident %}" class="btn btn-primary disabled">Edit</a>
+    {% endif %}
   </p>
   <p class="delete-object pull-right">
-    {% if perms.workshops.change_event %}<a href="{% url 'event_delete' event.get_ident %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")' class="btn btn-danger">Delete event</a>{% endif %}
+    {% if perms.workshops.change_event %}
+    <a href="{% url 'event_delete' event.get_ident %}" onclick='return confirm("Are you sure you wish to remove \"{{ event }}\"?")' class="btn btn-danger">Delete event</a>
+    {% else %}
+    <a href="{% url 'event_delete' event.get_ident %}" class="btn btn-danger disabled">Delete event</a>
+    {% endif %}
   </p>
 </div>
 

--- a/workshops/templates/workshops/host.html
+++ b/workshops/templates/workshops/host.html
@@ -2,7 +2,9 @@
 
 {% block content %}
 
-<p class="edit-object"><a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a></p>
+<p class="edit-object">
+  {% if perms.workshops.change_host %}<a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>{% endif %}
+</p>
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ host.fullname }}</td></tr>
   <tr><td>domain:</td><td><a href="http://{{ host.domain }}">{{ host.domain }}</a></td></tr>
@@ -42,7 +44,11 @@
 {% endif %}
 
 <div class="clearfix">
-  <p class="edit-object pull-left"><a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a></p>
-  <p class="delete-object pull-right"><a href="{% url 'host_delete' host.domain %}" onclick='return confirm("Are you sure you wish to remove \"{{ host }}\"?")' class="btn btn-danger">Delete host</a></p>
+  <p class="edit-object pull-left">
+    {% if perms.workshops.change_host %}<a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>{% endif %}
+  </p>
+  <p class="delete-object pull-right">
+    {% if perms.workshops.delete_host %}<a href="{% url 'host_delete' host.domain %}" onclick='return confirm("Are you sure you wish to remove \"{{ host }}\"?")' class="btn btn-danger">Delete host</a>{% endif %}
+  </p>
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/host.html
+++ b/workshops/templates/workshops/host.html
@@ -3,7 +3,11 @@
 {% block content %}
 
 <p class="edit-object">
-  {% if perms.workshops.change_host %}<a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>{% endif %}
+  {% if perms.workshops.change_host %}
+  <a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>
+  {% else %}
+  <a href="{% url 'host_edit' host.domain %}" class="btn btn-primary disabled">Edit</a>
+  {% endif %}
 </p>
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ host.fullname }}</td></tr>
@@ -45,10 +49,18 @@
 
 <div class="clearfix">
   <p class="edit-object pull-left">
-    {% if perms.workshops.change_host %}<a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>{% endif %}
+    {% if perms.workshops.change_host %}
+    <a href="{% url 'host_edit' host.domain %}" class="btn btn-primary">Edit</a>
+    {% else %}
+    <a href="{% url 'host_edit' host.domain %}" class="btn btn-primary disabled">Edit</a>
+    {% endif %}
   </p>
   <p class="delete-object pull-right">
-    {% if perms.workshops.delete_host %}<a href="{% url 'host_delete' host.domain %}" onclick='return confirm("Are you sure you wish to remove \"{{ host }}\"?")' class="btn btn-danger">Delete host</a>{% endif %}
+    {% if perms.workshops.delete_host %}
+    <a href="{% url 'host_delete' host.domain %}" onclick='return confirm("Are you sure you wish to remove \"{{ host }}\"?")' class="btn btn-danger">Delete host</a>
+    {% else %}
+    <a href="{% url 'host_delete' host.domain %}" class="btn btn-danger disabled">Delete host</a>
+    {% endif %}
   </p>
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -3,12 +3,14 @@
 {% block content %}
 <div class="edit-object">
   {% if perms.workshops.change_person %}<a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>{% endif %}
-  {% if perms.workshops.change_person %}
   <div class="btn-group pull-right" role="group">
+    {% if perms.workshops.change_person %}
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
+    {% endif %}
+    {% if perms.workshops.change_person or person == request.user %}
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
+    {% endif %}
   </div>
-  {% endif %}
 </div>
 <table class="table table-striped">
   <tr><td>username:</td><td id="username">{{ person.username|default:"—" }}</td></tr>
@@ -91,6 +93,8 @@
   <div class="btn-group pull-right" role="group">
     {% if perms.workshops.change_person %}
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
+    {% endif %}
+    {% if perms.workshops.change_person or person == request.user %}
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
     {% endif %}
     {% if perms.workshops.delete_person %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -2,11 +2,13 @@
 
 {% block content %}
 <div class="edit-object">
-  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>
+  {% if perms.workshops.change_person %}<a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>{% endif %}
+  {% if perms.workshops.change_person %}
   <div class="btn-group pull-right" role="group">
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
   </div>
+  {% endif %}
 </div>
 <table class="table table-striped">
   <tr><td>username:</td><td id="username">{{ person.username|default:"—" }}</td></tr>
@@ -85,11 +87,15 @@
 </div>
 
 <div class="edit-object">
-  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>
+  {% if perms.workshops.change_person %}<a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>{% endif %}
   <div class="btn-group pull-right" role="group">
+    {% if perms.workshops.change_person %}
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
+    {% endif %}
+    {% if perms.workshops.delete_person %}
     <a href="{% url 'person_delete' person.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ person }}\"?")' class="btn btn-danger">Delete person</a>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -2,13 +2,21 @@
 
 {% block content %}
 <div class="edit-object">
-  {% if perms.workshops.change_person %}<a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>{% endif %}
+  {% if perms.workshops.change_person %}
+  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>
+  {% else %}
+  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary disabled">Edit</a>
+  {% endif %}
   <div class="btn-group pull-right" role="group">
     {% if perms.workshops.change_person %}
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
+    {% else %}
+    <a href="{% url 'person_permissions' person.id %}" class="btn btn-default disabled">Change permissions</a>
     {% endif %}
     {% if perms.workshops.change_person or person == request.user %}
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
+    {% else %}
+    <a href="{% url 'person_password' person.id %}" class="btn btn-default disabled">Change password</a>
     {% endif %}
   </div>
 </div>
@@ -89,16 +97,26 @@
 </div>
 
 <div class="edit-object">
-  {% if perms.workshops.change_person %}<a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>{% endif %}
+  {% if perms.workshops.change_person %}
+  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary">Edit</a>
+  {% else %}
+  <a href="{% url 'person_edit' person.id %}" class="btn btn-primary disabled">Edit</a>
+  {% endif %}
   <div class="btn-group pull-right" role="group">
     {% if perms.workshops.change_person %}
     <a href="{% url 'person_permissions' person.id %}" class="btn btn-default">Change permissions</a>
+    {% else %}
+    <a href="{% url 'person_permissions' person.id %}" class="btn btn-default disabled">Change permissions</a>
     {% endif %}
     {% if perms.workshops.change_person or person == request.user %}
     <a href="{% url 'person_password' person.id %}" class="btn btn-default">Change password</a>
+    {% else %}
+    <a href="{% url 'person_password' person.id %}" class="btn btn-default disabled">Change password</a>
     {% endif %}
     {% if perms.workshops.delete_person %}
     <a href="{% url 'person_delete' person.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ person }}\"?")' class="btn btn-danger">Delete person</a>
+    {% else %}
+    <a href="{% url 'person_delete' person.id %}" class="btn btn-danger disabled">Delete person</a>
     {% endif %}
   </div>
 </div>

--- a/workshops/templates/workshops/task.html
+++ b/workshops/templates/workshops/task.html
@@ -9,7 +9,11 @@
 </table>
 
 <div class="clearfix">
+  {% if perms.workshops.change_task %}
   <p class="edit-object pull-left"><a href="{% url 'task_edit' task.id %}" class="btn btn-primary">Edit</a></p>
+  {% endif %}
+  {% if perms.workshops.delete_task %}
   <p class="delete-object pull-right"><a href="{% url 'task_delete' task.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ task }}\"?")' class="btn btn-danger">Delete task</a></p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/workshops/templates/workshops/task.html
+++ b/workshops/templates/workshops/task.html
@@ -11,9 +11,13 @@
 <div class="clearfix">
   {% if perms.workshops.change_task %}
   <p class="edit-object pull-left"><a href="{% url 'task_edit' task.id %}" class="btn btn-primary">Edit</a></p>
+  {% else %}
+  <p class="edit-object pull-left"><a href="{% url 'task_edit' task.id %}" class="btn btn-primary disabled">Edit</a></p>
   {% endif %}
   {% if perms.workshops.delete_task %}
   <p class="delete-object pull-right"><a href="{% url 'task_delete' task.id %}" onclick='return confirm("Are you sure you wish to remove \"{{ task }}\"?")' class="btn btn-danger">Delete task</a></p>
+  {% else %}
+  <p class="delete-object pull-right"><a href="{% url 'task_delete' task.id %}" class="btn btn-danger disabled">Delete task</a></p>
   {% endif %}
 </div>
 {% endblock %}

--- a/workshops/templatetags/navigation.py
+++ b/workshops/templatetags/navigation.py
@@ -4,7 +4,15 @@ from django.core.urlresolvers import reverse
 register = template.Library()
 
 
-def make_element(title, url, active=False, disabled=False):
+def navbar_template(title, url, active=False, disabled=False):
+    """
+    Compose an HTML anchor <a href='' /> inside a list item <li>.
+
+    List item can be added one or more class attributes:
+    * active: to highlight currently visited tab
+    * disabled: to disable access, for example for users without specific
+      permissions.
+    """
     screen_reader = ''
     classes = []
 
@@ -35,7 +43,7 @@ def navbar_element(context, title, url_name):
     """
     url = reverse(url_name)
     active = context['request'].path == url
-    return make_element(title, url, active=active)
+    return navbar_template(title, url, active=active)
 
 
 @register.simple_tag(takes_context=True)
@@ -49,16 +57,15 @@ def navbar_element_permed(context, title, url_name, perms):
     """
     url = reverse(url_name)
     active = context['request'].path == url
-    disabled = True
 
     # check permissions
     perms_ctx = context['perms']
     perms = perms.split(',')
+    # True for every perm (from perms_ctx) that's granted to the user
     perms = map(lambda x: x in perms_ctx, perms)
-    if all(perms):
-        disabled = False
+    disabled = not all(perms)  # or: enabled = all(perms)
 
-    return make_element(title, url, active=active, disabled=disabled)
+    return navbar_template(title, url, active=active, disabled=disabled)
 
 
 @register.simple_tag(takes_context=True)
@@ -68,4 +75,4 @@ def navbar_element_url(context, title, url):
     accessibility elements.  This tag takes a pre-made URL as an argument.
     """
     active = context['request'].path == url
-    return make_element(title, url, active=active)
+    return navbar_template(title, url, active=active)

--- a/workshops/templatetags/navigation.py
+++ b/workshops/templatetags/navigation.py
@@ -4,6 +4,28 @@ from django.core.urlresolvers import reverse
 register = template.Library()
 
 
+def make_element(title, url, active=False, disabled=False):
+    screen_reader = ''
+    classes = []
+
+    if disabled:
+        classes.append('disabled')
+
+    if active:
+        classes.append('active')
+        screen_reader = '<span class="sr-only">(active)</span>'
+
+    if classes:
+        classes = ' '.join(classes)
+        template = ('<li class="{classes}"><a href="{url}">{title} '
+                    '{screen_reader}</a></li>')
+        return template.format(classes=classes, url=url, title=title,
+                               screen_reader=screen_reader)
+    else:
+        template = ('<li><a href="{url}">{title}</a></li>')
+        return template.format(url=url, title=title)
+
+
 @register.simple_tag(takes_context=True)
 def navbar_element(context, title, url_name):
     """
@@ -12,7 +34,31 @@ def navbar_element(context, title, url_name):
     is later reversed into proper URL.
     """
     url = reverse(url_name)
-    return navbar_element_url(context, title, url)
+    active = context['request'].path == url
+    return make_element(title, url, active=active)
+
+
+@register.simple_tag(takes_context=True)
+def navbar_element_permed(context, title, url_name, perms):
+    """
+    Works like `navbar_element`, but also disables if user doesn't have
+    permissions.
+
+    `perms` can be a comma-separated string of permissions or a single
+    permission.
+    """
+    url = reverse(url_name)
+    active = context['request'].path == url
+    disabled = True
+
+    # check permissions
+    perms_ctx = context['perms']
+    perms = perms.split(',')
+    perms = map(lambda x: x in perms_ctx, perms)
+    if all(perms):
+        disabled = False
+
+    return make_element(title, url, active=active, disabled=disabled)
 
 
 @register.simple_tag(takes_context=True)
@@ -21,14 +67,5 @@ def navbar_element_url(context, title, url):
     Insert Bootstrap's `<li><a>...</a></li>` with specific classes and
     accessibility elements.  This tag takes a pre-made URL as an argument.
     """
-    request = context['request']
-
-    active = ""
-    screen_reader = ""
-
-    if request.path == url:
-        active = 'class="active"'
-        screen_reader = '<span class="sr-only">(active)</span>'
-    tmplt = '<li {0}><a href="{1}">{2} {3}</a></li>'
-
-    return tmplt.format(active, url, title, screen_reader)
+    active = context['request'].path == url
+    return make_element(title, url, active=active)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -624,9 +624,14 @@ class PersonPermissions(LoginRequiredMixin, PermissionRequiredMixin,
 
 
 @login_required
-@permission_required('workshops.change_person', raise_exception=True)
 def person_password(request, person_id):
     user = get_object_or_404(Person, pk=person_id)
+
+    # Either the user requests change of their own password, or someone with
+    # permission for changing person does.
+    if not ((request.user == user) or
+            (request.user.has_perm('workshops.change_person'))):
+        raise PermissionDenied
 
     Form = PasswordChangeForm
     if request.user.is_superuser:


### PR DESCRIPTION
This PR implements #464.

Work so far:
* setting `@permission_required` decorator (in various forms) for all non-read-only views (for example `delete_host` or `person_add`)
* hiding elements of UI for users without specific permissions

So in order to give someone a read-only access to AMY, all we have to do is to enable them to log in.

If we want to have someone as an administrator (like Maneesha or Giacomo), we can either set them as superuser (that's how it's done now) or explicitly select all specific permissions for them.

Things to consider:
* adding permission groups 'administrator', 'steering committee'
* adding a 'can_login' field to `Person`

The permission groups may be just a more verbose way so say that someone belongs to administrators or steering committee.

The `person.can_login` would indicate that someone may be able to log into AMY – right now we kind of don't see that. It's related to `person.is_password_usable() == False`, but it's not possible to any admin to, for example, disable login for someone.

@gvwilson any thoughts?