### PR TITLE
Add back the EU country, since it's used in some hosts

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -206,6 +206,7 @@ LOGIN_URL = '/account/login/'
 
 # explicitely add European Union as a country
 COUNTRIES_OVERRIDE = {
+    'EU': _('European Union'),
     'GB': _('United Kingdom'),
     'US': _('United States'),
     'W3': _('Online'),


### PR DESCRIPTION
This commits adds back the "fake" EU country. Apparently Europe's flag is already present in the django-countries, it's just the country that's not available.