### PR TITLE
Fix: react to more tricky cases of latitude/longitude/eventbrite_id

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -616,6 +616,7 @@ Other content.
             ('XYZ, ', (None, None)),
             (',-123', (None, -123.0)),
             (',', (None, None)),
+            (None, (None, None)),
         ]
         expected = {
             'slug': '',
@@ -637,6 +638,33 @@ Other content.
                 tags = dict(latlng=latlng)
                 expected['latitude'] = latitude
                 expected['longitude'] = longitude
+                self.assertEqual(expected, parse_tags_from_event_website(tags))
+
+    def test_parsing_tricky_eventbrite_id(self):
+        tests = [
+            ('', None),
+            ('string', None),
+            (None, None),
+        ]
+        expected = {
+            'slug': '',
+            'language': '',
+            'start': None,
+            'end': None,
+            'country': '',
+            'venue': '',
+            'address': '',
+            'latitude': None,
+            'longitude': None,
+            'reg_key': None,
+            'instructors': [],
+            'helpers': [],
+            'contact': '',
+        }
+        for eventbrite_id, reg_key in tests:
+            with self.subTest(eventbrite_id=eventbrite_id):
+                tags = dict(eventbrite=eventbrite_id)
+                expected['reg_key'] = reg_key
                 self.assertEqual(expected, parse_tags_from_event_website(tags))
 
     def test_validating_invalid_tags(self):

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -431,18 +431,26 @@ def parse_tags_from_event_website(tags):
     try:
         latitude, _ = tags.get('latlng', '').split(',')
         latitude = float(latitude.strip())
-    except ValueError:
+    except (ValueError, TypeError, AttributeError):
+        # value error: can't convert string to float
+        # type error: can't convert None to float
+        # attribute error: object doesn't have "split" or "strip" methods
         latitude = None
     try:
         _, longitude = tags.get('latlng', '').split(',')
         longitude = float(longitude.strip())
-    except ValueError:
+    except (ValueError, TypeError, AttributeError):
+        # value error: can't convert string to float
+        # type error: can't convert None to float
+        # attribute error: object doesn't have "split" or "strip" methods
         longitude = None
 
     try:
         reg_key = tags.get('eventbrite', '')
         reg_key = int(reg_key)
-    except ValueError:
+    except (ValueError, TypeError):
+        # value error: can't convert string to int
+        # type error: can't convert None to int
         reg_key = None
 
     try:

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -373,7 +373,7 @@ def generate_url_to_event_index(website_url):
     results = regex.match(website_url)
     if results:
         return template.format(**results.groupdict())
-    return None
+    raise ValueError('URL does not match Event.WEBSITE_REGEX.')
 
 ALLOWED_TAG_NAMES = [
     'slug', 'startdate', 'enddate', 'country', 'venue', 'address',
@@ -431,17 +431,15 @@ def parse_tags_from_event_website(tags):
     try:
         latitude, _ = tags.get('latlng', '').split(',')
         latitude = float(latitude.strip())
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, AttributeError):
         # value error: can't convert string to float
-        # type error: can't convert None to float
         # attribute error: object doesn't have "split" or "strip" methods
         latitude = None
     try:
         _, longitude = tags.get('latlng', '').split(',')
         longitude = float(longitude.strip())
-    except (ValueError, TypeError, AttributeError):
+    except (ValueError, AttributeError):
         # value error: can't convert string to float
-        # type error: can't convert None to float
         # attribute error: object doesn't have "split" or "strip" methods
         longitude = None
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -4,6 +4,7 @@ import datetime
 import io
 import re
 import requests
+from urllib.parse import urlparse
 
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
@@ -1061,15 +1062,18 @@ def event_import(request):
 
         if 'slug' not in tags:
             # there are no HTML tags, so let's try the old method
-            url = generate_url_to_event_index(url)
+            index_url = generate_url_to_event_index(url)
 
             # fetch page
-            response = requests.get(url)
+            response = requests.get(index_url)
 
             if response.status_code == 200:
                 # don't throw errors for pages we fall back to
                 content = response.text
                 tags = find_tags_on_event_index(content)
+
+                if 'slug' not in tags:
+                    tags['slug'] = urlparse(url).path.replace('/', '')
 
         # normalize (parse) them
         tags = parse_tags_from_event_website(tags)


### PR DESCRIPTION
This fixes #584.

Cases:
* tag is missing from the website - we get `None`
* tag has string content
* tag has empty string content

Tests for these cases were added.

Another change:
slug is now returned in `event_import` view when using the old, workshop
index.html method.