### PR TITLE
Fix: event_import AttributeError and uncaught request exception

### DIFF
--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -748,3 +748,15 @@ class TestEventMerging(TestBase):
 
         for key, value in assertions.items():
             self.assertEqual(set(getattr(self.event_b, key).all()), value, key)
+
+
+class TestEventImport(TestBase):
+    def setUp(self):
+        self._setUpUsersAndLogin()
+
+    def test_no_exception_when_empty_url(self):
+        """Regression test: ensure no exceptions are raised when accessing
+        `event_import` view without `url` GET param."""
+        url = reverse('event_import')
+        rv = self.client.get(url)
+        self.assertLess(rv.status_code, 500)

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -768,6 +768,37 @@ Other content.
         errors = validate_tags_from_event_website(tags)
         assert not errors
 
+    def test_no_attribute_error_missing_instructors_helpers(self):
+        """Regression test: ensure no exception is raised when instructors
+        or helpers aren't in the tags or their values are None."""
+        tests = [
+            ((None, None), ([], [])),
+            ((None, ''), ([], [])),
+            (('', None), ([], [])),
+        ]
+        expected = {
+            'slug': '',
+            'language': '',
+            'start': None,
+            'end': None,
+            'country': '',
+            'venue': '',
+            'address': '',
+            'latitude': None,
+            'longitude': None,
+            'reg_key': None,
+            'instructors': [],
+            'helpers': [],
+            'contact': '',
+        }
+
+        for (instructor, helper), (instructors, helpers) in tests:
+            with self.subTest(people=(instructor, helper)):
+                tags = dict(instructor=instructor, helper=helper)
+                expected['instructors'] = instructors
+                expected['helpers'] = helpers
+                self.assertEqual(expected, parse_tags_from_event_website(tags))
+
 
 class TestMembership(TestBase):
     """Tests for SCF membership."""

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -528,12 +528,10 @@ def parse_tags_from_event_website(tags):
 
     # Split string of comma-separated names into a list, but return empty list
     # instead of [''] when there are no instructors/helpers.
-    instructors = tags.get('instructor', '').split('|')
-    instructors = [instructor.strip() for instructor in instructors]
-    instructors = [] if not any(instructors) else instructors
-    helpers = tags.get('helper', '').split('|')
-    helpers = [helper.strip() for helper in helpers]
-    helpers = [] if not any(helpers) else helpers
+    instructors = (tags.get('instructor') or '').split('|')
+    instructors = [instr.strip() for instr in instructors if instr]
+    helpers = (tags.get('helper') or '').split('|')
+    helpers = [helper.strip() for helper in helpers if helper]
 
     return {
         'slug': tags.get('slug', ''),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1205,8 +1205,7 @@ def event_import(request):
             .format(url, e.response.status_code)
         )
 
-    except (requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout):
+    except requests.exceptions.RequestException:
         return HttpResponseBadRequest('Network connection error.')
 
     except WrongWorkshopURL as e:


### PR DESCRIPTION
This PR fixes two bugs related to event importing:

1. missing `url` GET param when accessing `event_import` view caused 500
2. AttributeError when imported event had no instructors/helpers listed