### PR TITLE
API: up throttle rates

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -256,8 +256,8 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.UserRateThrottle'
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100/day',
-        'user': '1000/day'
+        'anon': '50/hour',
+        'user': '200/hour'
     }
 }
 


### PR DESCRIPTION
Anonymous user: from 100/day up to 50/hour [6x] (production uses about
10/hour, leaving about 40/hour to other users trying to build the SWC
website).
Logged-in user: from 1000/day up to 200/hour [2.4x].

It's cumbersome to set up token access to the API
(http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)
so I may set up an account for production script later on (ref.
https://github.com/swcarpentry/website/issues/223).