### PR TITLE
Remove erroring DRF URLs

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -52,10 +52,4 @@ urlpatterns = [
     url('^', include(todos_router.urls)),
 ]
 
-# for login-logout functionality
-urlpatterns += [
-    url(r'^api-auth/',
-        include('rest_framework.urls', namespace='rest_framework')),
-]
-
 urlpatterns = format_suffix_patterns(urlpatterns)  # allow to specify format


### PR DESCRIPTION
For unknown reason they threw NoReverseMatch.

This fixes #682 by removing the URLs (actually removing the inclusion of
these URLs).