### PR TITLE
Fix for issue #705

### DIFF
--- a/workshops/templates/workshops/duplicates.html
+++ b/workshops/templates/workshops/duplicates.html
@@ -30,4 +30,21 @@
   {% else %}
   <p>None.</p>
   {% endif %}
+
+  <h3>Persons with the same emails</h3>
+  {% if duplicate_emails %}
+  <ul>
+    {% for person in duplicate_emails %}
+    <li>
+      <a href="{{ person.get_absolute_url }}">{{ person }}</a>
+      {% if not forloop.first %}
+      <a href="{% url 'persons_merge' %}?person_b_1={{ person.pk }}&person_a_1={{ prev_person_pk }}" target="_blank">(merge up)</a>
+      {% endif %}
+      {% assign person.pk as prev_person_pk %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>None.</p>
+  {% endif %}
 {% endblock %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2640,7 +2640,8 @@ def duplicates(request):
 
     Criteria for persons:
     * switched personal/family names
-    * same name on different people."""
+    * same name on different people
+    * same emails on different people."""
     names_normal = set(Person.objects.all().values_list('personal', 'family'))
     names_switched = set(Person.objects.all().values_list('family',
                                                           'personal'))
@@ -2667,15 +2668,15 @@ def duplicates(request):
     duplicate_persons = Person.objects.filter(duplicate_criteria) \
                                       .order_by('family', 'personal', 'email')
 
-    all_emails = [x.email.lower() for x in Person.objects.all()]
-    repeated_emails = set([x for x in all_emails if all_emails.count(x) > 1])
+    all_emails_lowercase = [x.email.lower() for x in Person.objects.all()]
+    repeated_emails = set([x for x in all_emails_lowercase if all_emails_lowercase.count(x) > 1])
 
     email_criteria = Q(id=0)
     for email in repeated_emails:
         email_criteria |= Q(email__icontains=email)
 
     duplicate_emails = Person.objects.filter(email_criteria) \
-                                      .order_by('family', 'personal', 'email')
+                                     .order_by('email', 'family', 'personal')
 
     context = {
         'title': 'Possible duplicates',


### PR DESCRIPTION
Added a view in `Reports -> List duplicates` to list down people with same emails (Issue #705 )
Also, the existing view showed all people instead of `None` if no duplicates were found. Also fixed that.
Please review.