### PR TITLE
Fix: run migration responsible for changing _ to . in usernames

### DIFF
--- a/workshops/migrations/0072_underscore_usernames_fixed_migration.py
+++ b/workshops/migrations/0072_underscore_usernames_fixed_migration.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def change_dots_to_underscores(apps, schemat_editor):
+    """Replace '.' with '_' in every username."""
+    Person = apps.get_model('workshops', 'Person')
+    persons = Person.objects.filter(username__contains='.')
+    for person in persons:
+        person.username = person.username.replace('.', '_')
+        person.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0071_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(change_dots_to_underscores),
+    ]


### PR DESCRIPTION
The error in previous migration was: even though there was a function
for migrating usernames, the operation for running this function was
never added.

Worse even: we have one server which applied this migration already, so
it was decided to add a new migration (properly this time!).