### PR TITLE
Fix: error when looking up non-int person id for assignment

### DIFF
--- a/workshops/util.py
+++ b/workshops/util.py
@@ -762,5 +762,5 @@ def assign(request, obj, person_id):
 
         obj.save()
 
-    except Person.DoesNotExist:
+    except (Person.DoesNotExist, ValueError):
         raise Http404("No person found matching the query.")


### PR DESCRIPTION
This fixes #694 by throwing Http404 when ValueError happens.

New tests were introduced to ensure `assign` mechanics work correctly.