### PR TITLE
Fix: 500 when submitting incomplete person match form

### DIFF
--- a/workshops/test/test_profile_update_request.py
+++ b/workshops/test/test_profile_update_request.py
@@ -114,6 +114,24 @@ class TestProfileUpdateRequest(TestBase):
             set(KnowledgeDomain.objects.all()[0:2])
         assert set(person.lessons.all()) == set(Lesson.objects.all()[0:2])
 
+    def test_incomplete_selection_of_matching_person(self):
+        """Regression test: no 500 when incomplete form submitted to select
+        a matching person."""
+        pr = ProfileUpdateRequest.objects.create(
+            active=True,
+            personal='Warry', family='Trotter', email='warry@trotter.com',
+            affiliation='Auror at Ministry of Magic', airport_iata='AAA',
+            occupation='', occupation_other='Auror',
+            github='hpotter', twitter='hpotter',
+            orcid='0000-1111', website='http://warry.trotter.com/', gender='M',
+        )
+        pr.domains.add(*KnowledgeDomain.objects.all()[0:2]),
+        pr.lessons.add(*Lesson.objects.all()[0:2]),
+        url = (reverse('profileupdaterequest_details', args=[pr.pk]) +
+               '?person_0=inigo&person_1=&submit=Submit')
+        rv = self.client.get(url)
+        self.assertNotEqual(rv.status_code, 500)
+
 
 class TestProfileUpdateRequestsViews(TestBase):
     def setUp(self):

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2182,26 +2182,27 @@ def profileupdaterequest_details(request, request_id):
 
     person_selected = False
 
+    person = None
+    form = None
+
     # Nested lookup.
     # First check if there's person with the same email, then maybe check if
     # there's a person with the same first and last names.
     try:
         person = Person.objects.get(email=update_request.email)
-        form = None
     except Person.DoesNotExist:
         try:
             person = Person.objects.get(personal=update_request.personal,
                                         family=update_request.family)
-            form = None
         except (Person.DoesNotExist, Person.MultipleObjectsReturned):
             # Either none or multiple people with the same first and last
             # names.
             # But the user might have submitted some person by themselves. We
             # should check that!
             try:
+                form = PersonLookupForm(request.GET)
                 person = Person.objects.get(pk=int(request.GET['person_1']))
                 person_selected = True
-                form = PersonLookupForm(request.GET)
             except KeyError:
                 person = None
                 # if the form wasn't submitted, initialize it without any


### PR DESCRIPTION
The report email came during the night: incomplete form submitted to find a matching person didn't work correctly (caused server 500 error).

The error was: `form` variable was unbound in the local scope (which was a result of wrong steps order in the person matching logic).