### PR TITLE
WIP: workshops/models.py: Add LanguageTag and LanguageQualification models

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -361,6 +361,14 @@ class PersonForm(forms.ModelForm):
         widget=selectable.AutoComboboxSelectWidget,
     )
 
+    languages = selectable.AutoCompleteSelectMultipleField(
+        lookup_class=lookups.LanguageLookup,
+        label='Languages',
+        required=False,
+        help_text=AUTOCOMPLETE_HELP_TEXT,
+        widget=selectable.AutoComboboxSelectMultipleWidget,
+    )
+
     class Meta:
         model = Person
         # don't display the 'password', 'user_permissions',
@@ -369,6 +377,15 @@ class PersonForm(forms.ModelForm):
         fields = ['username', 'personal', 'middle', 'family', 'may_contact',
                   'email', 'gender', 'airport', 'affiliation', 'github',
                   'twitter', 'url', 'notes', 'lessons', 'domains']
+
+    def __init__(self, instance=None, **kwargs):
+        kwargs['instance'] = instance
+        if instance:
+            if 'initial' not in kwargs:
+                kwargs['initial'] = {}
+            if 'languages' not in kwargs['initial']:
+                kwargs['initial']['languages'] = instance.languages.all()
+        super(PersonForm, self).__init__(**kwargs)
 
 
 class PersonPermissionsForm(forms.ModelForm):

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -110,6 +110,13 @@ class InstructorsForm(forms.Form):
                                              widget=CheckboxSelectMultiple(),
                                              required=False)
 
+    language = selectable.AutoCompleteSelectField(
+        lookup_class=lookups.LanguageLookup,
+        label='Language',
+        required=False,
+        widget=selectable.AutoComboboxSelectWidget,
+    )
+
     INSTRUCTOR_BADGE_CHOICES = (
         ('swc-instructor', 'Software Carpentry Instructor'),
         ('dc-instructor', 'Data Carpentry Instructor'),
@@ -165,6 +172,7 @@ class InstructorsForm(forms.Form):
                 ),
                 css_class='panel panel-default ',
             ),
+            'language',
             'gender',
             'lessons',
             'instructor_badges',

--- a/workshops/lookups.py
+++ b/workshops/lookups.py
@@ -66,8 +66,18 @@ class AirportLookup(ModelLookup):
     )
 
 
+@login_required
+class LanguageLookup(ModelLookup):
+    model = models.Language
+    search_fields = (
+        'name__icontains',
+        'language__icontains'
+    )
+
+
 registry.register(EventLookup)
 registry.register(HostLookup)
 registry.register(PersonLookup)
 registry.register(AdminLookup)
 registry.register(AirportLookup)
+registry.register(LanguageLookup)

--- a/workshops/migrations/0068_auto_20160102_1502.py
+++ b/workshops/migrations/0068_auto_20160102_1502.py
@@ -1,8 +1,60 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import email.parser
+import urllib.request
+
 from django.db import migrations, models
 from django.conf import settings
+
+
+def add_languages(
+        apps, schema_editor,
+        url='http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry'):
+    """Populate the Languages table.
+
+    [1] lists IANA as the registry maintainer, [2] looks like that
+    registry, and [3] describes the entry-format in the registry.
+
+    [1]: https://tools.ietf.org/html/rfc5646#section-2.2.1
+    [2]: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+    [3]: https://tools.ietf.org/html/rfc5646#section-3.1
+    """
+    with urllib.request.urlopen(url=url) as response:
+        payload_bytes = response.read()
+        charset = response.headers.get_content_charset()
+        payload = payload_bytes.decode(charset)
+    Language = apps.get_model('workshops', 'Language')
+    record = []
+    for line in payload.splitlines():
+        if line == '%%':
+            add_language(record=record, Language=Language)
+            record = []
+        else:
+            record.append(line)
+    add_language(record=record, Language=Language)
+
+
+def add_language(record, Language):
+    if len(record) == 0:
+        return
+    # https://tools.ietf.org/html/rfc5646#section-3.1.2
+    if len(record) == 1 and record[0].startswith('File-Date:'):
+        return
+    # https://docs.python.org/3/library/email.parser.html#parser-class-api
+    # to handle line-wrapping
+    # https://tools.ietf.org/html/rfc5646#section-3.1.1
+    fields = email.parser.Parser().parsestr('\r\n'.join(record))
+    if fields['Type'] != 'language':
+        return
+    if len(fields['Subtag']) > 2:
+        # skip these until we need them
+        # https://github.com/swcarpentry/amy/issues/582#issuecomment-159506884
+        return
+    Language.objects.get_or_create(
+        name=fields['Description'],
+        language=fields['Subtag'],
+    )
 
 
 class Migration(migrations.Migration):
