### PR TITLE
API reports

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -102,6 +102,11 @@ class InstructorsOverTimeSerializer(serializers.Serializer):
     count = serializers.IntegerField()
 
 
+class InstructorNumTaughtSerializer(serializers.Serializer):
+    person = PersonNameEmailUsernameSerializer(source='*')
+    num_taught = serializers.IntegerField()
+
+
 # ----------------------
 # "new" API starts below
 # ----------------------

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -155,17 +155,24 @@ class PersonSerializer(serializers.ModelSerializer):
         lookup_field='pk',
         lookup_url_kwarg='person_pk',
     )
+    tasks = serializers.HyperlinkedIdentityField(
+        view_name='api:person-tasks-list',
+        lookup_field='pk',
+        lookup_url_kwarg='person_pk',
+    )
 
     class Meta:
         model = Person
         fields = (
             'personal', 'middle', 'family', 'email', 'gender', 'may_contact',
             'airport', 'github', 'twitter', 'url', 'username', 'notes',
-            'affiliation', 'badges', 'lessons', 'domains', 'awards',
+            'affiliation', 'badges', 'lessons', 'domains', 'awards', 'tasks',
         )
 
 
 class TaskSerializer(serializers.ModelSerializer):
+    event = serializers.HyperlinkedRelatedField(
+        read_only=True, view_name='api:event-detail', lookup_field='slug')
     person = serializers.HyperlinkedRelatedField(
         read_only=True, view_name='api:person-detail')
     role = serializers.SlugRelatedField(
@@ -173,7 +180,7 @@ class TaskSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Task
-        fields = ('person', 'role')
+        fields = ('event', 'person', 'role')
 
 
 class TodoSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -91,6 +91,17 @@ class TimelineTodoSerializer(serializers.ModelSerializer):
             todo=obj.title,
         )
 
+
+class WorkshopsOverTimeSerializer(serializers.Serializer):
+    date = serializers.DateField(format=None, source='start')
+    count = serializers.IntegerField()
+
+
+class InstructorsOverTimeSerializer(serializers.Serializer):
+    date = serializers.DateField(format=None, source='awarded')
+    count = serializers.IntegerField()
+
+
 # ----------------------
 # "new" API starts below
 # ----------------------

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -103,7 +103,9 @@ class InstructorsOverTimeSerializer(serializers.Serializer):
 
 
 class InstructorNumTaughtSerializer(serializers.Serializer):
-    person = PersonNameEmailUsernameSerializer(source='*')
+    person = serializers.HyperlinkedRelatedField(
+        read_only=True, view_name='api:person-detail', lookup_field='pk',
+        source='*')
     num_taught = serializers.IntegerField()
 
 

--- a/api/test/test_api_structure.py
+++ b/api/test/test_api_structure.py
@@ -51,12 +51,14 @@ class TestAPIStructure(APITestCase):
         #   → todos
         # → hosts
         # → airports
+        # → reports
         index = self.client.get(reverse('api:root'))
         index_links = {
             'person-list': reverse('api:person-list'),
             'event-list': reverse('api:event-list'),
             'host-list': reverse('api:host-list'),
             'airport-list': reverse('api:airport-list'),
+            'reports-list': reverse('api:reports-list'),
         }
         for endpoint, link in index_links.items():
             self.assertIn(link, index.data[endpoint])
@@ -78,6 +80,24 @@ class TestAPIStructure(APITestCase):
         for endpoint, link in event_links.items():
             self.assertIn(link, event.data[endpoint])
 
+    def test_structure_for_reports(self):
+        """Ensure we have good links to all the reports."""
+        reports = self.client.get(reverse('api:reports-list'))
+        reports_links = {
+            'reports-all-activity-over-time':
+                reverse('api:reports-all-activity-over-time'),
+            'reports-instructor-num-taught':
+                reverse('api:reports-instructor-num-taught'),
+            'reports-instructors-over-time':
+                reverse('api:reports-instructors-over-time'),
+            'reports-learners-over-time':
+                reverse('api:reports-learners-over-time'),
+            'reports-workshops-over-time':
+                reverse('api:reports-workshops-over-time'),
+        }
+        for endpoint, link in reports_links.items():
+            self.assertIn(link, reports.data[endpoint])
+
     def test_links_between_resources(self):
         # event
         #   → host-detail (via host, administrator)
@@ -91,6 +111,7 @@ class TestAPIStructure(APITestCase):
         # person
         #   → airport-detail
         #   → award-list
