### PR TITLE
Event: add fields for survey links

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -275,9 +275,21 @@ class EventForm(forms.ModelForm):
         # wrap <div class='panel-body'> within <div class='panel panel-…'>
         self.helper[idx_start].wrap_together(Div,
                                              css_class='panel panel-default')
-        # add <div class='panel-heading'>Venue details</div> inside "div.panel"
+        # add <div class='panel-heading'>Loc. details</div> inside "div.panel"
         self.helper.layout[idx_start].insert(0, Div(HTML('Location details'),
                                                     css_class='panel-heading'))
+
+        id_learners_pre = self.helper['learners_pre'].slice[0][0][0]
+        id_learners_longterm = self.helper['learners_longterm'].slice[0][0][0]
+        # wrap all survey fields within <div class='panel-body'>
+        self.helper[id_learners_pre:id_learners_longterm + 1] \
+            .wrap_together(Div, css_class='panel-body')
+        # wrap <div class='panel-body'> within <div class='panel panel-…'>
+        self.helper[id_learners_pre].wrap_together(
+            Div, css_class='panel panel-default')
+        # add <div class='panel-heading'>Venue details</div> inside "div.panel"
+        self.helper.layout[id_learners_pre].insert(
+            0, Div(HTML('Survey links'), css_class='panel-heading'))
 
     def clean_slug(self):
         # Ensure slug is not an integer value for Event.get_by_ident
@@ -307,7 +319,9 @@ class EventForm(forms.ModelForm):
         fields = ('slug', 'completed', 'start', 'end', 'host', 'administrator',
                   'tags', 'url', 'reg_key', 'admin_fee', 'invoice_status',
                   'attendance', 'contact', 'notes',
-                  'country', 'venue', 'address', 'latitude', 'longitude')
+                  'country', 'venue', 'address', 'latitude', 'longitude',
+                  'learners_pre', 'learners_post', 'instructors_pre',
+                  'instructors_post', 'learners_longterm')
         # WARNING: don't change put any fields between 'country' and
         #          'longitude' that don't relate to the venue of the event
 

--- a/workshops/migrations/0068_auto_20160119_1247.py
+++ b/workshops/migrations/0068_auto_20160119_1247.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0067_person_username_regexvalidator'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='instructors_post',
+            field=models.URLField(verbose_name='Pre-workshop assessment survey for instructors', blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='instructors_pre',
+            field=models.URLField(verbose_name='Pre-workshop assessment survey for instructors', blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='learners_longterm',
+            field=models.URLField(verbose_name='Long-term assessment survey for learners', blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='learners_post',
+            field=models.URLField(verbose_name='Post-workshop assessment survey for learners', blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='learners_pre',
+            field=models.URLField(verbose_name='Pre-workshop assessment survey for learners', blank=True, default=''),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -623,6 +623,23 @@ class Event(AssignmentMixin, models.Model):
         help_text="Indicates that no more work is needed upon this event.",
     )
 
+    # links to the surveys
+    learners_pre = models.URLField(
+        blank=True, default="",
+        verbose_name="Pre-workshop assessment survey for learners")
+    learners_post = models.URLField(
+        blank=True, default="",
+        verbose_name="Post-workshop assessment survey for learners")
+    instructors_pre = models.URLField(
+        blank=True, default="",
+        verbose_name="Pre-workshop assessment survey for instructors")
+    instructors_post = models.URLField(
+        blank=True, default="",
+        verbose_name="Pre-workshop assessment survey for instructors")
+    learners_longterm = models.URLField(
+        blank=True, default="",
+        verbose_name="Long-term assessment survey for learners")
+
     class Meta:
         ordering = ('-start', )
 

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -89,6 +89,28 @@
   <tr class="{% if not event.venue %}bg-danger{% endif %}"><td>Venue:</td><td>{{ event.venue|default:"—" }}</td></tr>
   <tr class="{% if not event.address %}bg-danger{% endif %}"><td>Address:</td><td>{{ event.address|default:"—" }}</td></tr>
   <tr class="{% if not event.latitude or not event.longitude %}bg-danger{% endif %}"><td>Lat/long:</td><td>{{ event.latitude|default:"—" }} / {{ event.longitude|default:"—" }} {% if event.latitude and event.longitude %}<a href="{% url 'instructors' %}?latitude={{ event.latitude }}&amp;longitude={{ event.longitude }}&amp;submit=Submit" class="btn btn-primary btn-xs pull-right" id="find_closest_instructors">find closest instructors</a>{% else %}<a class="btn btn-danger btn-xs pull-right" id="error_closest_instructors" href="#" data-toggle="popover" data-trigger="focus" title="Search error" data-content="Cannot search for closest instructors without latitude and longitude of event's location.">Error</a>{% endif %}</td></tr>
+
+  <tr>
+    <td rowspan="5">survey links:</td>
+    <td>pre workshop for learners:</td>
+    <td>{{ event.learners_pre|default:"—"|urlize }}</td>
+  </tr>
+  <tr>
+    <td>post workshop for learners:</td>
+    <td>{{ event.learners_post|default:"—"|urlize }}</td>
+  </tr>
+  <tr>
+    <td>pre workshop for instructors:</td>
+    <td>{{ event.instructors_pre|default:"—"|urlize }}</td>
+  </tr>
+  <tr>
+    <td>post workshop for instructors:</td>
+    <td>{{ event.instructors_post|default:"—"|urlize }}</td>
+  </tr>
+  <tr>
+    <td>long-term for learners:</td>
+    <td>{{ event.learners_longterm|default:"—"|urlize }}</td>
+  </tr>
 </table>
 
 {% if event.url %}


### PR DESCRIPTION
This fixes #578.

The new fields are displayed in the table on event details page.
On the event-edit page, the fields are wrapped together into
a nice-looking container, which should help separate them visually.