### PR TITLE
Fix: uninvoiced events don't have to have an admin fee upfront

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -411,12 +411,12 @@ class EventQuerySet(models.query.QuerySet):
     def uninvoiced_events(self):
         '''Return a queryset for events that have not yet been invoiced.
 
-        These are events that have an admin fee, are not marked as invoiced, and have occurred.
+        These are marked as uninvoiced, and have occurred.
         Events are sorted oldest first.'''
 
-        return self.past_events().filter(admin_fee__gt=0)\
-                   .exclude(invoice_status='invoiced')\
-                   .order_by('start')
+        return self.past_events().filter(invoice_status='not-invoiced') \
+                                 .order_by('start')
+
 
 class EventManager(models.Manager):
     '''A custom manager which is essentially a proxy for EventQuerySet'''

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -213,6 +213,15 @@ class TestBase(TestCase):
                                  admin_fee=100,
                                  invoice_status=next(invoice))
 
+        # create a past event that has no admin fee specified, yet it needs
+        # invoice
+        event_start = today + datetime.timedelta(days=-4)
+        Event.objects.create(
+            start=event_start, end=today + datetime.timedelta(days=-1),
+            slug='{:%Y-%m-%d}-past-uninvoiced'.format(event_start),
+            host=test_host, admin_fee=None, invoice_status='not-invoiced',
+        )
+
         # Create an event that started yesterday and ends tomorrow
         # with no fee, and without specifying whether they've been
         # invoiced.
@@ -248,8 +257,7 @@ class TestBase(TestCase):
         self.num_uninvoiced_events = 0
         self.num_upcoming = 0
         for e in Event.objects.all():
-            if (e.admin_fee > 0) and (e.invoice_status == 'not-invoiced') \
-                    and (e.start < today):
+            if e.invoice_status == 'not-invoiced' and e.start < today:
                 self.num_uninvoiced_events += 1
             if e.url and (e.start > today):
                 self.num_upcoming += 1

--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -32,8 +32,8 @@ class TestEvent(TestBase):
         # There should be as many as there are strictly future events.
         assert len(uninvoiced_events) == self.num_uninvoiced_events
 
-        # Check that events with a fee of zero are not in the list of uninvoiced events.
-        assert not any([x for x in uninvoiced_events if x.admin_fee == 0])
+        # Check that events with a fee of zero or None are still on this list
+        assert any([x for x in uninvoiced_events if not x.admin_fee])
 
     def test_get_future_events(self):
         """Test that the events manager can find upcoming events"""
@@ -47,8 +47,7 @@ class TestEvent(TestBase):
 
         past_events = Event.objects.past_events()
 
-        # There are 3 past events
-        assert len(past_events) == 8
+        assert len(past_events) == 9
 
         # They should all start with past
         assert all(['past' in e.slug for e in past_events])


### PR DESCRIPTION
This fixes #550.

Event.objects.uninvoiced_events() returns only past events with
invoice_status of 'not-invoiced'.
Previously these events had to have non-zero (non-null) admin fee
specified to be considered "uninvoiced".