### PR TITLE
Add filtering to published events API endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -35,6 +35,7 @@ class EventSerializer(serializers.ModelSerializer):
     start = serializers.DateField(format=None)
     end = serializers.DateField(format=None)
     url = serializers.URLField(source='website_url')
+    eventbrite_id = serializers.CharField(source='reg_key')
 
     def get_humandate(self, obj):
         """Render start and end dates as human-readable short date."""
@@ -62,5 +63,5 @@ class EventSerializer(serializers.ModelSerializer):
         model = Event
         fields = (
             'slug', 'start', 'end', 'url', 'humandate', 'contact', 'country',
-            'venue', 'address', 'latitude', 'longitude',
+            'venue', 'address', 'latitude', 'longitude', 'eventbrite_id',
         )

--- a/api/test/test_events.py
+++ b/api/test/test_events.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from unittest.mock import patch
 
 from django.core.urlresolvers import reverse
 from rest_framework import status
@@ -50,6 +51,7 @@ class TestListingPastEvents(APITestCase):
             host=host, latitude=3, longitude=-2, venue='University',
             address='On the street', country='US', contact='sb@sth.edu',
             url='http://github.com/user/repository/',
+            reg_key='12341234',
         )
         # event with missing start
         self.event4 = Event.objects.create(
@@ -84,6 +86,7 @@ class TestListingPastEvents(APITestCase):
                 'country': 'US',
                 'url': 'https://user.github.io/repository/',
                 'contact': 'sb@sth.edu',
+                'eventbrite_id': '12341234',
             },
             {
                 'slug': 'event2',
@@ -99,6 +102,7 @@ class TestListingPastEvents(APITestCase):
                 'country': 'US',
                 'url': 'https://user.github.io/repository/',
                 'contact': 'sb@sth.edu',
+                'eventbrite_id': None,
             },
             {
                 'slug': 'event1',
@@ -112,10 +116,14 @@ class TestListingPastEvents(APITestCase):
                 'country': 'US',
                 'url': 'https://user.github.io/repository/',
                 'contact': 'sb@sth.edu',
+                'eventbrite_id': None,
             },
         ]
 
-    def test_serialization(self):
+    @patch.object(PublishedEvents, 'request', query_params={}, create=True)
+    def test_serialization(self, mock_request):
+        # we're mocking a request here because it's not possible to create
+        # a fake request context for the view
         response = self.serializer_class(self.view().get_queryset(), many=True)
         self.assertEqual(response.data, self.expecting)
 

--- a/api/views.py
+++ b/api/views.py
@@ -51,4 +51,18 @@ class PublishedEvents(ListAPIView):
     paginator = None  # disable pagination
 
     serializer_class = EventSerializer
-    queryset = Event.objects.published_events()
+
+    def get_queryset(self):
+        """Optionally restrict the returned event set to events hosted by
+        specific host or administered by specific admin."""
+        queryset = Event.objects.published_events()
+
+        administrator = self.request.query_params.get('administrator', None)
+        if administrator is not None:
+            queryset = queryset.filter(administrator__pk=administrator)
+
+        host = self.request.query_params.get('host', None)
+        if host is not None:
+            queryset = queryset.filter(host__pk=host)
+
+        return queryset


### PR DESCRIPTION
Filtered values:
* administrator organization
* host

Both take IDs.

Additionally a new value is being returned by the API: event's
eventbrite ID.

This fixes #529.