### PR TITLE
Install CSV renderer in one export view

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -14,8 +14,10 @@ from rest_framework.permissions import (
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
+from rest_framework_csv.renderers import CSVRenderer
 
 from workshops.models import (
     Badge,
@@ -128,6 +130,8 @@ class ExportMembersView(ListAPIView):
     """Show everyone who qualifies as an SCF member."""
     permission_classes = (IsAuthenticated, )
     paginator = None  # disable pagination
+
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [CSVRenderer, ]
 
     serializer_class = PersonNameEmailUsernameSerializer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-reversion>=1.10,<1.11
 diff-match-patch>=20121119
 djangorestframework>=3.3.0,<3.4.0
 djangorestframework-yaml>=1.0.0,<1.1.0
+djangorestframework-csv>=1.4.0,<1.5.0
 django-recaptcha>=1.0.0,<1.1.0
 fake-factory>=0.5.3,<0.6
 drf-nested-routers>=0.11.1,<0.12


### PR DESCRIPTION
Other views can't be rendered with this renderer since they use
a non-flat structure.

This fixes #684.