### PR TITLE
Switch for new/closed requests

### DIFF
--- a/workshops/templates/workshops/all_eventrequests.html
+++ b/workshops/templates/workshops/all_eventrequests.html
@@ -1,6 +1,10 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
+  <div class="btn-group" role="group" aria-label="Type of requests">
+    <a href="{% url 'all_eventrequests' %}" class="btn btn-default{% if active_requests %} active{% endif %}">New</a>
+    <a href="{% url 'all_closed_eventrequests' %}" class="btn btn-default{% if not active_requests %} active{% endif %}">Closed</a>
+  </div>
   {% if requests %}
   <table class="table table-striped">
     <thead>
@@ -33,6 +37,6 @@
     </tbody>
   </table>
   {% else %}
-  <p>No new workshop requests.</p>
+  <p>No workshop requests matching the filter.</p>
   {% endif %}
 {% endblock %}

--- a/workshops/templates/workshops/all_profileupdaterequests.html
+++ b/workshops/templates/workshops/all_profileupdaterequests.html
@@ -1,6 +1,10 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
+  <div class="btn-group" role="group" aria-label="Type of requests">
+    <a href="{% url 'all_profileupdaterequests' %}" class="btn btn-default{% if active_requests %} active{% endif %}">New</a>
+    <a href="{% url 'all_closed_profileupdaterequests' %}" class="btn btn-default{% if not active_requests %} active{% endif %}">Closed</a>
+  </div>
   {% if requests %}
   <table class="table table-striped">
     <thead>
@@ -21,6 +25,6 @@
     </tbody>
   </table>
   {% else %}
-  <p>No new profile update requests.</p>
+  <p>No profile update requests matching the filter.</p>
   {% endif %}
 {% endblock %}

--- a/workshops/templates/workshops/eventrequest.html
+++ b/workshops/templates/workshops/eventrequest.html
@@ -1,8 +1,14 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
+{% if not object.active %}
+  <div class="alert alert-warning" role="alert">
+    <p><strong>Warning:</strong> This request was closed.</p>
+  </div>
+{% endif %}
 {% include "workshops/eventrequest_email_html.html" %}
 
+{% if object.active %}
 <div class="clearfix">
   <p class="edit-object pull-left">
     {% if perms.workshops.change_eventrequest and perms.workshops.add_event %}
@@ -19,4 +25,5 @@
     {% endif %}
   </p>
 </div>
+{% endif %}
 {% endblock %}

--- a/workshops/templates/workshops/profileupdaterequest.html
+++ b/workshops/templates/workshops/profileupdaterequest.html
@@ -4,22 +4,28 @@
 {% load links %}
 
 {% block content %}
-<div class="alert alert-info" role="alert">
-  <p><strong>Instruction:</strong> Verify with the person from the
-  database that they updated their profile with data from the 'Update
-  request' column.</p>
-</div>
-{% if not old %}
-<div class="alert alert-danger" role="alert">
-  <p><strong>Error:</strong> No-one matches this email ({{ new.email }}) or name ({{ new.personal }} {{ new.family }}). Look up possible match yourself using search option and then point to that person below.</p>
-</div>
-{% crispy person_form form_helper %}
-{% endif %}
-{% if person_selected %}
-<div class="alert alert-warning" role="alert">
-  <p><strong>Re-select:</strong> You can change your selection below.</p>
-</div>
-{% crispy person_form form_helper %}
+{% if new.active %}
+  <div class="alert alert-info" role="alert">
+    <p><strong>Instruction:</strong> Verify with the person from the
+    database that they updated their profile with data from the 'Update
+    request' column.</p>
+  </div>
+  {% if not old %}
+  <div class="alert alert-danger" role="alert">
+    <p><strong>Error:</strong> No-one matches this email ({{ new.email }}) or name ({{ new.personal }} {{ new.family }}). Look up possible match yourself using search option and then point to that person below.</p>
+  </div>
+  {% crispy person_form form_helper %}
+  {% endif %}
+  {% if person_selected %}
+  <div class="alert alert-warning" role="alert">
+    <p><strong>Re-select:</strong> You can change your selection below.</p>
+  </div>
+  {% crispy person_form form_helper %}
+  {% endif %}
+{% else %}
+  <div class="alert alert-warning" role="alert">
+    <p><strong>Warning:</strong> This request was closed.</p>
+  </div>
 {% endif %}
 <table class="table table-striped">
   <thead>
@@ -48,7 +54,7 @@
         {% else %}
         <td><a href="{% url 'airport_add' %}" title="Add airport {{ new.airport_iata }}">{{ new.airport_iata }}</a> <span class="label label-danger">Missing airport</span>  (<a href="https://www.world-airport-codes.com/search/?s={{ new.airport_iata }}" target="_blank">Lookup</a>)</td>
         {% endif %}
