### PR TITLE
Show only active events in various places

### DIFF
--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -64,7 +64,7 @@ class EventStateFilter(django_filters.ChoiceFilter):
         # no need to check if value exists in self.extra['choices'] because
         # validation is done by django_filters
         try:
-            return getattr(qs, "{}_events".format(value))()
+            return getattr(qs, value)()
         except AttributeError:
             return qs
 
@@ -92,11 +92,13 @@ class EventFilter(FilterSetWithoutHelpText):
 
     STATUS_CHOICES = [
         ('', 'All'),
-        ('past', 'Past'),
-        ('ongoing', 'Ongoing'),
-        ('upcoming', 'Upcoming'),
-        ('unpublished', 'Unpublished'),
-        ('uninvoiced', 'Uninvoiced'),
+        ('active', 'Active'),
+        ('past_events', 'Past'),
+        ('ongoing_events', 'Ongoing'),
+        ('upcoming_events', 'Upcoming'),
+        ('unpublished_events', 'Unpublished'),
+        ('published_events', 'Published'),
+        ('uninvoiced_events', 'Uninvoiced'),
     ]
     status = EventStateFilter(choices=STATUS_CHOICES)
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -467,15 +467,16 @@ class Tag(models.Model):
 
 #------------------------------------------------------------
 
+
 # In order to make our custom filters chainable, we have to
 # define them on the QuerySet, not the Manager - see
 # http://www.dabapps.com/blog/higher-level-query-api-django-orm/
 class EventQuerySet(models.query.QuerySet):
     '''Handles finding past, ongoing and upcoming events'''
 
-    def no_stalled(self):
-        """Exclude events marked as 'stalled'."""
-        return self.exclude(tags__name='stalled')
+    def active(self):
+        """Exclude inactive events (stalled or completed)."""
+        return self.exclude(tags__name='stalled').exclude(completed=True)
 
     def past_events(self):
         '''Return past events.

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -147,9 +147,9 @@ def dashboard(request):
     '''Home page.'''
     current_events = (
         Event.objects.upcoming_events() | Event.objects.ongoing_events()
-    ).no_stalled()
-    uninvoiced_events = Event.objects.uninvoiced_events().no_stalled()
-    unpublished_events = Event.objects.unpublished_events().no_stalled() \
+    ).active()
+    uninvoiced_events = Event.objects.active().uninvoiced_events()
+    unpublished_events = Event.objects.active().unpublished_events() \
                                       .select_related('host')
 
     assigned_to, is_admin = assignment_selection(request)
@@ -1684,7 +1684,7 @@ def all_activity_over_time(request):
 def workshop_issues(request):
     '''Display workshops in the database whose records need attention.'''
 
-    events = Event.objects.past_events().filter(
+    events = Event.objects.active().past_events().filter(
         Q(attendance=None) | Q(attendance=0) |
         Q(country=None) |
         Q(venue=None) | Q(venue__exact='') |


### PR DESCRIPTION
This fixes #651.

Active event means:
* it's not stalled (it doesn't have "stalled" Tag)
* it's not marked as completed.

Altered views:
* dashboard
* workshop issues