### PR TITLE
workshop/forms.py: change some fields' widgets to TextInput

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -2,7 +2,7 @@ import re
 
 from django import forms
 from django.core.validators import RegexValidator
-from django.forms import HiddenInput, CheckboxSelectMultiple
+from django.forms import HiddenInput, CheckboxSelectMultiple, TextInput
 
 from captcha.fields import ReCaptchaField
 from crispy_forms.helper import FormHelper
@@ -258,7 +258,7 @@ class EventForm(forms.ModelForm):
     )
 
     admin_fee = forms.DecimalField(min_value=0, decimal_places=2,
-                                   required=False)
+                                   required=False, widget=TextInput)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -310,6 +310,12 @@ class EventForm(forms.ModelForm):
                   'country', 'venue', 'address', 'latitude', 'longitude')
         # WARNING: don't change put any fields between 'country' and
         #          'longitude' that don't relate to the venue of the event
+
+        widgets = {
+            'attendance': TextInput,
+            'latitude': TextInput,
+            'longitude': TextInput,
+        }
 
     class Media:
         # thanks to this, {{ form.media }} in the template will generate


### PR DESCRIPTION
This fixes #559 by changing default widgets to TextInput for these
fields:

* admin_fee
* attendance
* latitude
* longitude.

Unfortunately the `admin_fee` field's declaration is more important
than Meta.widgets content so the widget for admin_fee had to be
overwritten in the declaration.

Let me just add that the reason for this change is that under MacOS the HTML5 widgets can change value upon scrolling over them. This is not the case for Linux, and certainly not for Windows, but our admins use MacOSX so…