### PR TITLE
Add more options to Event.invoiced

### DIFF
--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -74,7 +74,7 @@ class EventFilter(django_filters.FilterSet):
             'tags',
             'host',
             'administrator',
-            'invoiced',
+            'invoice_status',
         ]
         order_by = ['-slug', 'slug', 'start', '-start', 'end', '-end']
 

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -259,7 +259,7 @@ class EventForm(forms.ModelForm):
         model = Event
         # reorder fields, don't display 'deleted' field
         fields = ('slug', 'start', 'end', 'host', 'administrator',
-                  'tags', 'url', 'reg_key', 'admin_fee', 'invoiced',
+                  'tags', 'url', 'reg_key', 'admin_fee', 'invoice_status',
                   'attendance', 'contact', 'notes',
                   'country', 'venue', 'address', 'latitude', 'longitude')
         # WARNING: don't change put any fields between 'country' and

--- a/workshops/management/commands/report_invoicing.py
+++ b/workshops/management/commands/report_invoicing.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
         records = [['event', 'fee', 'paid']]
         for e in events:
-            records.append([e.slug, e.admin_fee, e.invoiced])
+            records.append([e.slug, e.admin_fee, e.invoice_status])
 
         writer = csv.writer(sys.stdout)
         writer.writerows(records)