@@ -34,4 +86,5 @@ class Migration(migrations.Migration):
             name='languages',
             field=models.ManyToManyField(to='workshops.Language', through='workshops.LanguageQualification', blank=True),
         ),
+        migrations.RunPython(add_languages),
     ]

--- a/workshops/migrations/0068_auto_20160102_1502.py
+++ b/workshops/migrations/0068_auto_20160102_1502.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0067_person_username_regexvalidator'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Language',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True, verbose_name='ID', auto_created=True)),
+                ('name', models.CharField(max_length=40, help_text='Description of this language tag in English')),
+                ('language', models.CharField(max_length=10, help_text='Primary language subtag.  https://tools.ietf.org/html/rfc5646#section-2.2.1')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='LanguageQualification',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True, verbose_name='ID', auto_created=True)),
+                ('weight', models.FloatField(default=1, help_text='https://tools.ietf.org/html/rfc7231#section-5.3.1')),
+                ('language', models.ForeignKey(to='workshops.Language')),
+                ('person', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='person',
+            name='languages',
+            field=models.ManyToManyField(to='workshops.Language', through='workshops.LanguageQualification', blank=True),
+        ),
+    ]

--- a/workshops/migrations/0069_auto_20160102_1719.py
+++ b/workshops/migrations/0069_auto_20160102_1719.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import workshops.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0068_auto_20160102_1502'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventrequest',
+            name='language',
+            field=models.ForeignKey(to='workshops.Language', default=workshops.models.get_english, blank=True, verbose_name='What human language do you want the workshop to be run in?'),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -241,6 +241,11 @@ class Person(AbstractBaseUser, PermissionsMixin):
         limit_choices_to=~Q(name__startswith='Don\'t know yet'),
         blank=True,
     )
+    languages = models.ManyToManyField(
+        'Language',
+        through='LanguageQualification',
+        blank=True,
+    )
 
     # new people will be inactive by default
     is_active = models.BooleanField(default=False)
@@ -1104,6 +1109,43 @@ class KnowledgeDomain(models.Model):
 
     def __str__(self):
         return self.name
+
+#------------------------------------------------------------
+
+class Language(models.Model):
+    """A language tag.
+
+    https://tools.ietf.org/html/rfc5646
+    """
+    name = models.CharField(
+        max_length=STR_MED,
+        help_text='Description of this language tag in English')
+    language = models.CharField(
+        max_length=STR_SHORT,
+        help_text=
+            'Primary language subtag.  '
+            'https://tools.ietf.org/html/rfc5646#section-2.2.1')
+
+    def tag(self):
+        return self.language
+
+    def __str__(self):
+        return self.name
+
+
+class LanguageQualification(models.Model):
+    """What language can someone speak?
+
+    https://tools.ietf.org/html/rfc7231#section-5.3.5
+    """
+    person = models.ForeignKey(Person)
+    language = models.ForeignKey(Language)
+    weight = models.FloatField(
+        default=1,
+        help_text='https://tools.ietf.org/html/rfc7231#section-5.3.1')
+
+    def __str__(self):
+        return '({}, {}, {})'.format(self.person, self.language, self.weight)
 
 # ------------------------------------------------------------
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -780,6 +780,10 @@ class Event(AssignmentMixin, models.Model):
         super(Event, self).save(*args, **kwargs)
 
 
+def get_english():
+    return Language.objects.get(language='en').pk
+
+
 class EventRequest(AssignmentMixin, models.Model):
     active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -804,11 +808,11 @@ class EventRequest(AssignmentMixin, models.Model):
                   'to accommodate those requests.',
         verbose_name='Preferred workshop dates',
     )
