### PR TITLE
Hotfix: wrong date formatting on event's details page

### DIFF
--- a/api/test/test_events.py
+++ b/api/test/test_events.py
@@ -13,6 +13,7 @@ from workshops.models import (
     Event,
     Host,
 )
+from workshops.util import universal_date_format
 
 
 class TestListingPastEvents(APITestCase):
@@ -122,8 +123,9 @@ class TestListingPastEvents(APITestCase):
         # turn dates into strings for the sake of this test
         for i, event in enumerate(self.expecting):
             for date in ['start', 'end']:
-                self.expecting[i][date] = '{:%Y-%m-%d}' \
-                                          .format(self.expecting[i][date])
+                self.expecting[i][date] = universal_date_format(
+                    self.expecting[i][date],
+                )
 
         # test only JSON output
         url = reverse(self.url)

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -564,12 +564,14 @@ class Event(models.Model):
         return self.invoice_status == 'not-invoiced'
 
     def get_invoice_form_url(self):
+        from .util import universal_date_format
+
         query = {
             'entry.823772951': self.venue,  # Organization to invoice
             'entry.351294200': 'Workshop administrative fee',  # Reason
 
             # Date of event
-            'entry.1749215879': ('{:%Y-%m-%d}'.format(self.start)
+            'entry.1749215879': (universal_date_format(self.start)
                                  if self.start else ''),
             'entry.508035854': self.slug,  # Event or item ID
             'entry.821460022': self.admin_fee,  # Total invoice amount
@@ -934,8 +936,11 @@ class TodoItem(models.Model):
         ordering = ["due", "title"]
 
     def __str__(self):
+        from .util import universal_date_format
+
         if self.due:
-            return "{title} due {due:%Y-%m-%d}".format(title=self.title,
-                                                       due=self.due)
+            return "{title} due {due}".format(
+                title=self.title, due=universal_date_format(self.due),
+            )
         else:
             return self.title

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -569,7 +569,8 @@ class Event(models.Model):
             'entry.351294200': 'Workshop administrative fee',  # Reason
 
             # Date of event
-            'entry.1749215879': '{:%Y-%m-%d}'.format(self.start),
+            'entry.1749215879': ('{:%Y-%m-%d}'.format(self.start)
+                                 if self.start else ''),
             'entry.508035854': self.slug,  # Event or item ID
             'entry.821460022': self.admin_fee,  # Total invoice amount
             'entry.1316946828': 'US dollars',  # Currency

--- a/workshops/test/base.py
+++ b/workshops/test/base.py
@@ -21,6 +21,8 @@ from ..models import \
     Qualification, \
     Host
 
+from ..util import universal_date_format
+
 
 class TestBase(TestCase):
     '''Base class for AMY test cases.'''
@@ -187,7 +189,7 @@ class TestBase(TestCase):
         add_url = True
         for t in range(1, 11):
             event_start = today + datetime.timedelta(days=t)
-            date_string = event_start.strftime('%Y-%m-%d')
+            date_string = universal_date_format(event_start)
             slug = '{0}-upcoming'.format(date_string)
             if add_url:
                 url = 'http://' + ('{0}'.format(t) * 20)
@@ -206,7 +208,7 @@ class TestBase(TestCase):
         invoice = itertools.cycle(['invoiced', 'not-invoiced'])
         for t in range(3, 11):
             event_start = today + datetime.timedelta(days=-t)
-            date_string = event_start.strftime('%Y-%m-%d')
+            date_string = universal_date_format(event_start)
             Event.objects.create(start=event_start,
                                  slug='{0}-past'.format(date_string),
                                  host=test_host,
@@ -218,7 +220,9 @@ class TestBase(TestCase):
         event_start = today + datetime.timedelta(days=-4)
         Event.objects.create(
             start=event_start, end=today + datetime.timedelta(days=-1),
-            slug='{:%Y-%m-%d}-past-uninvoiced'.format(event_start),
+            slug='{}-past-uninvoiced'.format(
+                universal_date_format(event_start)
+            ),
             host=test_host, admin_fee=None, invoice_status='not-invoiced',
         )
 

--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -501,6 +501,17 @@ class TestEventViews(TestBase):
         rv = self.client.post(reverse('event_add'), data, follow=False)
         self.assertEqual(rv.status_code, 200)
 
+    def test_display_of_event_without_start_date(self):
+        """A bug prevented events without start date to throw a 404.
+
+        This is a regression test against that bug.
+        The error happened when "".format encountered None instead of
+        datetime."""
+        event = Event.objects.create(slug='regression_event_0',
+                                     host=self.test_host)
+        rv = self.client.get(reverse('event_details', args=[event.pk]))
+        assert rv.status_code == 200
+
 
 class TestEventNotes(TestBase):
     """Make sure notes once written are saved forever!"""

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -467,3 +467,7 @@ def update_event_attendance_from_tasks(event):
         .filter(pk=event.pk) \
         .filter(Q(attendance__lt=learners) | Q(attendance__isnull=True)) \
         .update(attendance=learners)
+
+
+def universal_date_format(date):
+    return '{:%Y-%m-%d}'.format(date)


### PR DESCRIPTION
Events without start date caused `"".format()` to error out because it received `None` object instead of `datetime`.

The fix was merged to the master and deployed so that admins can continue to work.