### PR TITLE
Empty results if no duplicates found

### DIFF
--- a/workshops/test/test_finding_duplicates.py
+++ b/workshops/test/test_finding_duplicates.py
@@ -4,6 +4,7 @@ from ..models import Person
 from .base import TestBase
 
 class TestEmptyDuplicates(TestBase):
+    """Tests to return empty context variables when no matches found."""
     def setUp(self):
         self._setUpUsersAndLogin()
 
@@ -23,6 +24,7 @@ class TestEmptyDuplicates(TestBase):
         self.url = reverse('duplicates')
 
     def test_switched_names_persons(self):
+        """Ensure none of the above persons are in `switched_persons`."""
         rv = self.client.get(self.url)
         switched = rv.context['switched_persons']
         self.assertNotIn(self.harry, switched)
@@ -31,6 +33,7 @@ class TestEmptyDuplicates(TestBase):
         self.assertNotIn(self.ironman, switched)
 
     def test_duplicate_persons(self):
+        """Ensure none of the above persons are in `duplicate_persons`."""
         rv = self.client.get(self.url)
         switched = rv.context['duplicate_persons']
         self.assertNotIn(self.harry, switched)

--- a/workshops/test/test_finding_duplicates.py
+++ b/workshops/test/test_finding_duplicates.py
@@ -3,6 +3,40 @@ from django.core.urlresolvers import reverse
 from ..models import Person
 from .base import TestBase
 
+class TestEmptyDuplicates(TestBase):
+    def setUp(self):
+        self._setUpUsersAndLogin()
+
+        self.harry = Person.objects.create(
+            personal='Harry', family='Potter', username='potter_harry',
+            email='hp@hogwart.edu')
+        self.kira = Person.objects.create(
+            personal='Light', family='Yagami', username='light_yagami',
+            email='ly@hogwart.edu')
+        self.batman = Person.objects.create(
+            personal='Bruce', family='Wayne', username='bruce_wayne',
+            email='batman@waynecorp.com')
+        self.ironman = Person.objects.create(
+            personal='Tony', family='Stark', username='tony_stark',
+            email='ironman@starkindustries.com')
+
+        self.url = reverse('duplicates')
+
+    def test_switched_names_persons(self):
+        rv = self.client.get(self.url)
+        switched = rv.context['switched_persons']
+        self.assertNotIn(self.harry, switched)
+        self.assertNotIn(self.kira, switched)
+        self.assertNotIn(self.batman, switched)
+        self.assertNotIn(self.ironman, switched)
+
+    def test_duplicate_persons(self):
+        rv = self.client.get(self.url)
+        switched = rv.context['duplicate_persons']
+        self.assertNotIn(self.harry, switched)
+        self.assertNotIn(self.kira, switched)
+        self.assertNotIn(self.batman, switched)
+        self.assertNotIn(self.ironman, switched)
 
 class TestFindingDuplicates(TestBase):
     def setUp(self):

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2646,7 +2646,8 @@ def duplicates(request):
                                                           'personal'))
     names = names_normal & names_switched  # intersection
 
-    switched_criteria = Q()
+    switched_criteria = Q(id=0)
+    # empty query results if names is empty
     for personal, family in names:
         # get people who appear in `names`
         switched_criteria |= (Q(personal=personal) & Q(family=family))
@@ -2659,7 +2660,7 @@ def duplicates(request):
                                     .annotate(count_id=Count('id')) \
                                     .filter(count_id__gt=1)
 
-    duplicate_criteria = Q()
+    duplicate_criteria = Q(id=0)
     for name in duplicate_names:
         # get people who appear in `names`
         duplicate_criteria |= (Q(personal=name['personal']) &


### PR DESCRIPTION
The `List duplicates` page currently displays all persons if no duplicates are found.
This fix resolves the issue.