### PR TITLE
Debrief: exclude stalled, TTT and unresponsive events from search

### DIFF
--- a/workshops/templates/workshops/debrief.html
+++ b/workshops/templates/workshops/debrief.html
@@ -9,16 +9,16 @@
 <h3>Events happening between {{ start_date }} and {{ end_date }}</h3>
     <table class="table table-striped">
         <tr>
-	    <th>event</th>
-	    <th>person</th>
-	    <td></td>
-	</tr>
+        <th>event</th>
+        <th>person</th>
+        <td></td>
+    </tr>
     {% for task in all_tasks %}
         <tr>
             <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
             <td><a href="{{ task.person.get_absolute_url }}">{{ task.person.get_full_name }}</a>{% if task.person.email and task.person.may_contact %} &lt;{{ task.person.email|urlize }}&gt;{% endif %} (taught {{ task.person.task_set.instructors.count }} times)</a></td>
-	    <td><a href="{% url 'task_details' task.id %}">...</a></td>
-	</tr>
+        <td><a href="{% url 'task_details' task.id %}">...</a></td>
+    </tr>
     {% endfor %}
     </table>
     <a href="mailto:{% for task in all_tasks %}{% if task.person.email %}{{ task.person.email }}{% if not forloop.last %},{% endif %}{% endif %}{% endfor %}">Send email</a>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1483,6 +1483,8 @@ def debrief(request):
 
     start_date = end_date = None
 
+    tags = Tag.objects.filter(name__in=['TTT', 'stalled', 'unresponsive'])
+
     if request.method == 'POST':
         form = DebriefForm(request.POST)
         if form.is_valid():
@@ -1493,7 +1495,8 @@ def debrief(request):
                 event__end__lte=end_date,
                 role__name='instructor',
                 person__may_contact=True,
-            ).order_by('event', 'person', 'role')
+            ).exclude(event__tags=tags).order_by('event', 'person', 'role') \
+             .select_related('person', 'event', 'role')
 
     else:
         # if a GET (or any other method) we'll create a blank form

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1483,7 +1483,7 @@ def debrief(request):
 
     start_date = end_date = None
 
-    tags = Tag.objects.filter(name__in=['TTT', 'stalled', 'unresponsive'])
+    tags = Tag.objects.filter(name__in=['stalled', 'unresponsive'])
 
     if request.method == 'POST':
         form = DebriefForm(request.POST)


### PR DESCRIPTION
Additionally fix indentation in the template (it was tabs, should be
spaces) and speed up the retrieval of related objects (event, person,
role).

This fixes #643.