-    language = models.CharField(
-        max_length=STR_LONG,
+    language = models.ForeignKey(
+        'Language',
         verbose_name='What human language do you want the workshop to be run'
                      ' in?',
-        blank=True, default='English',
+        blank=True, default=get_english,
     )
 
     WORKSHOP_TYPE_CHOICES = (

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -74,6 +74,17 @@
     {% else %}
     <h5>No tasks.</h5>
     {% endif %}
+
+    {% if language_qualifications %}
+    <h5>Languages:</h5>
+    <ul>
+      {% for lang in language_qualifications %}
+      <li>{{ lang.language }} ({{lang.weight}})</li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <h5>No languages.</h5>
+    {% endif %}
   </div>
 
   <div class="col-sm-6">

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1387,6 +1387,11 @@ def instructors(request):
                     airport__country__in=data['country']
                 ).order_by('family')
 
+            if data['language']:
+                instructors = instructors.filter(
+                    languagequalification__language=data['language'],
+                    languagequalification__weight__gte=0.5)
+
             if data['gender']:
                 instructors = instructors.filter(gender=data['gender'])
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -437,6 +437,7 @@ def person_details(request, person_id):
     tasks = person.task_set.all()
     lessons = person.lessons.all()
     domains = person.domains.all()
+    language_qualifications = person.languagequalification_set.all()
     context = {
         'title': 'Person {0}'.format(person),
         'person': person,
@@ -444,6 +445,7 @@ def person_details(request, person_id):
         'tasks': tasks,
         'lessons': lessons,
         'domains': domains,
+        'language_qualifications': language_qualifications,
     }
     return render(request, 'workshops/person.html', context)
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -41,6 +41,7 @@ from workshops.models import (
     Badge,
     Event,
     Qualification,
+    LanguageQualification,
     Lesson,
     Person,
     Role,
@@ -634,6 +635,10 @@ class PersonCreate(LoginRequiredMixin, PermissionRequiredMixin,
         for lesson in form.cleaned_data['lessons']:
             Qualification.objects.create(lesson=lesson, person=self.object)
 
+        for language in form.cleaned_data['languages']:
+            LanguageQualification.objects.create(
+                person=self.object, language=language)
+
         # Important: we need to use ModelFormMixin.form_valid() here!
         # But by doing so we omit SuccessMessageMixin completely, so we need to
         # simulate it.  The code below is almost identical to
@@ -710,7 +715,7 @@ def person_edit(request, person_id):
                                extra_tags='tasks')
 
         else:
-            person_form = PersonForm(request.POST, prefix='person',
+            person_form = PersonForm(data=request.POST, prefix='person',
                                      instance=person)
             if person_form.is_valid():
                 lessons = person_form.cleaned_data['lessons']
@@ -724,6 +729,11 @@ def person_edit(request, person_id):
 
                 # don't save related lessons
                 del person_form.cleaned_data['lessons']
+
+                LanguageQualification.objects.filter(person=person).delete()
+                for language in person_form.cleaned_data['languages']:
+                    LanguageQualification.objects.create(
+                        person=person, language=language)
 
                 person = person_form.save()
 


### PR DESCRIPTION
Based on [a very restricted subset][1] of [RFC 5646][2].  This will
allow us to match instructors (and potentially students) with events
in an appropriate language.

As of the current tip (63fa782), this stores language ↔ person
associations, but doesn't currently allow you to edit weights (the
database has weights, but the UI doesn't provide a way to edit them,
and will clobber with 1s on person-edit).

There's currently no support for @pbanaszkiewicz's [requested][3]:

* store event language in events
* ask for the language in profile update form

I'm not familiar enough with the latter to know how to handle it.  Do
I have to do anything besides updating ProfileUpdateRequest?  I looked
around briefly for a template that we email instructors, since that
probably needs to be updated to list the languages we know about, but
couldn't find anything.  Can anyone give me some pointers or a refence
to docs or previous similar work?

I haven't stored event languages, because I expect there's not much
use for this information after the event is setup.  The EventRequest
form now uses a many-to-many language table, so we don't have to parse
user-entered languages.  And once the EventRequest is translated into
an Event, the language bits have already taken care of themselves
(unless we want to list them on out upcoming events feed?)

So this is a bit of a work-in-progress, but I think it's far enough
along to get some feedback ;).

[1]: https://github.com/swcarpentry/amy/issues/582#issuecomment-158678235
[2]: https://tools.ietf.org/html/rfc5646
[3]: https://github.com/swcarpentry/amy/issues/582#issuecomment-158628490