+        #   → task-list
         # airport (no links)
         # award
         #   → event-detail
@@ -122,6 +143,7 @@ class TestAPIStructure(APITestCase):
             'airport': reverse('api:airport-detail',
                                args=[self.admin.airport.iata]),
             'awards': reverse('api:person-awards-list', args=[self.admin.pk]),
+            'tasks': reverse('api:person-tasks-list', args=[self.admin.pk]),
         }
         for attr, link in person_links.items():
             self.assertIn(link, person.data[attr])

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,10 @@ router.register('reports', views.ReportsViewSet, base_name='reports')
 router.register('persons', views.PersonViewSet)
 awards_router = routers.NestedSimpleRouter(router, 'persons', lookup='person')
 awards_router.register('awards', views.AwardViewSet, base_name='person-awards')
+person_task_router = routers.NestedSimpleRouter(router, 'persons',
+                                                lookup='person')
+person_task_router.register('tasks', views.PersonTaskViewSet,
+                            base_name='person-tasks')
 router.register('events', views.EventViewSet)
 tasks_router = routers.NestedSimpleRouter(router, 'events', lookup='event')
 tasks_router.register('tasks', views.TaskViewSet, base_name='event-tasks')
@@ -39,6 +43,7 @@ urlpatterns = [
 
     url('^', include(router.urls)),
     url('^', include(awards_router.urls)),
+    url('^', include(person_task_router.urls)),
     url('^', include(tasks_router.urls)),
     url('^', include(todos_router.urls)),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,6 +6,7 @@ from . import views
 
 # routers generate URLs for methods like `.list` or `.retrieve`
 router = routers.SimpleRouter()
+router.register('reports', views.ReportsViewSet, base_name='reports')
 router.register('persons', views.PersonViewSet)
 awards_router = routers.NestedSimpleRouter(router, 'persons', lookup='person')
 awards_router.register('awards', views.AwardViewSet, base_name='person-awards')
@@ -35,6 +36,7 @@ urlpatterns = [
     url('^todos/user/$',
         views.UserTodoItems.as_view(),
         name='user-todos'),
+
     url('^', include(router.urls)),
     url('^', include(awards_router.urls)),
     url('^', include(tasks_router.urls)),

--- a/api/views.py
+++ b/api/views.py
@@ -403,6 +403,14 @@ class ReportsViewSet(ViewSet):
             }
         })
 
+    # TODO: implement once #649 is merged
+    # @list_route(methods=['GET'])
+    # def instructor_activity_over_time(self, request, format=None):
+    #     """Who our instructors are, and they did, and with whom."""
+    #     # this is API endpoint for our `instructors_activity` management
+    #     # command
+    #     pass
+
 
 # ----------------------
 # "new" API starts below

--- a/api/views.py
+++ b/api/views.py
@@ -336,8 +336,8 @@ class ReportsViewSet(ViewSet):
         swc_dc_workshops = events_qs.filter(tags__in=[swc_tag, dc_tag]).count()
         wise_workshops = events_qs.filter(tags=wise_tag).count()
         ttt_workshops = events_qs.filter(tags=TTT_tag).count()
-        self_organized_workshops = events_qs.filter(host=self_organized_host) \
-                                            .count()
+        self_organized_workshops = events_qs \
+            .filter(administrator=self_organized_host).count()
 
         # total and unique instructors
         total_instructors = Person.objects \

--- a/api/views.py
+++ b/api/views.py
@@ -90,6 +90,8 @@ class ApiRoot(APIView):
                                         request=request, format=format),
             'user-todos': reverse('api:user-todos',
                                   request=request, format=format),
+            'reports-list': reverse('api:reports-list',
+                                    request=request, format=format),
 
             # "new" API list-type endpoints below
             'airport-list': reverse('api:airport-list', request=request,
@@ -425,6 +427,26 @@ class ReportsViewSet(ViewSet):
     #     # this is API endpoint for our `instructors_activity` management
     #     # command
     #     pass
+
+    def list(self, request, format=None):
+        """Display list of links to the reports."""
+        return Response({
+            'reports-all-activity-over-time': reverse(
+                'api:reports-all-activity-over-time', request=request,
+                format=format),
+            'reports-instructor-num-taught': reverse(
+                'api:reports-instructor-num-taught', request=request,
+                format=format),
+            'reports-instructors-over-time': reverse(
+                'api:reports-instructors-over-time', request=request,
+                format=format),
+            'reports-learners-over-time': reverse(
+                'api:reports-learners-over-time', request=request,
+                format=format),
+            'reports-workshops-over-time': reverse(
+                'api:reports-workshops-over-time', request=request,
+                format=format),
+        })
 
 
 # ----------------------

--- a/api/views.py
+++ b/api/views.py
@@ -305,9 +305,8 @@ class ReportsViewSet(ViewSet):
                 )
             )
         ).filter(may_contact=True).order_by('-num_taught')
