### PR TITLE
Complete events

### DIFF
--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -68,6 +68,10 @@ class EventFilter(django_filters.FilterSet):
     ]
     status = EventStateFilter(choices=STATUS_CHOICES)
 
+    invoice_status = django_filters.ChoiceFilter(
+        choices=((None, '---------'), ) + Event.INVOICED_CHOICES,
+    )
+
     class Meta:
         model = Event
         fields = [

--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -3,6 +3,8 @@ from django_countries import Countries
 
 from workshops.models import Event, Host, Person, Task, Airport
 
+EMPTY_SELECTION = (None, '---------')
+
 
 class AllCountriesFilter(django_filters.ChoiceFilter):
     @property
@@ -15,7 +17,7 @@ class AllCountriesFilter(django_filters.ChoiceFilter):
         countries.only = choices
 
         self.extra['choices'] = list(countries)
-        self.extra['choices'].insert(0, (None, '---------'))
+        self.extra['choices'].insert(0, EMPTY_SELECTION)
         return super().field
 
 
@@ -33,7 +35,7 @@ class ForeignKeyAllValuesFilter(django_filters.ChoiceFilter):
         qs1 = qs1.order_by(name).values_list(name, flat=True)
         qs2 = model.objects.filter(pk__in=qs1)
         self.extra['choices'] = [(o.pk, str(o)) for o in qs2]
-        self.extra['choices'].insert(0, (None, '---------'))
+        self.extra['choices'].insert(0, EMPTY_SELECTION)
         return super().field
 
 
@@ -69,7 +71,7 @@ class EventFilter(django_filters.FilterSet):
     status = EventStateFilter(choices=STATUS_CHOICES)
 
     invoice_status = django_filters.ChoiceFilter(
-        choices=((None, '---------'), ) + Event.INVOICED_CHOICES,
+        choices=(EMPTY_SELECTION, ) + Event.INVOICED_CHOICES,
     )
 
     class Meta:

--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -79,6 +79,7 @@ class EventFilter(django_filters.FilterSet):
             'host',
             'administrator',
             'invoice_status',
+            'completed',
         ]
         order_by = ['-slug', 'slug', 'start', '-start', 'end', '-end']
 

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -281,7 +281,7 @@ class EventForm(forms.ModelForm):
     class Meta:
         model = Event
         # reorder fields, don't display 'deleted' field
-        fields = ('slug', 'start', 'end', 'host', 'administrator',
+        fields = ('slug', 'completed', 'start', 'end', 'host', 'administrator',
                   'tags', 'url', 'reg_key', 'admin_fee', 'invoice_status',
                   'attendance', 'contact', 'notes',
                   'country', 'venue', 'address', 'latitude', 'longitude')

--- a/workshops/migrations/0054_auto_20151021_1347.py
+++ b/workshops/migrations/0054_auto_20151021_1347.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0053_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='completed',
+            field=models.BooleanField(help_text='Indicates that no more work is needed upon this event.', default=False),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -501,6 +501,11 @@ class Event(models.Model):
     latitude = models.FloatField(null=True, blank=True)
     longitude = models.FloatField(null=True, blank=True)
 
+    completed = models.BooleanField(
+        default=False,
+        help_text="Indicates that no more work is needed upon this event.",
+    )
+
     class Meta:
         ordering = ('-start', )
 

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -18,25 +18,24 @@
 {% if all_events %}
     <table class="table table-striped">
       <tr>
-        <th>ID</th>
-        <th>tags</th>
-        <th>instructors</th>
         <th>slug</th>
+        <th>tags</th>
         <th>url</th>
+        <th>instructors</th>
         <th>host</th>
         <th>dates</th>
         <th>attendance</th>
         <th>admin fee</th>
         <th>invoice</th>
+        <th>completed</th>
         <th class="additional-links"></th>
       </tr>
     {% for event in all_events %}
+      {% if event.completed %}
+      <tr class="bg-success">
+      {% else %}
       <tr>
-        <td>{{ event.id }}</td>
-        <td>{{ event.tags.all | join:", " }}</td>
-        {% with num_instructors=event.task_set.instructors.count %}
-        <td {% if num_instructors == 0 %}class="warning"{% endif %}>{{ num_instructors }}</td>
-        {% endwith %}
+      {% endif %}
         <td {% if not event.slug %}class="warning"{% endif %}>
           {% if not event.slug %}
             —
@@ -46,14 +45,21 @@
             </a>
           {% endif %}
         </td>
+        <td>{{ event.tags.all | join:", " }}</td>
         <td {% if not event.repository_url %}class="warning"{% endif %}>
           {{ event.repository_url|default:"—"|urlize_newtab }}
         </td>
+        {% with num_instructors=event.task_set.instructors.count %}
+        <td {% if num_instructors == 0 %}class="warning"{% endif %}>{{ num_instructors }}</td>
+        {% endwith %}
         <td><a href="{% url 'host_details' event.host.domain %}">{{ event.host }}</a></td>
         <td>{{ event.start }} &ndash; {{ event.end }}</td>
         <td>{{ event.attendance|default_if_none:"—" }}</td>
         <td>{{ event.admin_fee|default_if_none:"—" }}</td>
         <td>{{ event.get_invoice_status_display }}</td>
+        <td>
+          {{ event.completed|yesno }}
+        </td>
         <td>
           <a href="{% url 'event_details' event.get_ident %}" title="View {{ event.get_ident }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -4,6 +4,11 @@
 {% load revisions %}
 
 {% block content %}
+{% if event.completed %}
+<div class="alert alert-success" role="alert">
+  <strong>Well done!</strong> This event is completed, you don't have to work on it.
+</div>
+{% endif %}
 {% last_modified event %}
 <p class="edit-object">
   {% if perms.workshops.change_event %}
@@ -14,6 +19,7 @@
 </p>
 <table class="table table-striped">
   <tr><td>slug:</td><td colspan="2">{{ event.slug|default:"—" }}</td></tr>
+  <tr><td>completed:</td><td colspan="2">{{ event.completed|yesno }}</td></tr>
   <tr><td>start date:</td><td colspan="2">{{ event.start|default:"—" }}</td></tr>
   <tr><td>end date: </td><td colspan="2">{{ event.end|default:"—" }}</td></tr>
   <tr><td>host:</td><td colspan="2"><a href="{% url 'host_details' event.host.domain %}">{{ event.host }}</a></td></tr>


### PR DESCRIPTION
Fixes #471.

The implementation adds a new field, `Event.completed` — it will be easier to do filtering in all-events view than when using Tag to do this task.

For example, with current approach we can display all events, events complete, or events incomplete. With Tag-approach we could only filter events incomplete, or complete.

I decided to not change the dashboard at all. My thinking is admins will only mark events as completed once they're not ongoing, nor upcoming, nor uninvoiced, nor unpublished.

If you would rather have `Event.complete` than `Event.completed`, just let me know.