-        <td>{% if old %}<a href="{{ old.airport.get_absolute_url }}">{{ old.airport.iata }}</a>{% endif %}</td></tr>
+        <td>{% if old and old.airport %}<a href="{{ old.airport.get_absolute_url }}">{{ old.airport.iata }}</a>{% else %}—{% endif %}</td></tr>
     <tr><th>Has instructor badge:</th>
         <td>N/A</td>
         <td>{% if old %}{{ old.has_instructor_badge|yesno }}{% endif %}</td></tr>
@@ -115,6 +121,7 @@
   </tbody>
 </table>
 
+{% if new.active %}
 <div class="clearfix">
   <p class="edit-object pull-left">
     {% if old and airport and perms.workshops.change_profileupdaterequest and perms.workshops.change_person %}
@@ -131,4 +138,5 @@
     {% endif %}
   </p>
 </div>
+{% endif %}
 {% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     url(r'^revision/(?P<revision_id>[\d]+)/?$', views.object_changes, name='object_changes'),
 
     url(r'^requests/$', views.AllEventRequests.as_view(), name='all_eventrequests'),
+    url(r'^requests/closed/$', views.AllClosedEventRequests.as_view(), name='all_closed_eventrequests'),
     url(r'^request/(?P<request_id>\d+)/?$', views.EventRequestDetails.as_view(), name='eventrequest_details'),
     url(r'^request/(?P<request_id>\d+)/discard/?$', views.eventrequest_discard, name='eventrequest_discard'),
     url(r'^request/(?P<request_id>\d+)/accept/?$', views.eventrequest_accept, name='eventrequest_accept'),

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -75,6 +75,7 @@ urlpatterns = [
     url(r'^dc/request/$', views.DCEventRequest.as_view(), name='dc_workshop_request'),
 
     url(r'^profile_updates/$', views.AllProfileUpdateRequests.as_view(), name='all_profileupdaterequests'),
+    url(r'^profile_updates/closed/$', views.AllClosedProfileUpdateRequests.as_view(), name='all_closed_profileupdaterequests'),
     url(r'^profile_update/(?P<request_id>\d+)/?$', views.profileupdaterequest_details, name='profileupdaterequest_details'),
     url(r'^profile_update/(?P<request_id>\d+)/discard/?$', views.profileupdaterequest_discard, name='profileupdaterequest_discard'),
     url(r'^profile_update/(?P<request_id>\d+)/accept/(?P<person_id>[\w\.-]+)/?$', views.profileupdaterequest_accept, name='profileupdaterequest_accept'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1522,18 +1522,27 @@ class DCEventRequest(SWCEventRequest):
 
 
 class AllEventRequests(LoginRequiredMixin, ListView):
-    queryset = EventRequest.objects.filter(active=True).order_by('-created_at')
+    active_requests = True
     context_object_name = 'requests'
     template_name = 'workshops/all_eventrequests.html'
+
+    def get_queryset(self):
+        return EventRequest.objects.filter(active=self.active_requests) \
+                                   .order_by('-created_at')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = 'Workshop requests'
+        context['active_requests'] = self.active_requests
         return context
 
 
+class AllClosedEventRequests(AllEventRequests):
+    active_requests = False
+
+
 class EventRequestDetails(LoginRequiredMixin, DetailView):
-    queryset = EventRequest.objects.filter(active=True)
+    queryset = EventRequest.objects.all()
     context_object_name = 'object'
     template_name = 'workshops/eventrequest.html'
     pk_url_kwarg = 'request_id'

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1629,20 +1629,29 @@ def profileupdaterequest_create(request):
 
 
 class AllProfileUpdateRequests(LoginRequiredMixin, ListView):
-    queryset = ProfileUpdateRequest.objects.filter(active=True) \
-                .order_by('-created_at')
+    active_requests = True
     context_object_name = 'requests'
     template_name = 'workshops/all_profileupdaterequests.html'
+
+    def get_queryset(self):
+        return ProfileUpdateRequest.objects \
+                                   .filter(active=self.active_requests) \
+                                   .order_by('-created_at')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = 'Instructor profile update requests'
+        context['active_requests'] = self.active_requests
         return context
+
+
+class AllClosedProfileUpdateRequests(AllProfileUpdateRequests):
+    active_requests = False
 
 
 @login_required
 def profileupdaterequest_details(request, request_id):
-    update_request = get_object_or_404(ProfileUpdateRequest, active=True,
+    update_request = get_object_or_404(ProfileUpdateRequest,
                                        pk=request_id)
 
     person_selected = False


### PR DESCRIPTION
This fixes #523.

New "filter switch" was added on both event requests and profile update requests lists. They allow users to quickly switch between closed and open requests.