-        # for now it uses a very simple person serializer
-        # TODO: use hyperlinks once #649 is merged
-        serializer = InstructorNumTaughtSerializer(persons, many=True)
+        serializer = InstructorNumTaughtSerializer(
+            persons, many=True, context=dict(request=request))
         return Response(serializer.data)
 
     def _default_start_end_dates(self):
@@ -375,8 +374,11 @@ class ReportsViewSet(ViewSet):
         dc_total_learners = dc_workshops.aggregate(count=Sum('attendance'))
         dc_total_learners = dc_total_learners['count']
 
-        # workshops missing any of this data
-        # TODO: use hyperlinks once #649 is merged
+        # Workshops missing any of this data.
+        # There's no point in using hyperlinks here, because it would:
+        # a) require using reverse() unless we somehow managed to switch to
+        #    serializer for this view
+        # b) make JS part even harder (what is available right now just works)
         missing_attendance = events_qs.filter(attendance=None) \
                                       .values_list('slug', flat=True)
         missing_instructors = events_qs.annotate(

--- a/bower.json
+++ b/bower.json
@@ -69,6 +69,7 @@
     "bootstrap": "^3.3.4",
     "bootstrap-datepicker": "^1.5.0",
     "jquery": "^2.1.3",
-    "vis": "~4.10.0"
+    "vis": "~4.10.0",
+    "metrics-graphics": "~2.8.0"
   }
 }

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -51,6 +51,7 @@
                 {% navbar_element "Learners over time" "learners_over_time" %}
                 {% navbar_element "Instructors over time" "instructors_over_time" %}
                 {% navbar_element "How often instructors have taught" "instructor_num_taught" %}
+                {% navbar_element "All activity over time" "all_activity_over_time" %}
                 <li class="divider"></li>
                 {% navbar_element "Workshop issues" "workshop_issues" %}
                 {% navbar_element "Instructor issues" "instructor_issues" %}

--- a/workshops/templates/workshops/all_activity_over_time.html
+++ b/workshops/templates/workshops/all_activity_over_time.html
@@ -1,0 +1,95 @@
+{% extends "workshops/_page.html" %}
+
+{% load static %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-12">
+    <p>
+      <a href="{{ api_endpoint }}">API link</a>.
+    </p>
+
+    <form class="form-inline" action="{{ api_endpoint }}" method="GET" id="form">
+      <div class="form-group">
+        <label for="id_start">Start date:</label>
+        <input type="date" class="form-control" id="id_start" name="start">
+      </div>
+      <div class="form-group">
+        <label for="id_end">End date:</label>
+        <input type="date" class="form-control" id="id_end" name="end">
+      </div>
+      <input type="hidden" name="format" value="json" />
+      <input type="submit" class="btn btn-default" value="Submit" />
+    </form>
+
+    <h3>Results</h3>
+    <dl>
+      <dt>Total number of instructors who taught in this period:</dt>
+      <dd id="instructors_total">None</dd>
+      <dt>Number of unique instructors who taught in this period:</dt>
+      <dd id="instructors_unique">None</dd>
+      <dt>Total number of learners:</dt>
+      <dd id="learners_total">None</dd>
+      <dt>Number of SWC workshops:</dt>
+      <dd id="workshops_SWC">None</dd>
+      <dt>Number of DC workshops:</dt>
+      <dd id="workshops_DC">None</dd>
+      <dt>Number of SWC or DC workshops:</dt>
+      <dd id="workshops_SWCDC">None</dd>
+      <dt>Number of TTT workshops:</dt>
+      <dd id="workshops_TTT">None</dd>
+      <dt>Number of WiSE workshops:</dt>
+      <dd id="workshops_WiSE">None</dd>
+      <dt>Number of self-organized workshops:</dt>
+      <dd id="workshops_self-organized">None</dd>
+      <dt>Workshops with missing instructors:</dt>
+      <dd id="missing_instructors">None</dd>
+      <dt>Workshops with missing attendance:</dt>
+      <dd id="missing_attendance">None</dd>
+    </dl>
+  </div>
+</div>
+{% endblock %}
+
+{% block extrajs %}
+  <script type="text/javascript" src="{% static 'calendar_popup.js' %}"></script>
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('#form').submit(function(e) {
+        var form = $(e.target);
+        $.ajax({
+          type: form.attr('method'),
+          url: form.attr('action'),
+          data: form.serialize(),
+          success: function(data) {
+            // go through level 1 of our structure
+            for (var name in data) {
+
+              // ignore elements 'start' and 'end'
+              if (!(name == "start" || name == "end")) {
+
+                // go through level 2 of our structure
+                for (var subname in data[name]) {
+
+                  // subelements usually have a number or string as their value
+                  var content = data[name][subname];
+
+                  // two subelements have arrays as their values
+                  if (data[name][subname] instanceof Array) {
+                    content = data[name][subname].join(', ');
+                  }
+
+                  // construct ID of <dd> that will have its content replaced
+                  var element = '#' + name + '_' + (subname.replace(',', ''));
+
+                  $(element).text(content);
+                }
+              }
+            }
+          }
+        });
+        return false;
+      });
+    });
+  </script>
+{% endblock %}

