### PR TITLE
New host: self-organized

### DIFF
--- a/workshops/migrations/0054_self_organized_host.py
+++ b/workshops/migrations/0054_self_organized_host.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import re
+
+import django
+from django.db import models, migrations
+from django.db.models import Q
+
+
+def add_self_organized_host(apps, schema_editor):
+    """Make new host: self-organized."""
+    Host = apps.get_model('workshops', 'Host')
+    Host.objects.create(domain='-', fullname='self-organized', country='W3')
+
+
+def update_administrator_to_self_organized(apps, schema_editor):
+    """Find all events that were self-organized and set administrator for them
+    to be "self-organized"."""
+    Host = apps.get_model('workshops', 'Host')
+    self_org = Host.objects.get(fullname='self-organized')
+
+    Event = apps.get_model('workshops', 'Event')
+    Event.objects.filter(administrator__isnull=True) \
+        .filter(
+            Q(invoice_status='na-self-org') |
+            Q(notes__contains='self-organized') |
+            Q(notes__contains='self organized')
+        ) \
+        .update(administrator=self_org)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0053_merge'),
+    ]
+
+    operations = [
+        # some missing migration, totally healthy (changes only validators for the field)
+        migrations.AlterField(
+            model_name='event',
+            name='url',
+            field=models.CharField(validators=[django.core.validators.RegexValidator(re.compile('https?://github\\.com/(?P<name>[^/]+)/(?P<repo>[^/]+)/?', 32), inverse_match=True)], unique=True, max_length=100, help_text='Setting this and startdate "publishes" the event.<br />Use link to the event\'s website.', blank=True, null=True),
+        ),
+
+        migrations.RunPython(add_self_organized_host),
+        migrations.RunPython(update_administrator_to_self_organized),
+    ]

--- a/workshops/migrations/0054_self_organized_host.py
+++ b/workshops/migrations/0054_self_organized_host.py
@@ -10,7 +10,8 @@ from django.db.models import Q
 def add_self_organized_host(apps, schema_editor):
     """Make new host: self-organized."""
     Host = apps.get_model('workshops', 'Host')
-    Host.objects.create(domain='-', fullname='self-organized', country='W3')
+    Host.objects.create(domain='self-organized', fullname='self-organized',
+                        country='W3')
 
 
 def update_administrator_to_self_organized(apps, schema_editor):

--- a/workshops/migrations/0055_auto_20151031_0832.py
+++ b/workshops/migrations/0055_auto_20151031_0832.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0054_self_organized_host'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='administrator',
+            field=models.ForeignKey(to='workshops.Host', help_text='Organization responsible for administrative work.', on_delete=django.db.models.deletion.PROTECT, null=True, related_name='administrator', blank=True),
+        ),
+    ]

--- a/workshops/migrations/0056_merge.py
+++ b/workshops/migrations/0056_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0055_auto_20151031_0832'),
+        ('workshops', '0054_auto_20151021_1347'),
+    ]
+
+    operations = [
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -466,8 +466,7 @@ class Event(models.Model):
     administrator = models.ForeignKey(
         Host, related_name='administrator', null=True, blank=True,
         on_delete=models.PROTECT,
-        help_text='Organization responsible for administrative work. Leave '
-        'blank if self-organized.'
+        help_text='Organization responsible for administrative work.'
     )
     start      = models.DateField(null=True, blank=True,
                                   help_text='Setting this and url "publishes" the event.')

--- a/workshops/test/test_search.py
+++ b/workshops/test/test_search.py
@@ -54,7 +54,7 @@ class TestSearchHost(TestBase):
                             'Expected three search results',
                             expected=3)
         texts = set([n.text for n in nodes])
-        assert texts == {'alpha.edu', '-', 'beta.com'}, \
+        assert texts == {'alpha.edu', 'self-organized', 'beta.com'}, \
             'Wrong names {0} in search result'.format(texts)
 
     def test_search_for_people_by_personal_family_names(self):

--- a/workshops/test/test_search.py
+++ b/workshops/test/test_search.py
@@ -51,10 +51,10 @@ class TestSearchHost(TestBase):
                                      'in_hosts' : 'on'})
         doc = self._check_status_code_and_parse(response, 200)
         nodes = self._get_N(doc,  ".//a[@class='searchresult']",
-                            'Expected two search results',
-                            expected=2)
+                            'Expected three search results',
+                            expected=3)
         texts = set([n.text for n in nodes])
-        assert texts == {'alpha.edu', 'beta.com'}, \
+        assert texts == {'alpha.edu', '-', 'beta.com'}, \
             'Wrong names {0} in search result'.format(texts)
 
     def test_search_for_people_by_personal_family_names(self):


### PR DESCRIPTION
This fixes #484.

A new host ('self-organized') was added.

Events that had no administrator and one of the following conditions were updated with 'self-organized' as admin:

* have "self-organized" in notes, or
* have "self organized" in notes, or
* have "Not applicable since self-organized" as invoice status

WIP since I'm waiting for the list of self-organized events.