### PR TITLE
Enabling consistent command-line display of published workshops.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ invoicing :
 incomplete :
 	@${MANAGE} report_incomplete_instructors
 
+## published    : report all published events
+published :
+	@${MANAGE} report_published_events
+
 ## serve        : run a server
 serve : bower_components workshops/git_version.py
 	${MANAGE} runserver

--- a/api/views.py
+++ b/api/views.py
@@ -51,6 +51,4 @@ class PublishedEvents(ListAPIView):
     paginator = None  # disable pagination
 
     serializer_class = EventSerializer
-    queryset = Event.objects.exclude(
-        Q(start__isnull=True) | Q(url__isnull=True)
-    ).order_by('-start')
+    queryset = Event.objects.published_events()

--- a/workshops/management/commands/report_published_events.py
+++ b/workshops/management/commands/report_published_events.py
@@ -1,0 +1,17 @@
+import datetime
+from django.core.management.base import BaseCommand, CommandError
+from workshops.models import Event
+
+
+class Command(BaseCommand):
+    args = ''
+    help = 'List slugs and URLs of all published events.'
+
+    def handle(self, *args, **options):
+        if len(args) != 0:
+            raise CommandError('Usage: report_published_events')
+
+        events = Event.objects.published_events()
+
+        for e in events:
+            print(e.slug, e.url)

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -249,6 +249,17 @@ class EventQuerySet(models.query.QuerySet):
         return self.filter(future_without_url | unknown_start)\
                    .order_by('slug', 'id')
 
+    def published_events(self):
+        '''Return events that have a start date and a URL.
+
+        Events are ordered by slug and then by serial number.'''
+
+        queryset = self.exclude(
+            Q(start__isnull=True) | Q(url__isnull=True)
+            ).order_by('slug', 'id')
+
+        return queryset
+
     def uninvoiced_events(self):
         '''Return a queryset for events that have not yet been invoiced.
 
@@ -281,6 +292,9 @@ class EventManager(models.Manager):
 
     def unpublished_events(self):
         return self.get_queryset().unpublished_events()
+
+    def published_events(self):
+        return self.get_queryset().published_events()
 
     def uninvoiced_events(self):
         return self.get_queryset().uninvoiced_events()

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -252,11 +252,11 @@ class EventQuerySet(models.query.QuerySet):
     def published_events(self):
         '''Return events that have a start date and a URL.
 
-        Events are ordered by slug and then by serial number.'''
+        Events are ordered most recent first and then by serial number.'''
 
         queryset = self.exclude(
             Q(start__isnull=True) | Q(url__isnull=True)
-            ).order_by('slug', 'id')
+            ).order_by('-start', 'id')
 
         return queryset
 


### PR DESCRIPTION
1.  Add `published_events` to `Event`.
2.  Use that in the REST API.
3.  Use it in a management command.
4.  Add a target to `Makefile` to run that management command.

Together, these changes ensure that the API and the management command are always in sync reporting published events. This will help testing as we start building the main website directly from AMY.