### PR TITLE
Add 'stalled' tag

### DIFF
--- a/workshops/migrations/0062_add_stalled_unresponsive_tags.py
+++ b/workshops/migrations/0062_add_stalled_unresponsive_tags.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def add_stalled_unresponsive_tags(apps, schema_editor):
+    """Add "stalled" and "unresponsive" tags."""
+    Tag = apps.get_model('workshops', 'Tag')
+    Tag.objects.create(
+        name='stalled',
+        details='Events with lost contact with the host or TTT events that '
+                'aren\'t running.',
+    )
+    Tag.objects.create(
+        name='unresponsive',
+        details='Events whose hosts and/or organizers aren\'t going to send '
+                'attendance data',
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0061_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_stalled_unresponsive_tags),
+        migrations.AlterField(
+            model_name='event',
+            name='tags',
+            field=models.ManyToManyField(help_text="<ul><li><i>stalled</i> — for events with lost contact with the host or TTT events that aren't running.</li><li><i>unresponsive</i> – for events whose hosts and/or organizers aren't going to send us attendance data.</li></ul>", to='workshops.Tag'),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -358,6 +358,10 @@ class Tag(models.Model):
 class EventQuerySet(models.query.QuerySet):
     '''Handles finding past, ongoing and upcoming events'''
 
+    def no_stalled(self):
+        """Exclude events marked as 'stalled'."""
+        return self.exclude(tags__name='stalled')
+
     def past_events(self):
         '''Return past events.
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -456,7 +456,14 @@ class Event(AssignmentMixin, models.Model):
 
     host = models.ForeignKey(Host, on_delete=models.PROTECT,
                              help_text='Organization hosting the event.')
-    tags       = models.ManyToManyField(Tag)
+    tags = models.ManyToManyField(
+        Tag,
+        help_text='<ul><li><i>stalled</i> — for events with lost contact with '
+                  'the host or TTT events that aren\'t running.</li>'
+                  '<li><i>unresponsive</i> – for events whose hosts and/or '
+                  'organizers aren\'t going to send us attendance data.</li>'
+                  '</ul>',
+    )
     administrator = models.ForeignKey(
         Host, related_name='administrator', null=True, blank=True,
         on_delete=models.PROTECT,

--- a/workshops/templates/workshops/all_eventrequests.html
+++ b/workshops/templates/workshops/all_eventrequests.html
@@ -2,6 +2,7 @@
 
 {% load crispy_forms_tags %}
 {% load pagination %}
+{% load tags %}
 
 {% block sidebar %}
     <h3>Filter</h3>
@@ -29,13 +30,7 @@
         <td>{{ req.name }} &lt;{{ req.email|urlize }}&gt;</td>
         <td>{{ req.affiliation }}</td>
         <td>{{ req.preferred_date }}</td>
-        <td>
-        {% if req.workshop_type == 'swc' %}
-          <span class="label label-primary">SWC</span>
-        {% else %}
-          <span class="label label-default">DC</span>
-        {% endif %}
-        </td>
+        <td>{% bootstrap_tag req.workshop_type|upper %}</td>
         <td>{{ req.comment|truncatewords:5|default:"—" }}</td>
         <td><a href="{{ req.get_absolute_url }}"><span class="glyphicon glyphicon-info-sign"></span></a></td>
       </tr>

--- a/workshops/templates/workshops/all_events.html
+++ b/workshops/templates/workshops/all_events.html
@@ -3,6 +3,7 @@
 {% load crispy_forms_tags %}
 {% load links %}
 {% load pagination %}
+{% load tags %}
 
 {% block sidebar %}
     <h3>Filter</h3>
@@ -45,7 +46,7 @@
             </a>
           {% endif %}
         </td>
-        <td>{{ event.tags.all | join:", " }}</td>
+        <td>{% for tag in event.tags.all %}{% bootstrap_tag tag.name %}{% endfor %}</td>
         <td {% if not event.repository_url %}class="warning"{% endif %}>
           {{ event.repository_url|default:"—"|urlize_newtab }}
         </td>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -3,6 +3,7 @@
 {% load crispy_forms_tags %}
 {% load links %}
 {% load revisions %}
+{% load tags %}
 
 {% block content %}
 {% if event.completed %}
@@ -40,7 +41,7 @@
   <tr class="{% if event.start > event.end %}bg-danger{% endif %}"><td>end date: </td><td colspan="2">{{ event.end|default:"—" }}</td></tr>
   <tr><td>host:</td><td colspan="2"><a href="{% url 'host_details' event.host.domain %}">{{ event.host }}</a></td></tr>
   <tr><td>administrator:</td><td colspan="2">{% if event.administrator %}<a href="{{ event.administrator.get_absolute_url }}">{{ event.administrator }}</a>{% else %}—{% endif %}</td></tr>
-  <tr><td>tags:</td><td colspan="2">{{ event.tags.all | join:", " }}</td></tr>
+  <tr><td>tags:</td><td colspan="2">{% for tag in event.tags.all %}{% bootstrap_tag tag.name %}{% endfor %}</td></tr>
   <tr><td>Website URL:</td><td colspan="2">{{ event.website_url|default:"—"|urlize_newtab }} {% if event.url %}<a href="{% url 'validate_event' event.get_ident %}" class="btn btn-primary btn-xs pull-right" id="validate_event">validate event</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_event_url" href="#" data-toggle="popover" data-trigger="focus" title="Validation error" data-content="Cannot validate an event without URL pointing to the GitHub repository, e.g.: <code>https://github.com/swcarpentry/2015-05-24-training</code>">Error</a>{% endif %}</td></tr>
   <tr><td>Eventbrite key:</td><td colspan="2">{% if event.reg_key %}<a href="https://www.eventbrite.com/myevent?eid={{ event.reg_key }}" title="Go to Eventbrite's page for this event" target="_blank">{{ event.reg_key }}</a>{% else %}—{% endif %}</td></tr>
   <tr><td>admin fee:</td><td colspan="2">{{ event.admin_fee|default_if_none:"—" }}</td></tr>

--- a/workshops/templates/workshops/instructor_issues.html
+++ b/workshops/templates/workshops/instructor_issues.html
@@ -71,6 +71,30 @@ Thanks for your help.{% endfilter %}">
 {% else %}
   <p>None.</p>
 {% endif %}
+
+<h2>Stalled Trainees</h2>
+{% if stalled %}
+  <table class="table table-striped">
+    <tr>
+      <th>Person</th>
+      <th>Training(s) <a href="#" data-toggle="tooltip" title="Instructor Training(s) not finished and marked as stalled">[?]</a></th>
+    </tr>
+    {% regroup stalled by person as trainings %}
+    {% for person_training in trainings %}
+    <tr>
+      <td><a href="{% url 'person_details' person_training.grouper.id %}">{{ person_training.grouper.get_full_name }}</a></td>
+      <td>
+        {% for e in person_training.list %}
+          <a href="{% url 'event_details' e.event.get_ident %}">{{ e.event }}</a>{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+{% else %}
+  <p>None.</p>
+{% endif %}
+
 {% endblock %}
 
 {% block extrajs %}

--- a/workshops/templatetags/tags.py
+++ b/workshops/templatetags/tags.py
@@ -1,0 +1,27 @@
+from django import template
+# from django.template.defaultfilters import stringfilter
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+# @register.filter(is_safe=True, needs_autoescape=True)
+# @stringfilter
+@register.simple_tag
+def bootstrap_tag(name):
+    """Wrap <span> around a tag so that it's displayed as Bootstrap label:
+    http://getbootstrap.com/components/#labels"""
+
+    addn_class = 'label-default'
+    if name == 'SWC':
+        addn_class = 'label-primary'
+    elif name == 'DC':
+        addn_class = 'label-success'
+    elif name == 'online':
+        addn_class = 'label-info'
+    elif name == 'LC':
+        addn_class = 'label-warning'
+
+    fmt = '<span class="label {additional_class}">{name}</span>'
+    fmt = fmt.format(additional_class=addn_class, name=name)
+    return mark_safe(fmt)

--- a/workshops/test/test_instructor_issues.py
+++ b/workshops/test/test_instructor_issues.py
@@ -1,0 +1,41 @@
+from django.core.urlresolvers import reverse
+
+from .base import TestBase
+from ..models import Tag, Event, Task, Role
+
+
+class TestInstructorIssues(TestBase):
+    """Tests for the `instructor_issues` view."""
+
+    def setUp(self):
+        super().setUp()
+        self._setUpUsersAndLogin()
+
+        TTT, _ = Tag.objects.get_or_create(name='TTT')
+        stalled = Tag.objects.get(name='stalled')
+        learner, _ = Role.objects.get_or_create(name='learner')
+
+        # add two TTT events, one stalled and one normal
+        e1 = Event.objects.create(slug='ttt-stalled', host=self.host_alpha)
+        e1.tags = [TTT, stalled]
+
+        e2 = Event.objects.create(slug='ttt-not-stalled', host=self.host_alpha)
+        e2.tags.add(TTT)
+
+        Task.objects.create(event=e1, person=self.spiderman, role=learner)
+        Task.objects.create(event=e1, person=self.ironman, role=learner)
+        Task.objects.create(event=e1, person=self.blackwidow, role=learner)
+        Task.objects.create(event=e2, person=self.spiderman, role=learner)
+
+    def test_stalled_trainees_not_in_pending(self):
+        """"""
+        rv = self.client.get(reverse('instructor_issues'))
+        pending = [t.person for t in rv.context['pending']]
+        stalled = [t.person for t in rv.context['stalled']]
+
+        self.assertIn(self.spiderman, pending)
+        self.assertNotIn(self.spiderman, stalled)
+        self.assertNotIn(self.ironman, pending)
+        self.assertIn(self.ironman, stalled)
+        self.assertNotIn(self.blackwidow, pending)
+        self.assertIn(self.blackwidow, stalled)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -174,9 +174,9 @@ def dashboard(request):
     '''Home page.'''
     current_events = (
         Event.objects.upcoming_events() | Event.objects.ongoing_events()
-    )
-    unpublished_events = Event.objects.unpublished_events()
-    uninvoiced_events = Event.objects.uninvoiced_events()
+    ).no_stalled()
+    uninvoiced_events = Event.objects.uninvoiced_events().no_stalled()
+    unpublished_events = Event.objects.unpublished_events().no_stalled()
 
     user = request.user
     is_admin = user.groups.filter(name='administrators').exists()

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1578,7 +1578,13 @@ def instructor_issues(request):
         .select_related('person', 'event')
 
     pending_instructors = trainees.exclude(event__tags=stalled)
-    stalled_instructors = trainees.filter(event__tags=stalled)
+    pending_instructors_person_ids = pending_instructors.values_list(
+        'person__pk', flat=True,
+    )
+
+    stalled_instructors = trainees \
+        .filter(event__tags=stalled) \
+        .exclude(person__id__in=pending_instructors_person_ids)
 
     context = {
         'title': 'Instructors with Issues',

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1570,17 +1570,21 @@ def instructor_issues(request):
     # Everyone who's been in instructor training but doesn't yet have a badge.
     learner = Role.objects.get(name='learner')
     ttt = Tag.objects.get(name='TTT')
-    ttt_events = Event.objects.filter(tags__in=[ttt])
-    pending_instructors = Task.objects \
-        .filter(event__in=ttt_events, role=learner) \
+    stalled = Tag.objects.get(name='stalled')
+    trainees = Task.objects \
+        .filter(event__tags__in=[ttt], role=learner) \
         .exclude(person__badges__in=[instructor_badge]) \
         .order_by('person__family', 'person__personal', 'event__start') \
         .select_related('person', 'event')
+
+    pending_instructors = trainees.exclude(event__tags=stalled)
+    stalled_instructors = trainees.filter(event__tags=stalled)
 
     context = {
         'title': 'Instructors with Issues',
         'instructors': instructors,
         'pending': pending_instructors,
+        'stalled': stalled_instructors,
     }
     return render(request, 'workshops/instructor_issues.html', context)
 


### PR DESCRIPTION
For use in cases when admins lost contact with event's host, or for TTT
events that are no longer running.

Fixes #549.
Fixes #545.