### PR TITLE
Adding 'country' field to 'airport' record in API.

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -26,7 +26,7 @@ class ExportInstructorLocationsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Airport
-        fields = ('name', 'latitude', 'longitude', 'instructors')
+        fields = ('name', 'latitude', 'longitude', 'instructors', 'country')
 
 
 class EventSerializer(serializers.ModelSerializer):

--- a/api/test/test_export.py
+++ b/api/test/test_export.py
@@ -98,6 +98,7 @@ class TestExportingInstructors(APITestCase):
         self.expecting = [
             {
                 'name': 'Airport1',
+                'country': 'PL',
                 'latitude': 1.0,
                 'longitude': 2.0,
                 'instructors': [


### PR DESCRIPTION
This allow the main website to gather countries from this API call, so that we no longer have to manage the country flags manually.