### PR TITLE
New lookup to PersonLookup: matches tokenized names

### DIFF
--- a/workshops/lookups.py
+++ b/workshops/lookups.py
@@ -1,3 +1,7 @@
+from functools import reduce
+import operator
+import re
+
 from django.contrib.auth.models import Group
 from django.db.models import Q
 
@@ -32,6 +36,32 @@ class PersonLookup(ModelLookup):
         'email__icontains',
         'username__icontains'
     )
+
+    def get_query(self, request, term):
+        """Override this method to allow for additional lookup method: """
+        # original code from selectable.base.ModelLookup.get_query:
+        qs = self.get_queryset()
+        if term:
+            search_filters = []
+            if self.search_fields:
+                for field in self.search_fields:
+                    search_filters.append(Q(**{field: term}))
+
+            # tokenizing part
+            tokens = re.split('\s+', term)
+            if len(tokens) == 2:
+                name1, name2 = tokens
+                complex_q = (
+                    Q(personal__icontains=name1) & Q(family__icontains=name2)
+                ) | (
+                    Q(personal__icontains=name2) & Q(family__icontains=name1)
+                )
+                search_filters.append(complex_q)
+
+            # this is brilliant: it applies OR to all search filters
+            qs = qs.filter(reduce(operator.or_, search_filters))
+
+        return qs
 
 
 @login_required


### PR DESCRIPTION
The new lookup unfortunately has to reuse code from django-selectable.
It's splitting term for tokens, each applied against first/last name.

This fixes #712.