### PR TITLE
Event.mailto: new property for grabbing event's contact emails

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -585,6 +585,30 @@ class Event(AssignmentMixin, models.Model):
         """Indicate if the event has been invoiced or not."""
         return self.invoice_status == 'not-invoiced'
 
+    @property
+    def mailto(self):
+        """Return list of emails we can contact about workshop details, like
+        attendance."""
+        from workshops.util import find_emails
+
+        emails = Task.objects \
+            .filter(event=self) \
+            .filter(
+                # we only want hosts, organizers and instructors
+                Q(role__name='host') | Q(role__name='organizer') |
+                Q(role__name='instructor')
+            ) \
+            .filter(person__may_contact=True) \
+            .exclude(Q(person__email='') | Q(person__email=None)) \
+            .values_list('person__email', flat=True)
+
+        additional_emails = find_emails(self.contact)
+        # Emails will become an iterator in 1.9 (ValuesListQuerySet previously)
+        # so we need a normal list that will be extended by that iterator.
+        # Bonus points: it works in 1.8.x too!
+        additional_emails.extend(emails)
+        return ','.join(additional_emails)
+
     def get_invoice_form_url(self):
         from .util import universal_date_format
 

--- a/workshops/templates/workshops/attendance_email_href.html
+++ b/workshops/templates/workshops/attendance_email_href.html
@@ -1,0 +1,5 @@
+mailto:{{ event.mailto }}?subject={% filter urlencode %}Missing attendance figures for workshop {{ event.get_ident }}{% endfilter %}&body={% filter urlencode %}Hi,
+
+Can you please send us attendance figures for the workshop {{ event.get_ident }}?  As per our FAQ (http://software-carpentry.org/faq.html#trademark), this is one of the conditions of using the Software Carpentry name and logo, and we need to get these figures to funders.
+
+Thanks for your help.{% endfilter %}

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -56,7 +56,17 @@
       {% endif %}
     </td>
   </tr>
-  <tr class="{% if not event.attendance %}bg-danger{% endif %}"><td>attendance:</td><td colspan="2">{{ event.attendance|default_if_none:"—" }}</td></tr>
+  <tr class="{% if not event.attendance %}bg-danger{% endif %}">
+    <td>attendance:</td>
+    <td colspan="2">
+      {{ event.attendance|default_if_none:"—" }}
+      {% if not event.attendance and event.mailto %}
+      <a href="{% include 'workshops/attendance_email_href.html' with event=event %}" target="_blank" class="btn btn-primary btn-xs pull-right">Ask for attendance</a>
+      {% else %}
+      <a href="#" class="btn btn-primary btn-xs pull-right disabled">Ask for attendance</a>
+      {% endif %}
+    </td>
+  </tr>
   <tr><td>contact:</td><td colspan="2">{{ event.contact|default_if_none:"—"|urlize }}</td></tr>
   <tr>
     <td rowspan="4">location details:</td>

--- a/workshops/templates/workshops/workshop_issues.html
+++ b/workshops/templates/workshops/workshop_issues.html
@@ -18,12 +18,8 @@
     </td>
     <td>
       {% if event.missing_attendance_ %}
-        {% if event.mailto_ %}
-          <a href="mailto:{{event.mailto_}}?subject={% filter urlencode %}Missing attendance figures for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
-
-Can you please send us attendance figures for the workshop {{ event.get_ident }}?  As per our FAQ (http://software-carpentry.org/faq.html#trademark), this is one of the conditions of using the Software Carpentry name and logo, and we need to get these figures to funders.
-
-Thanks for your help.{% endfilter %}">
+        {% if event.mailto %}
+          <a href="{% include 'workshops/attendance_email_href.html' with event=event %}">
           <span class="glyphicon glyphicon-envelope"></span>
           </a>
         {% else %}
@@ -33,8 +29,8 @@ Thanks for your help.{% endfilter %}">
     </td>
     <td>
       {% if event.missing_location_ %}
-        {% if event.mailto_ %}
-          <a href="mailto:{{event.mailto_}}?subject={% filter urlencode %}Missing location for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
+        {% if event.mailto %}
+          <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Missing location for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
 
 Can you please send us the location where the {{ event.get_ident }} workshop took place? We need a country, address, venue, and latitude/longitude.
 
@@ -48,8 +44,8 @@ Thanks for your help.{% endfilter %}">
     </td>
     <td>
       {% if event.bad_dates_ %}
-        {% if event.mailto_ %}
-          <a href="mailto:{{event.mailto_}}?subject={% filter urlencode %}Bad dates for workshop {{ event.get_ident }}{% endfilter %}&body={% filter urlencode %}Hi,
+        {% if event.mailto %}
+          <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Bad dates for workshop {{ event.get_ident }}{% endfilter %}&body={% filter urlencode %}Hi,
 
 Can you please confirm the start and end dates for the workshop {{ event.get_ident }}?
 
@@ -72,7 +68,7 @@ Thanks for your help.{% endfilter %}">
 {% block extrajs %}
 <script type="text/javascript">
 $(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
+  $('[data-toggle="tooltip"]').tooltip();
+});
 </script>
 {% endblock %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1534,8 +1534,6 @@ def instructor_num_taught(request):
 def workshop_issues(request):
     '''Display workshops in the database whose records need attention.'''
 
-    host = Role.objects.get(name='host')
-    instructor = Role.objects.get(name='instructor')
     events = Event.objects.past_events().filter(
         Q(attendance=None) | Q(attendance=0) |
         Q(country=None) |
@@ -1544,16 +1542,15 @@ def workshop_issues(request):
         Q(latitude=None) | Q(longitude=None) |
         Q(start__gt=F('end'))
     )
+
     for e in events:
-        tasks = Task.objects.filter(event=e).\
-            filter(Q(role=host) | Q(role=instructor))
-        e.mailto_ = ','.join([t.person.email for t in tasks if t.person.email])
         e.missing_attendance_ = (not e.attendance)
         e.missing_location_ = (
-            not e.country or not e.venue or not e.address or not e.latitude
-            or not e.longitude
+            not e.country or not e.venue or not e.address or not e.latitude or
+            not e.longitude
         )
         e.bad_dates_ = e.start and e.end and (e.start > e.end)
+
     context = {'title': 'Workshops with Issues',
                'events': events}
     return render(request, 'workshops/workshop_issues.html', context)


### PR DESCRIPTION
Used on event's details page and on workshop issues page.

This commit also contains:
* new utility function `find_emails` for finding emails in text (it's
  being used to find emails in Event.contact)
* "mailto:..." content of 'href' attributes was factored out into new
  template (since we don't like repeating ourselves). It's being used by
  event.html, workshop_issues.html templates.

This fixes #553.