--- a/workshops/migrations/0040_invoice_status.py
+++ b/workshops/migrations/0040_invoice_status.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def migrate_invoiced(apps, schema_editor):
+    """Migrate `invoiced` bool field into `invoice_status` text field."""
+    Event = apps.get_model('workshops', 'Event')
+
+    # null → 'unknown'
+    Event.objects.filter(invoiced__isnull=True) \
+        .update(invoice_status='unknown')
+    # true → 'invoiced'
+    Event.objects.filter(invoiced=True) \
+        .update(invoice_status='invoiced')
+    # false → 'invoiced'
+    Event.objects.filter(invoiced=False) \
+        .update(invoice_status='not-invoiced')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0039_add_permission_groups'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='invoice_status',
+            field=models.CharField(verbose_name='Invoice status', max_length=40, default='unknown', blank=True, choices=[('unknown', 'Unknown'), ('invoiced', 'Invoiced'), ('not-invoiced', 'Not invoiced'), ('na-self-org', 'Not applicable because self-organized'), ('na-waiver', 'Not applicable because waiver granted'), ('na-other', 'Not applicable because other arrangements made')]),
+        ),
+        migrations.RunPython(migrate_invoiced),
+        migrations.RemoveField(
+            model_name='event',
+            name='invoiced',
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -267,7 +267,7 @@ class EventQuerySet(models.query.QuerySet):
         Events are sorted oldest first.'''
 
         return self.past_events().filter(admin_fee__gt=0)\
-                   .exclude(invoiced=True)\
+                   .exclude(invoice_status='invoiced')\
                    .order_by('start')
 
 class EventManager(models.Manager):
@@ -322,7 +322,20 @@ class Event(models.Model):
     reg_key    = models.CharField(max_length=STR_REG_KEY, null=True, blank=True, verbose_name="Eventbrite key")
     attendance = models.PositiveIntegerField(null=True, blank=True)
     admin_fee  = models.DecimalField(max_digits=6, decimal_places=2, null=True, blank=True, validators=[MinValueValidator(0)])
-    invoiced   = models.NullBooleanField(default=False, blank=True)
+    INVOICED_CHOICES = (
+        ('unknown', 'Unknown'),
+        ('invoiced', 'Invoiced'),
+        ('not-invoiced', 'Not invoiced'),
+        ('na-self-org', 'Not applicable because self-organized'),
+        ('na-waiver', 'Not applicable because waiver granted'),
+        ('na-other', 'Not applicable because other arrangements made'),
+    )
+    invoice_status = models.CharField(
+        max_length=STR_MED,
+        choices=INVOICED_CHOICES,
+        verbose_name='Invoice status',
+        default='unknown', blank=True,
+    )
     notes      = models.TextField(default="", blank=True)
     contact = models.CharField(max_length=255, default="", blank=True)
     country = CountryField(null=True, blank=True)

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -26,7 +26,7 @@
         <th>dates</th>
         <th>attendance</th>
         <th>admin fee</th>
-        <th>invoiced</th>
+        <th>invoice</th>
         <th class="additional-links"></th>
       </tr>
     {% for event in all_events %}
@@ -54,7 +54,7 @@
         <td>{{ event.start }} &ndash; {{ event.end }}</td>
         <td>{{ event.attendance|default_if_none:"—" }}</td>
         <td>{{ event.admin_fee|default_if_none:"—" }}</td>
-        <td>{{ event.invoiced|yesno:"yes,no,unknown" }}</td>
+        <td>{{ event.get_invoice_status_display }}</td>
         <td>
           <a href="{% url 'event_details' event.get_ident %}" title="View {{ event.get_ident }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -19,7 +19,7 @@
   <tr><td>Repository URL:</td><td colspan="2">{{ event.get_repository_url|default:"—"|urlize }} {% if event.get_repository_url %}<a href="{% url 'validate_event' event.get_ident %}" class="btn btn-primary btn-xs pull-right" id="validate_event">validate event</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_event_url" href="#" data-toggle="popover" data-trigger="focus" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>">Error</a>{% endif %}</td></tr>
   <tr><td>Eventbrite key:</td><td colspan="2">{% if event.reg_key %}<a href="https://www.eventbrite.com/myevent?eid={{ event.reg_key }}" title="Go to Eventbrite's page for this event">{{ event.reg_key }}</a>{% else %}—{% endif %}</td></tr>
   <tr><td>admin fee:</td><td colspan="2">{{ event.admin_fee|default_if_none:"—" }}</td></tr>
-  <tr><td>invoiced:</td><td colspan="2">{{ event.invoiced|yesno:"yes,no,unknown" }}</td></tr>
+  <tr><td>invoice:</td><td colspan="2">{{ event.get_invoice_status_display }}</td></tr>
   <tr><td>attendance:</td><td colspan="2">{{ event.attendance|default_if_none:"—" }}</td></tr>
   <tr><td>contact:</td><td colspan="2">{{ event.contact|default_if_none:"—" }}</td></tr>
   <tr><td rowspan="4">location details:</td><td>Country:</td><td>{{ event.country|default:"—" }}</td></tr>

--- a/workshops/templates/workshops/event_diff.html
+++ b/workshops/templates/workshops/event_diff.html
@@ -42,8 +42,8 @@
     <td>{% semantic_diff previous_version current_version 'admin_fee' %}</td>
   </tr>
   <tr>
-    <th>invoiced:</th>
-    <td>{% semantic_diff previous_version current_version 'invoiced' %}</td>
+    <th>invoice:</th>
+    <td>{% semantic_diff previous_version current_version 'invoice_status' %}</td>
   </tr>
   <tr>
     <th>attendance:</th>

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -198,12 +198,12 @@ class TestBase(TestCase):
                                      slug=slug,
                                      host=test_host,
                                      admin_fee=100,
-                                     invoiced=False,
+                                     invoice_status='not-invoiced',
                                      url=url)
 
         # Create one new event for each day from 10 days ago to
         # 3 days ago, half invoiced
-        invoiced = True
+        invoice = itertools.cycle(['invoiced', 'not-invoiced'])
         for t in range(3, 11):
             event_start = today + datetime.timedelta(days=-t)
             date_string = event_start.strftime('%Y-%m-%d')
@@ -211,8 +211,7 @@ class TestBase(TestCase):
                                  slug='{0}-past'.format(date_string),
                                  host=test_host,
                                  admin_fee=100,
-                                 invoiced=invoiced)
-            invoiced = not invoiced
+                                 invoice_status=next(invoice))
 
         # Create an event that started yesterday and ends tomorrow
         # with no fee, and without specifying whether they've been
@@ -249,7 +248,8 @@ class TestBase(TestCase):
         self.num_uninvoiced_events = 0
         self.num_upcoming = 0
         for e in Event.objects.all():
-            if (e.admin_fee > 0) and (not e.invoiced) and (e.start < today):
+            if (e.admin_fee > 0) and (e.invoice_status == 'not-invoiced') \
+                    and (e.start < today):
                 self.num_uninvoiced_events += 1
             if e.url and (e.start > today):
                 self.num_upcoming += 1


### PR DESCRIPTION
Actually the Event.invoiced field was migrated to text field and renamed
`invoice_status` since it doesn't answer the question
"Was the workshop's host invoiced?", but rather shows the status of
workshop's invoicing.

This commit provides:
* all necessary migrations
* display changes (`invoiced|yesno` -> `get_invoice_status_display`
  mostly)
* test updates

This fixes #469.