### PR TITLE
Suppressing invalid HTTP HOST notifications

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -49,7 +49,7 @@ else:
 
 # email settings
 ADMINS = (
-    ('Piotr Banaszkiewicz', 'piotr@banaszkiewicz.org'),
+    ('Sysadmins ML', 'sysadmin@lists.software-carpentry.org'),
 )
 # "From:" for error messages sent out to ADMINS
 SERVER_EMAIL = os.environ.get('AMY_SERVER_EMAIL', 'root@localhost')

--- a/amy/settings.py
+++ b/amy/settings.py
@@ -234,3 +234,20 @@ REST_FRAMEWORK = {
         'user': '1000/day'
     }
 }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,  # merge with default configuration
+    'handlers': {
+        'null': {
+            'class': 'logging.NullHandler',
+        },
+    },
+    'loggers': {
+        # disable "Invalid HTTP_HOST" notifications
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+    },
+}


### PR DESCRIPTION
This one:

* stops sending notifications to me (and Greg, as of #595)
* starts sending notifications to our sysadmin mailing list
* stops informing about "invalid HTTP_HOST header" errors (someone requests our pages without proper HOST header, usually "104.130.229.225" [which is server's IP address] or "*.software-carpentry.org")