--- a/workshops/templates/workshops/all_activity_over_time.html
+++ b/workshops/templates/workshops/all_activity_over_time.html
@@ -24,12 +24,6 @@
 
     <h3>Results</h3>
     <dl>
-      <dt>Total number of instructors who taught in this period:</dt>
-      <dd id="instructors_total">None</dd>
-      <dt>Number of unique instructors who taught in this period:</dt>
-      <dd id="instructors_unique">None</dd>
-      <dt>Total number of learners:</dt>
-      <dd id="learners_total">None</dd>
       <dt>Number of SWC workshops:</dt>
       <dd id="workshops_SWC">None</dd>
       <dt>Number of DC workshops:</dt>
@@ -42,6 +36,22 @@
       <dd id="workshops_WiSE">None</dd>
       <dt>Number of self-organized workshops:</dt>
       <dd id="workshops_self-organized">None</dd>
+
+      <dt>Total number of instructors in SWC workshops:</dt>
+      <dd id="instructors_SWC_total">None</dd>
+      <dt>Number of unique instructors in SWC workshops:</dt>
+      <dd id="instructors_SWC_unique">None</dd>
+
+      <dt>Total number of instructors in DC workshops:</dt>
+      <dd id="instructors_DC_total">None</dd>
+      <dt>Number of unique instructors in DC workshops:</dt>
+      <dd id="instructors_DC_unique">None</dd>
+
+      <dt>Total number of learners in SWC workshops:</dt>
+      <dd id="learners_SWC">None</dd>
+      <dt>Total number of learners in DC workshops:</dt>
+      <dd id="learners_DC">None</dd>
+
       <dt>Workshops with missing instructors:</dt>
       <dd id="missing_instructors">None</dd>
       <dt>Workshops with missing attendance:</dt>
@@ -71,18 +81,32 @@
                 // go through level 2 of our structure
                 for (var subname in data[name]) {
 
-                  // subelements usually have a number or string as their value
-                  var content = data[name][subname];
+                  var content = '', element = '';
 
-                  // two subelements have arrays as their values
-                  if (data[name][subname] instanceof Array) {
-                    content = data[name][subname].join(', ');
+                  if (!(data[name][subname] instanceof Array || typeof data[name][subname] == 'string' || typeof data[name][subname] == 'number')) {
+                    // TL;DR: JavaScript sucks. Instead of checking if we're
+                    // dealing with object here I check if we're dealing with
+                    // something that isn't an Array, a string or a number --
+                    // because for example an Array is an Object in JavaScript!
+
+                    // go through level 3 of our structure
+                    for (var subsubname in data[name][subname]) {
+                      content = data[name][subname][subsubname];
+                      element = '#' + Array(name, subname, subsubname).join('_');
+                      $(element).text(content);
+                    }
+                  } else {
+
+                    // some subelements have arrays as their values
+                    if (data[name][subname] instanceof Array) {
+                      content = data[name][subname].join(', ');
+                    } else {
+                      content = data[name][subname];
+                    }
+
+                    element = '#' + Array(name, subname.replace(',', '')).join('_');
+                    $(element).text(content);
                   }
-
-                  // construct ID of <dd> that will have its content replaced
-                  var element = '#' + name + '_' + (subname.replace(',', ''));
-
-                  $(element).text(content);
                 }
               }
             }

