### PR TITLE
Workshop issues: show events w/o instructors

### DIFF
--- a/workshops/templates/workshops/workshop_issues.html
+++ b/workshops/templates/workshops/workshop_issues.html
@@ -23,6 +23,7 @@
       <tr>
         <th>Event</th>
         <th>Attendance <a href="#" data-toggle="tooltip" title="Number of attendees is missing">[?]</a></th>
+        <th>Instructors <a href="#" data-toggle="tooltip" title="No instructors assigned to the event">[?]</a></th>
         <th>Location <a href="#" data-toggle="tooltip" title="Country, venue, address or lat/long are missing">[?]</a></th>
         <th>Dates <a href="#" data-toggle="tooltip" title="Start date is in future of end date">[?]</a></th>
       </tr>
@@ -35,6 +36,21 @@
           {% if event.missing_attendance_ %}
             {% if event.mailto %}
               <a href="{% include 'workshops/attendance_email_href.html' with event=event %}">
+              <span class="glyphicon glyphicon-envelope"></span>
+              </a>
+            {% else %}
+              <span class="glyphicon glyphicon-remove"></span>
+            {% endif %}
+          {% endif %}
+        </td>
+        <td>
+          {% if event.no_instructors_ %}
+            {% if event.mailto %}
+              <a href="mailto:{{event.mailto}}?subject={% filter urlencode %}Missing instructors for workshop {{event.get_ident}}{% endfilter %}&body={% filter urlencode %}Hi,
+
+Can you please send us list of instructors who taught at {{ event.get_ident }} workshop?
+
+Thanks for your help.{% endfilter %}">
               <span class="glyphicon glyphicon-envelope"></span>
               </a>
             {% else %}

--- a/workshops/test/test_issues.py
+++ b/workshops/test/test_issues.py
@@ -1,0 +1,129 @@
+from datetime import timedelta, date
+
+from django.core.urlresolvers import reverse
+
+from ..models import Event, Host, Role, Person
+from .base import TestBase
+
+
+class TestIssuesViews(TestBase):
+    def setUp(self):
+        super()._setUpUsersAndLogin()
+        super()._setUpRoles()
+
+        self.url = reverse('workshop_issues')
+        self.today = date.today()
+        oneday = timedelta(days=1)
+        self.weekago = self.today - 7 * oneday
+        self.yesterday = self.today - oneday
+        self.tomorrow = self.today + oneday
+        self.instructor_role = Role.objects.get(name='instructor')
+
+    def test_workshop_issues_past(self):
+        """Test if workshop issues collects events from past only."""
+        past = Event.objects.create(
+            slug='event-in-past', start=self.yesterday,
+            host=Host.objects.first())
+        future = Event.objects.create(
+            slug='event-in-future', start=self.tomorrow,
+            host=Host.objects.first())
+
+        rv = self.client.get(self.url)
+        self.assertIn(past, rv.context['events'])
+        self.assertNotIn(future, rv.context['events'])
+
+    def test_workshop_issues_active(self):
+        """Test if workshop issues collects active events only."""
+        inactive = Event.objects.create(
+            slug='inactive-event', start=self.yesterday,
+            completed=True, host=Host.objects.first())
+        active = Event.objects.create(
+            slug='active-event', start=self.yesterday,
+            completed=False, host=Host.objects.first())
+
+        rv = self.client.get(self.url)
+        self.assertNotIn(inactive, rv.context['events'])
+        self.assertIn(active, rv.context['events'])
+
+    def test_workshop_issues_no_attendance(self):
+        """Test if workshop issues collects events without attendance
+        figures."""
+        attendance = Event.objects.create(
+            slug='event-with-attendance',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        attendance.task_set.create(person=Person.objects.first(),
+                                   role=self.instructor_role)
+        no_attendance = Event.objects.create(
+            slug='event-with-no-attendance',
+            start=self.weekago, end=self.yesterday,
+            attendance=0, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        no_attendance.task_set.create(person=Person.objects.first(),
+                                      role=self.instructor_role)
+
+        rv = self.client.get(self.url)
+        self.assertNotIn(attendance, rv.context['events'])
+        self.assertIn(no_attendance, rv.context['events'])
+
+    def test_workshop_issues_no_location(self):
+        """Test if workshop issues collects events without location."""
+        location = Event.objects.create(
+            slug='event-with-location',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        location.task_set.create(person=Person.objects.first(),
+                                 role=self.instructor_role)
+        no_location = Event.objects.create(
+            slug='event-with-no-location',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='', venue='B', latitude=89, longitude=179)
+        no_location.task_set.create(person=Person.objects.first(),
+                                    role=self.instructor_role)
+
+        rv = self.client.get(self.url)
+        self.assertNotIn(location, rv.context['events'])
+        self.assertIn(no_location, rv.context['events'])
+
+    def test_workshop_issues_wrong_dates(self):
+        """Test if workshop issues collects events with invalid dates."""
+        okay = Event.objects.create(
+            slug='event-with-okay-dates',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        okay.task_set.create(person=Person.objects.first(),
+                             role=self.instructor_role)
+        invalid_dates = Event.objects.create(
+            slug='event-with-invalid-dates',
+            start=self.yesterday, end=self.weekago,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        invalid_dates.task_set.create(person=Person.objects.first(),
+                                      role=self.instructor_role)
+
+        rv = self.client.get(self.url)
+        self.assertNotIn(okay, rv.context['events'])
+        self.assertIn(invalid_dates, rv.context['events'])
+
+    def test_workshop_issues_no_instructors(self):
+        """Test if workshop issues collects events without instructors."""
+        instructor = Event.objects.create(
+            slug='event-with-instructor',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+        instructor.task_set.create(person=Person.objects.first(),
+                                   role=self.instructor_role)
+        no_instructors = Event.objects.create(
+            slug='event-with-no-instructors',
+            start=self.weekago, end=self.yesterday,
+            attendance=36, host=Host.objects.first(),
+            country='US', address='A', venue='B', latitude=89, longitude=179)
+
+        rv = self.client.get(self.url)
+        self.assertNotIn(instructor, rv.context['events'])
+        self.assertIn(no_instructors, rv.context['events'])


### PR DESCRIPTION
This fixes #661 by extending search for events with no tasks with
role=instructor.

Additionally, tests against that view were introduced.