### PR TITLE
Dev database: create initial revisions automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ dev_database :
 	rm -f ${APP_DB}
 	${MANAGE} migrate
 	${MANAGE} fake_database
+	${MANAGE} createinitialrevisions
 
 ## superuser    : make a super-user in the database
 superuser :


### PR DESCRIPTION
Initial revisions will be created for objects created in fake_database
command.

This fixes #638.