--- a/workshops/templates/workshops/instructor_num_taught.html
+++ b/workshops/templates/workshops/instructor_num_taught.html
@@ -1,6 +1,18 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
-<pre>{% for a in awards %}
-{{a.num_taught}},{{a.person.get_full_name}},{{a.person.email}},{{a.awarded|date:"Y-m-d"}},{{a.person.gender}},{% if a.person.airport %}{{a.person.airport.country}}{% else %}-{% endif %}{% endfor %}</pre>
+<p>
+  <a href="{{ api_endpoint }}">API link</a>.
+</p>
+<pre id="source"></pre>
+{% endblock %}
+
+{% block extrajs %}
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $.get('{{ api_endpoint }}?format=json', function(data) {
+        $('#source').text(data);
+      }, "html");
+    });
+  </script>
 {% endblock %}

--- a/workshops/templates/workshops/instructor_num_taught.html
+++ b/workshops/templates/workshops/instructor_num_taught.html
@@ -10,8 +10,12 @@
 {% block extrajs %}
   <script type="text/javascript">
     $(document).ready(function() {
-      $.get('{{ api_endpoint }}?format=json', function(data) {
-        $('#source').text(data);
+      $.getJSON('{{ api_endpoint }}?format=json', function(data) {
+        var items = [];
+        $.each(data, function(record, value) {
+            items.push(value.person + ": " + value.num_taught);
+        });
+        $('#source').text(items.join("\n"));
       }, "html");
     });
   </script>

--- a/workshops/templates/workshops/time_series.html
+++ b/workshops/templates/workshops/time_series.html
@@ -1,9 +1,33 @@
 {% extends "workshops/_page.html" %}
 
+{% load static %}
+
 {% block content %}
-{% if data %}
-<pre>{{data}}</pre>
-{% else %}
-<p>Error: no such data.</p>
-{% endif %}
+<p>
+  <a href="{{ api_endpoint }}">API link</a>.
+</p>
+<div id='chart'></div>
+{% endblock %}
+
+{% block extrastyle %}
+    <link rel="stylesheet" href="{% static 'metrics-graphics/dist/metricsgraphics.css' %}" />
+{% endblock %}
+{% block extrajs %}
+    <script src="{% static 'd3/d3.min.js' %}"></script>
+    <script src="{% static 'metrics-graphics/dist/metricsgraphics.js' %}"></script>
+
+    <script type="text/javascript">
+        d3.json('{{ api_endpoint }}?format=json', function(data) {
+            data = MG.convert.date(data, 'date');
+            MG.data_graphic({
+                title: "{{ title }}",
+                data: data,
+                width: 800,
+                height: 600,
+                target: document.getElementById('chart'),
+                x_accessor: 'date',
+                y_accessor: 'count'
+            });
+        });
+    </script>
 {% endblock %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -72,6 +72,7 @@ urlpatterns = [
     url(r'^reports/learners_over_time/?$', views.learners_over_time, name='learners_over_time'),
     url(r'^reports/instructors_over_time/?$', views.instructors_over_time, name='instructors_over_time'),
     url(r'^reports/instructor_num_taught/?$', views.instructor_num_taught, name='instructor_num_taught'),
+    url(r'^reports/all_activity_over_time/?$', views.all_activity_over_time, name='all_activity_over_time'),
     url(r'^reports/workshop_issues/?$', views.workshop_issues, name='workshop_issues'),
     url(r'^reports/instructor_issues/?$', views.instructor_issues, name='instructor_issues'),
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1571,23 +1571,11 @@ def instructors_over_time(request):
 
 @login_required
 def instructor_num_taught(request):
-    '''Export CSV of how often instructors have taught.'''
-
-    badges = Badge.objects.instructor_badges()
-    awards = Award.objects.filter(badge__in=badges).annotate(
-        num_taught=Count(
-            Case(
-                When(
-                    person__task__role__name='instructor',
-                    then=Value(1)
-                ),
-                output_field=IntegerField()
-            )
-        )
-    ).select_related('person', 'person__airport') \
-     .filter(person__may_contact=True).order_by('-num_taught', 'awarded')
-    context = {'title': 'Frequency of Instruction',
-               'awards': awards}
+    '''Export JSON of how often instructors have taught.'''
+    context = {
+        'api_endpoint': reverse('api:reports-instructor-num-taught'),
+        'title': 'Frequency of Instruction',
+    }
     return render(request, 'workshops/instructor_num_taught.html', context)
 
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1541,7 +1541,7 @@ def export_members(request):
 
 @login_required
 def workshops_over_time(request):
-    '''Export CSV of count of workshops vs. time.'''
+    '''Export JSON of count of workshops vs. time.'''
     context = {
         'api_endpoint': reverse('api:reports-workshops-over-time'),
         'title': 'Workshops over time',
@@ -1551,7 +1551,7 @@ def workshops_over_time(request):
 
 @login_required
 def learners_over_time(request):
-    '''Export CSV of count of learners vs. time.'''
+    '''Export JSON of count of learners vs. time.'''
     context = {
         'api_endpoint': reverse('api:reports-learners-over-time'),
         'title': 'Learners over time',
@@ -1561,7 +1561,7 @@ def learners_over_time(request):
 
 @login_required
 def instructors_over_time(request):
-    '''Export CSV of count of instructors vs. time.'''
+    '''Export JSON of count of instructors vs. time.'''
     context = {
         'api_endpoint': reverse('api:reports-instructors-over-time'),
         'title': 'Instructors over time',

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1542,34 +1542,31 @@ def export_members(request):
 @login_required
 def workshops_over_time(request):
     '''Export CSV of count of workshops vs. time.'''
-
-    data = dict(Event.objects
-                     .past_events()
-                     .values_list('start')
-                     .annotate(Count('id')))
-    return _time_series(request, data, 'Workshop over time')
+    context = {
+        'api_endpoint': reverse('api:reports-workshops-over-time'),
+        'title': 'Workshops over time',
+    }
+    return render(request, 'workshops/time_series.html', context)
 
 
 @login_required
 def learners_over_time(request):
     '''Export CSV of count of learners vs. time.'''
-
-    data = dict(Event.objects
-                     .past_events()
-                     .values_list('start')
-                     .annotate(Sum('attendance')))
-    return _time_series(request, data, 'Learners over time')
+    context = {
+        'api_endpoint': reverse('api:reports-learners-over-time'),
+        'title': 'Learners over time',
+    }
+    return render(request, 'workshops/time_series.html', context)
 
 
 @login_required
 def instructors_over_time(request):
     '''Export CSV of count of instructors vs. time.'''
-
-    badges = Badge.objects.instructor_badges()
-    data = dict(Award.objects.filter(badge__in=badges)
-                     .values_list('awarded')
-                     .annotate(Count('person__id')))
-    return _time_series(request, data, 'Instructors over time')
+    context = {
+        'api_endpoint': reverse('api:reports-instructors-over-time'),
+        'title': 'Instructors over time',
+    }
+    return render(request, 'workshops/time_series.html', context)
 
 
 @login_required
@@ -1748,27 +1745,6 @@ def _get_pagination_items(request, all_objects):
         result = paginator.page(paginator.num_pages)
 
     return result
-
-
-def _time_series(request, data, title):
-    '''Prepare time-series data for display and render it.'''
-
-    # Make sure addition will work.
-    for key in data:
-        if data[key] is None:
-            data[key] = 0
-
-    # Create running total.
-    data = list(data.items())
-    data.sort()
-    for i in range(1, len(data)):
-        data[i] = (data[i][0], data[i][1] + data[i-1][1])
-
-    # Textualize and display.
-    data = '\n'.join(['{0},{1}'.format(*d) for d in data])
-    context = {'title': title,
-               'data': data}
-    return render(request, 'workshops/time_series.html', context)
 
 
 def _failed_to_delete(request, object, protected_objects, back=None):

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1592,6 +1592,17 @@ def instructor_num_taught(request):
 
 
 @login_required
+def all_activity_over_time(request):
+    """Display number of workshops (of differend kinds), instructors and
+    learners over some specific period of time."""
+    context = {
+        'api_endpoint': reverse('api:reports-all-activity-over-time'),
+        'title': 'All activity over time',
+    }
+    return render(request, 'workshops/all_activity_over_time.html', context)
+
+
+@login_required
 def workshop_issues(request):
     '''Display workshops in the database whose records need attention.'''
 


### PR DESCRIPTION
This fixes #631 by:
* adding an API report with requested data
* adding a web interface for that API request

This fixes #616 by:
* moving `{workshops,instructors,learners}_over_time` to API (as reports)
* adding graphs to their web interfaces
* moving `instructors_num_taught` to API as well (again, as report) - its web interface doesn't change much, though
* moving `instructors_activity` to API (this will be done after WIP)

WIP: I want to merge #649 and then rebase this one as with #649 we may get better serializers+views and use hyperlinked resources in some of the new reports.

EDIT: rebase is done, so now we need to fix all the TODOS in the code.
EDIT: TODOS fixed, but I want to change one report and be done.