### PR TITLE
API: return members' usernames

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -12,12 +12,12 @@ class PersonUsernameSerializer(serializers.ModelSerializer):
         fields = ('name', 'user', )
 
 
-class PersonNameEmailSerializer(serializers.ModelSerializer):
+class PersonNameEmailUsernameSerializer(serializers.ModelSerializer):
     name = serializers.CharField(source='get_full_name')
 
     class Meta:
         model = Person
-        fields = ('name', 'email')
+        fields = ('name', 'email', 'username')
 
 
 class ExportBadgesSerializer(serializers.ModelSerializer):

--- a/api/test/test_export.py
+++ b/api/test/test_export.py
@@ -170,7 +170,8 @@ class TestExportingMembers(BaseExportingTest):
         self.expecting = [
             {
                 'name': 'Peter Q. Parker',
-                'email': 'peter@webslinger.net'
+                'email': 'peter@webslinger.net',
+                'username': 'spiderman',
             },
         ]
 

--- a/api/views.py
+++ b/api/views.py
@@ -73,7 +73,7 @@ class ExportInstructorLocationsView(ListAPIView):
 
 class ExportMembersView(ListAPIView):
     """Show everyone who qualifies as an SCF member."""
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticated, )
     paginator = None  # disable pagination
 
     serializer_class = PersonNameEmailUsernameSerializer

--- a/api/views.py
+++ b/api/views.py
@@ -14,7 +14,7 @@ from workshops.models import Badge, Airport, Event, TodoItem, Tag
 from workshops.util import get_members, default_membership_cutoff
 
 from .serializers import (
-    PersonNameEmailSerializer,
+    PersonNameEmailUsernameSerializer,
     ExportBadgesSerializer,
     ExportInstructorLocationsSerializer,
     EventSerializer,
@@ -76,7 +76,7 @@ class ExportMembersView(ListAPIView):
     permission_classes = (IsAuthenticatedOrReadOnly, )
     paginator = None  # disable pagination
 
-    serializer_class = PersonNameEmailSerializer
+    serializer_class = PersonNameEmailUsernameSerializer
 
     def get_queryset(self):
         earliest_default, latest_default = default_membership_cutoff()


### PR DESCRIPTION
This fixes #604.

The 'export members' view will be accessible only to users who are logged into AMY.