### PR TITLE
Fix: export-* management commands use API

### DIFF
--- a/api/test/test_events.py
+++ b/api/test/test_events.py
@@ -17,6 +17,7 @@ from workshops.models import (
 
 class TestListingPastEvents(APITestCase):
     view = PublishedEvents
+    serializer_class = EventSerializer
     url = 'api:events-published'
     maxDiff = None
 
@@ -87,7 +88,7 @@ class TestListingPastEvents(APITestCase):
                 'slug': 'event2',
                 'start': self.event2.start,
                 'end': self.event2.end,
-                'humandate': EventSerializer.human_readable_date(
+                'humandate': self.serializer_class.human_readable_date(
                     self.event2.start, self.event2.end
                 ),
                 'latitude': 3,
@@ -114,9 +115,7 @@ class TestListingPastEvents(APITestCase):
         ]
 
     def test_serialization(self):
-        # test calling the view directly, with "fake" request object (None)
-        view = self.view()
-        response = view.get(None)
+        response = self.serializer_class(self.view().get_queryset(), many=True)
         self.assertEqual(response.data, self.expecting)
 
     def test_view(self):

--- a/api/test/test_export.py
+++ b/api/test/test_export.py
@@ -9,6 +9,10 @@ from api.views import (
     ExportBadgesView,
     ExportInstructorLocationsView,
 )
+from api.serializers import (
+    ExportBadgesSerializer,
+    ExportInstructorLocationsSerializer,
+)
 from workshops.models import (
     Badge,
     Award,
@@ -49,9 +53,9 @@ class TestExportingBadges(APITestCase):
         ]
 
     def test_serialization(self):
-        # test calling the view directly, with "fake" request object (None)
         view = ExportBadgesView()
-        response = view.get(None)
+        serializer = view.get_serializer_class()
+        response = serializer(view.get_queryset(), many=True)
         self.assertEqual(response.data, self.expecting)
 
     def test_view(self):
@@ -104,9 +108,9 @@ class TestExportingInstructors(APITestCase):
         ]
 
     def test_serialization(self):
-        # test calling the view directly, with "fake" request object (None)
         view = ExportInstructorLocationsView()
-        response = view.get(None)
+        serializer = view.get_serializer_class()
+        response = serializer(view.get_queryset(), many=True)
         self.assertEqual(response.data, self.expecting)
 
     def test_view(self):

--- a/workshops/management/commands/export_airports.py
+++ b/workshops/management/commands/export_airports.py
@@ -1,7 +1,6 @@
-import yaml
-
 from django.core.management.base import BaseCommand
-from api.views import ExportInstructorLocationsView
+from django.core.urlresolvers import reverse
+from rest_framework.test import APIClient
 
 
 class Command(BaseCommand):
@@ -9,6 +8,7 @@ class Command(BaseCommand):
     help = 'Display YAML for airports.'
 
     def handle(self, *args, **options):
-        view = ExportInstructorLocationsView()
-        response = view.get(None, format='yaml')
-        print(yaml.dump(response.data))
+        client = APIClient()
+        response = client.get(reverse('api:export-instructors'),
+                              {'format': 'yaml'})
+        print(response.content.decode('utf-8'))

--- a/workshops/management/commands/export_airports.py
+++ b/workshops/management/commands/export_airports.py
@@ -1,10 +1,14 @@
 import yaml
-from django.core.management.base import BaseCommand, CommandError
-from workshops.views import _export_instructors
+
+from django.core.management.base import BaseCommand
+from api.views import ExportInstructorLocationsView
+
 
 class Command(BaseCommand):
     args = 'no arguments'
     help = 'Display YAML for airports.'
 
     def handle(self, *args, **options):
-        print(yaml.dump(_export_instructors()).rstrip())
+        view = ExportInstructorLocationsView()
+        response = view.get(None, format='yaml')
+        print(yaml.dump(response.data))

--- a/workshops/management/commands/export_badges.py
+++ b/workshops/management/commands/export_badges.py
@@ -1,10 +1,14 @@
 import yaml
-from django.core.management.base import BaseCommand, CommandError
-from workshops.views import _export_badges
+
+from django.core.management.base import BaseCommand
+from api.views import ExportBadgesView
+
 
 class Command(BaseCommand):
     args = 'no arguments'
     help = 'Display YAML for badges.'
 
     def handle(self, *args, **options):
-        print(yaml.dump(_export_badges()).rstrip())
+        view = ExportBadgesView()
+        response = view.get(None, format='yaml')
+        print(yaml.dump(response.data))

--- a/workshops/management/commands/export_badges.py
+++ b/workshops/management/commands/export_badges.py
@@ -1,7 +1,6 @@
-import yaml
-
 from django.core.management.base import BaseCommand
-from api.views import ExportBadgesView
+from django.core.urlresolvers import reverse
+from rest_framework.test import APIClient
 
 
 class Command(BaseCommand):
@@ -9,6 +8,7 @@ class Command(BaseCommand):
     help = 'Display YAML for badges.'
 
     def handle(self, *args, **options):
-        view = ExportBadgesView()
-        response = view.get(None, format='yaml')
-        print(yaml.dump(response.data))
+        client = APIClient()
+        response = client.get(reverse('api:export-badges'),
+                              {'format': 'yaml'})
+        print(response.content.decode('utf-8'))


### PR DESCRIPTION
export-* commands used workshops.views views instead of calling
API endpoints.
This fix "simulates" the incoming request and then gets back all the
data from API, and serializes it in YAML.

This fixes #474, but the output format changes slightly (since the switch to API).