### PR TITLE
Finding duplicates

### DIFF
--- a/workshops/templates/navigation_fixed.html
+++ b/workshops/templates/navigation_fixed.html
@@ -56,6 +56,7 @@
                 <li class="divider"></li>
                 {% navbar_element "Workshop issues" "workshop_issues" %}
                 {% navbar_element "Instructor issues" "instructor_issues" %}
+                {% navbar_element "Find duplicates" "duplicates" %}
               </ul>
             </li>
           </ul>

--- a/workshops/templates/workshops/duplicates.html
+++ b/workshops/templates/workshops/duplicates.html
@@ -1,5 +1,7 @@
 {% extends "base_nav_fixed.html" %}
 
+{% load assignments %}
+
 {% block content %}
   <h3>Persons with switched names</h3>
   {% if switched_persons %}
@@ -16,7 +18,13 @@
   {% if duplicate_persons %}
   <ul>
     {% for person in duplicate_persons %}
-    <li><a href="{{ person.get_absolute_url }}">{{ person }}</a></li>
+    <li>
+      <a href="{{ person.get_absolute_url }}">{{ person }}</a>
+      {% if not forloop.first %}
+      <a href="{% url 'persons_merge' %}?person_b_1={{ person.pk }}&person_a_1={{ prev_person_pk }}" target="_blank">(merge up)</a>
+      {% endif %}
+      {% assign person.pk as prev_person_pk %}
+    </li>
     {% endfor %}
   </ul>
   {% else %}

--- a/workshops/templates/workshops/duplicates.html
+++ b/workshops/templates/workshops/duplicates.html
@@ -1,0 +1,25 @@
+{% extends "base_nav_fixed.html" %}
+
+{% block content %}
+  <h3>Persons with switched names</h3>
+  {% if switched_persons %}
+  <ul>
+    {% for person in switched_persons %}
+    <li><a href="{{ person.get_absolute_url }}">{{ person }}</a></li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>None.</p>
+  {% endif %}
+
+  <h3>Persons with the same names</h3>
+  {% if duplicate_persons %}
+  <ul>
+    {% for person in duplicate_persons %}
+    <li><a href="{{ person.get_absolute_url }}">{{ person }}</a></li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>None.</p>
+  {% endif %}
+{% endblock %}

--- a/workshops/templatetags/assignments.py
+++ b/workshops/templatetags/assignments.py
@@ -1,0 +1,13 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def assign(variable):
+    """Directly pass a variable to the output.
+
+    This tag is intended to use with the new 'as' syntax:
+    {% assign "123" as number %}"""
+    return mark_safe(variable)

--- a/workshops/test/test_finding_duplicates.py
+++ b/workshops/test/test_finding_duplicates.py
@@ -1,0 +1,42 @@
+from django.core.urlresolvers import reverse
+
+from ..models import Person
+from .base import TestBase
+
+
+class TestFindingDuplicates(TestBase):
+    def setUp(self):
+        self._setUpUsersAndLogin()
+
+        self.harry = Person.objects.create(
+            personal='Harry', family='Potter', username='potter_harry',
+            email='hp@hogwart.edu')
+        self.potter = Person.objects.create(
+            personal='Potter', family='Harry', username='harry_potter',
+            email='hp+1@hogwart.edu')
+        self.ron = Person.objects.create(
+            personal='Ron', family='Weasley', username='weasley_ron',
+            email='rw@hogwart.edu')
+        self.ron2 = Person.objects.create(
+            personal='Ron', family='Weasley', username='weasley_ron_2',
+            email='rw+1@hogwart.edu')
+
+        self.url = reverse('duplicates')
+
+    def test_switched_names_persons(self):
+        rv = self.client.get(self.url)
+        switched = rv.context['switched_persons']
+        self.assertIn(self.harry, switched)
+        self.assertIn(self.potter, switched)
+        self.assertNotIn(self.ron, switched)
+        self.assertNotIn(self.ron2, switched)
+
+    def test_duplicate_persons(self):
+        rv = self.client.get(self.url)
+        switched = rv.context['duplicate_persons']
+        self.assertIn(self.ron, switched)
+        self.assertIn(self.ron2, switched)
+        self.assertNotIn(self.harry, switched)
+        self.assertNotIn(self.potter, switched)
+
+    # there might be more to come

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -81,6 +81,7 @@ urlpatterns = [
     url(r'^reports/all_activity_over_time/?$', views.all_activity_over_time, name='all_activity_over_time'),
     url(r'^reports/workshop_issues/?$', views.workshop_issues, name='workshop_issues'),
     url(r'^reports/instructor_issues/?$', views.instructor_issues, name='instructor_issues'),
+    url(r'^reports/duplicates/?$', views.duplicates, name='duplicates'),
 
     url(r'^revision/(?P<revision_id>[\d]+)/?$', views.object_changes, name='object_changes'),
 


### PR DESCRIPTION
This fixes #624.

This PR provides a new view for finding possible duplicates amongst persons.
It looks for people who may have gotten their names switched (person↔family mixed up), and for people who may appear in the database more than once.