### PR TITLE
Fix: ignore "empty" lines in CSVs bulk-uploaded to AMY

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -56,6 +56,15 @@ john,m,doe,john@doe.com"""
         person_tasks, empty_fields = self.compute_from_string(bad_csv)
         self.assertTrue('email' in empty_fields)
 
+    def test_csv_with_empty_lines(self):
+        csv = """personal,middle,family,emailaddress
+john,m,doe,john@doe.com
+,,,"""
+        person_tasks, empty_fields = self.compute_from_string(csv)
+        self.assertEqual(len(person_tasks), 1)
+        person = person_tasks[0]
+        self.assertEqual(person['personal'], 'john')
+
     def test_empty_field(self):
         ''' Ensure we don't mis-order fields given blank data '''
         csv = """personal,middle,family,email

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -71,6 +71,10 @@ def upload_person_task_csv(stream):
     empty_fields = set()
 
     for row in reader:
+        # skip empty lines in the CSV
+        if not any(row.values()):
+            continue
+
         entry = {}
         for col in Person.PERSON_UPLOAD_FIELDS:
             try:


### PR DESCRIPTION
I put "empty" in quotes because these lines may just as well be composed
of commas (something like ",,,,,"), but after parsing they would make
dicts with proper keys but no values.

This fixes #512.