### PR TITLE
Workshop-issues: add filtering by assignment

### DIFF
--- a/workshops/templates/workshops/workshop_issues.html
+++ b/workshops/templates/workshops/workshop_issues.html
@@ -1,68 +1,85 @@
 {% extends "workshops/_page.html" %}
 
 {% block content %}
-{% if events %}
-<p><span class="glyphicon glyphicon-envelope"></span> = mail instructors and host about problem</p>
-<p><span class="glyphicon glyphicon-remove"></span> = no email addresses available</p>
-<table class="table table-striped">
-  <tr>
-    <th>Event</th>
-    <th>Attendance <a href="#" data-toggle="tooltip" title="Number of attendees is missing">[?]</a></th>
-    <th>Location <a href="#" data-toggle="tooltip" title="Country, venue, address or lat/long are missing">[?]</a></th>
-    <th>Dates <a href="#" data-toggle="tooltip" title="Start date is in future of end date">[?]</a></th>
-  </tr>
-  {% for event in events %}
-  <tr>
-    <td>
-      <a href="{% url 'event_details' event.get_ident %}">{{ event }}</a>
-    </td>
-    <td>
-      {% if event.missing_attendance_ %}
-        {% if event.mailto %}
-          <a href="{% include 'workshops/attendance_email_href.html' with event=event %}">
-          <span class="glyphicon glyphicon-envelope"></span>
-          </a>
-        {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
-        {% endif %}
-      {% endif %}
-    </td>
-    <td>
-      {% if event.missing_location_ %}
-        {% if event.mailto %}
-          <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Missing location for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
+
+{% if is_admin or user.is_superuser %}
+<div class="row">
+  <div class="col-xs-12">
+    <div class="btn-group" role="group" aria-label="Events assignment">
+      <a href="?assigned_to=me" class="btn btn-default{% if assigned_to == 'me' %} active{% endif %}">Mine</a>
+      <a href="?assigned_to=noone" class="btn btn-default{% if assigned_to == 'noone' %} active{% endif %}">Unassigned</a>
+      <a href="?assigned_to=all" class="btn btn-default{% if assigned_to == 'all' %} active{% endif %}">All</a>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<div class="row">
+  <div class="col-xs-12">
+    {% if events %}
+    <p><span class="glyphicon glyphicon-envelope"></span> = mail instructors and host about problem</p>
+    <p><span class="glyphicon glyphicon-remove"></span> = no email addresses available</p>
+    <table class="table table-striped">
+      <tr>
+        <th>Event</th>
+        <th>Attendance <a href="#" data-toggle="tooltip" title="Number of attendees is missing">[?]</a></th>
+        <th>Location <a href="#" data-toggle="tooltip" title="Country, venue, address or lat/long are missing">[?]</a></th>
+        <th>Dates <a href="#" data-toggle="tooltip" title="Start date is in future of end date">[?]</a></th>
+      </tr>
+      {% for event in events %}
+      <tr>
+        <td>
+          <a href="{% url 'event_details' event.get_ident %}">{{ event }}</a>
+        </td>
+        <td>
+          {% if event.missing_attendance_ %}
+            {% if event.mailto %}
+              <a href="{% include 'workshops/attendance_email_href.html' with event=event %}">
+              <span class="glyphicon glyphicon-envelope"></span>
+              </a>
+            {% else %}
+              <span class="glyphicon glyphicon-remove"></span>
+            {% endif %}
+          {% endif %}
+        </td>
+        <td>
+          {% if event.missing_location_ %}
+            {% if event.mailto %}
+              <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Missing location for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
 
 Can you please send us the location where the {{ event.get_ident }} workshop took place? We need a country, address, venue, and latitude/longitude.
 
 Thanks for your help.{% endfilter %}">
-          <span class="glyphicon glyphicon-envelope"></span>
-          </a>
-        {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
-        {% endif %}
-      {% endif %}
-    </td>
-    <td>
-      {% if event.bad_dates_ %}
-        {% if event.mailto %}
-          <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Bad dates for workshop {{ event.get_ident }}{% endfilter %}&body={% filter urlencode %}Hi,
+              <span class="glyphicon glyphicon-envelope"></span>
+              </a>
+            {% else %}
+              <span class="glyphicon glyphicon-remove"></span>
+            {% endif %}
+          {% endif %}
+        </td>
+        <td>
+          {% if event.bad_dates_ %}
+            {% if event.mailto %}
+              <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Bad dates for workshop {{ event.get_ident }}{% endfilter %}&body={% filter urlencode %}Hi,
 
 Can you please confirm the start and end dates for the workshop {{ event.get_ident }}?
 
 Thanks for your help.{% endfilter %}">
-          <span class="glyphicon glyphicon-envelope"></span>
-          </a>
-        {% else %}
-          <span class="glyphicon glyphicon-remove"></span>
-        {% endif %}
-      {% endif %}
-    </td>
-  </tr>
-  {% endfor %}
-</table>
-{% else %}
-<p>None</p>
-{% endif %}
+              <span class="glyphicon glyphicon-envelope"></span>
+              </a>
+            {% else %}
+              <span class="glyphicon glyphicon-remove"></span>
+            {% endif %}
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+    {% else %}
+    <p>None</p>
+    {% endif %}
+  </div>
+</div>
 {% endblock %}
 
 {% block extrajs %}

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -3,8 +3,9 @@ import cgi
 import datetime
 from io import StringIO
 
+from django.contrib.auth.models import Group
 from django.contrib.sessions.serializers import JSONSerializer
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
 
 from ..models import Host, Event, Role, Person, Task, Badge, Award
@@ -18,6 +19,7 @@ from ..util import (
     validate_tags_from_event_website,
     get_members,
     default_membership_cutoff,
+    assignment_selection,
 )
 
 from .base import TestBase
@@ -846,3 +848,66 @@ class TestMembership(TestBase):
         self.assertNotIn(self.harry, members)  # only teaching in the future
         self.assertIn(self.spiderman, members)  # explicit member
         self.assertEqual(len(members), 1)
+
+
+class TestAssignmentSelection(TestCase):
+    def setUp(self):
+        """Set up RequestFactory and some users with different levels of
+        privileges."""
+        self.factory = RequestFactory()
+        self.superuser = Person.objects.create_superuser(
+            username='superuser', personal='admin', family='admin',
+            email='superuser@superuser', password='superuser')
+        self.admin = Person.objects.create_user(
+            username='admin', personal='admin', family='admin',
+            email='admin@admin', password='admin')
+        self.admin.groups = [Group.objects.get(name='administrators')]
+        self.normal_user = Person.objects.create_user(
+            username='user', personal='typical', family='user',
+            email='typical@user', password='user')
+
+    def test_no_selection_superuser(self):
+        """User is superuser and they selected nothing. The result should be
+        default value for this kind of a user."""
+        request = self.factory.get('/')
+        request.user = self.superuser
+        assignment, is_admin = assignment_selection(request)
+        self.assertEqual(assignment, 'all')
+        self.assertFalse(is_admin)
+
+    def test_no_selection_admin(self):
+        """User is admin and they selected nothing. The result should be
+        default value for this kind of a user."""
+        request = self.factory.get('/')
+        request.user = self.admin
+        assignment, is_admin = assignment_selection(request)
+        self.assertEqual(assignment, 'me')
+        self.assertTrue(is_admin)
+
+    def test_no_selection_normal_user(self):
+        """User is normal user and they selected nothing. The result should be
+        default value for this kind of a user."""
+        request = self.factory.get('/')
+        request.user = self.normal_user
+        assignment, is_admin = assignment_selection(request)
+        self.assertEqual(assignment, 'all')
+        self.assertFalse(is_admin)
+
+    def test_selection_normal_user(self):
+        """User is normal user and they selected self-assigned. This is invalid
+        selection (normal user cannot select anything), so the default option
+        should be returned."""
+        request = self.factory.get('/', {'assigned_to': 'me'})
+        request.user = self.normal_user
+        assignment, is_admin = assignment_selection(request)
+        self.assertEqual(assignment, 'all')
+        self.assertFalse(is_admin)
+
+    def test_selection_privileged_user(self):
+        """User is admin and they selected "not assigned to anyone". Actually
+        for privileged user any selection should make through."""
+        request = self.factory.get('/', {'assigned_to': 'noone'})
+        request.user = self.admin
+        assignment, is_admin = assignment_selection(request)
+        self.assertEqual(assignment, 'noone')
+        self.assertTrue(is_admin)

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -664,3 +664,27 @@ def find_emails(text):
             emails.append('{}@{}'.format(local, domain))
 
     return emails
+
+
+def assignment_selection(request):
+    """Parse `assigned_to` query param depending on the logged-in user."""
+    user = request.user
+    is_admin = user.groups.filter(name='administrators').exists()
+
+    # it's always possible to assign something entirely else
+    # in the `?assigned_to` query param
+
+    if is_admin:
+        # One of the administrators.
+        # They should be presented with their events by default.
+        assigned_to = request.GET.get('assigned_to', 'me')
+
+    elif user.is_superuser:
+        # A superuser.  Should see all events by default
+        assigned_to = request.GET.get('assigned_to', 'all')
+
+    else:
+        # Normal user (for example subcommittee members).
+        assigned_to = 'all'
+
+    return assigned_to, is_admin


### PR DESCRIPTION
This is based off of dashboard's filtering widget (three buttons saying
'Mine | Unassigned | All').
An auxiliary function was introduced to help decide what '?assigned_to'
means depending on user's permissions (it's used in both dashboard
and workshop issues views).

This fixes #609.