### PR TITLE
Add: remove award functionality

### DIFF
--- a/workshops/templates/workshops/badge.html
+++ b/workshops/templates/workshops/badge.html
@@ -20,12 +20,16 @@
       <th>person</th>
       <th>awarded</th>
       <th>event</th>
+      <th></th>
     </tr>
     {% for award in awards %}
     <tr>
       <td><a href="{{ award.person.get_absolute_url }}">{{ award.person.get_full_name }}</a>{% if award.person.email and award.person.may_contact %} &lt;{{ award.person.email|urlize }}&gt;{% endif %}</td>
       <td>{{ award.awarded }}</td>
       <td>{% if award.event %}<a href="{% url 'event_details' award.event.get_ident %}">{{ award.event }}</a>{% else %}—{% endif %}</td>
+      <td>
+        <a onclick='return confirm("Are you sure you wish to drop award \"{{ award.badge.title }}\" from \"{{ award.person }}\"?")' href="{% url 'award_delete' award_id=award.pk %}" class='btn btn-danger'>Delete</a>
+      </td>
     </tr>
     {% endfor %}
   </table>

--- a/workshops/templates/workshops/person_edit_form.html
+++ b/workshops/templates/workshops/person_edit_form.html
@@ -25,6 +25,7 @@
           <th>badge</th>
           <th>awarded</th>
           <th>event</th>
+          <th>action</th>
         </tr>
       </thead>
       <tbody>
@@ -33,6 +34,9 @@
           <td><a href="{{ award.badge.get_absolute_url }}">{{ award.badge.title }}</a></td>
           <td>{{ award.awarded }}</td>
           <td>{% if award.event %}<a href="{{ award.event.get_absolute_url }}">{{ award.event }}</a>{% else %}—{% endif %}</td>
+          <td>
+            <a onclick='return confirm("Are you sure you wish to drop award \"{{ award.badge.title }}\" from \"{{ award.person }}\"?")' href="{% url 'award_delete' award_id=award.pk person_id=award.person.pk %}" class='btn btn-danger'>Delete</a>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/workshops/test/test_badge.py
+++ b/workshops/test/test_badge.py
@@ -49,3 +49,29 @@ class TestBadge(TestBase):
         self._check_status_code_and_parse(response, 200)
 
         assert self.instructor.award_set.count() == 4
+
+    def test_remove_award(self):
+        "Remove a badge from someone (ie. remove corresponding Award object)."
+        person = self.hermione
+        award = person.award_set.all()[0]
+        badge = award.badge
+        # test first URL
+        rv = self.client.get(
+            reverse('award_delete',
+                    kwargs=dict(award_id=award.pk, person_id=person.pk)),
+        )
+        assert rv.status_code == 302
+        assert award not in badge.award_set.all()  # award really removed
+        assert badge not in person.badges.all()  # badge not avail. via Awards
+
+        person = self.ron
+        award = person.award_set.all()[0]
+        badge = award.badge
+        # test second URL
+        rv = self.client.get(
+            reverse('award_delete',
+                    kwargs=dict(award_id=award.pk)),
+        )
+        assert rv.status_code == 302
+        assert award not in badge.award_set.all()  # award really removed
+        assert badge not in person.badges.all()  # badge not avail. via Awards

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -44,6 +44,9 @@ urlpatterns = [
     url(r'^event/(?P<event_ident>[\w-]+)/task/(?P<task_id>\d+)/delete$', views.task_delete, name='task_delete'),
     url(r'^tasks/add/$', views.TaskCreate.as_view(), name='task_add'),
 
+    url(r'^award/(?P<award_id>\d+)/delete$', views.award_delete, name='award_delete'),
+    url(r'^person/(?P<person_id>[\w\.-]+)/award/(?P<award_id>\d+)/delete$', views.award_delete, name='award_delete'),
+
     url(r'^badges/?$', views.all_badges, name='all_badges'),
     url(r'^badge/(?P<badge_name>[\w\.=-]+)/?$', views.badge_details, name='badge_details'),
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -971,6 +971,25 @@ class TaskUpdate(LoginRequiredMixin, PermissionRequiredMixin,
     pk_url_kwarg = 'task_id'
     template_name = 'workshops/generic_form.html'
 
+#------------------------------------------------------------
+
+
+@permission_required('workshops.delete_award', raise_exception=True)
+def award_delete(request, award_id, person_id=None):
+    """Delete an award. This is used on the person edit page."""
+    award = get_object_or_404(Award, pk=award_id)
+    badge_name = award.badge.name
+    award.delete()
+
+    messages.success(request, 'Award was deleted successfully.',
+                     extra_tags='awards')
+
+    if person_id:
+        # if a second form of URL, then return back to person edit page
+        return redirect(person_edit, person_id)
+
+    return redirect(reverse(badge_details, args=[badge_name]))
+
 
 #------------------------------------------------------------
 


### PR DESCRIPTION
This fixes #434.

It's now possible to remove Award from person's details page or from
badge's details page. Both removals should end up with correct
redirects.

Tests are included.