### PR TITLE
Pass url within the response from `event_import` view.

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1196,6 +1196,7 @@ def event_import(request):
 
         # normalize (parse) them
         tags = parse_tags_from_event_website(tags)
+        tags['url'] = url
 
         return JsonResponse(tags)
 


### PR DESCRIPTION
The event_import view function did not pass the url as a
parameter in the JSON response.
Fixes #746

@pbanaszkiewicz Is this solution acceptable?