### PR TITLE
Add new people from profile update request

### DIFF
--- a/workshops/templates/workshops/profileupdaterequest.html
+++ b/workshops/templates/workshops/profileupdaterequest.html
@@ -126,11 +126,16 @@
 
 {% if new.active %}
 <div class="clearfix">
-  <div class="edit-object pull-left">
+  <div class="edit-object pull-left btn-group" role="group">
     {% if old and airport and perms.workshops.change_profileupdaterequest and perms.workshops.change_person %}
-    <a href="{% url 'profileupdaterequest_accept' new.pk old.pk %}"  onclick='return confirm("Did you verify the changes with \"{{ old }}\"? If you agree, their record will get updated.")' class="btn btn-success">Update</a>
+    <a href="{% url 'profileupdaterequest_accept' new.pk old.pk %}" role="button" onclick='return confirm("Did you verify the changes with \"{{ old }}\"? If you agree, their record will get updated.")' class="btn btn-success">Update</a>
     {% else %}
-    <a href="#" class="btn btn-success disabled">Update</a>
+    <a href="#" class="btn btn-success disabled" role="button">Update</a>
+    {% endif %}
+    {% if not old and airport and perms.workshops.change_profileupdaterequest and perms.workshops.add_person %}
+    <a href="{% url 'profileupdaterequest_accept' new.pk %}" class="btn btn-success" role="button">Add new person</a>
+    {% else %}
+    <a href="#" class="btn btn-success disabled" role="button">Add new person</a>
     {% endif %}
   </div>
   <div class="btn-group delete-object pull-right" role="group">

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -111,6 +111,7 @@ urlpatterns = [
     url(r'^profile_update/(?P<request_id>\d+)/?$', views.profileupdaterequest_details, name='profileupdaterequest_details'),
     url(r'^profile_update/(?P<request_id>\d+)/fix/?$', views.ProfileUpdateRequestFix.as_view(), name='profileupdaterequest_fix'),
     url(r'^profile_update/(?P<request_id>\d+)/discard/?$', views.profileupdaterequest_discard, name='profileupdaterequest_discard'),
+    url(r'^profile_update/(?P<request_id>\d+)/accept/?$', views.profileupdaterequest_accept, name='profileupdaterequest_accept'),
     url(r'^profile_update/(?P<request_id>\d+)/accept/(?P<person_id>[\w\.-]+)/?$', views.profileupdaterequest_accept, name='profileupdaterequest_accept'),
     url(r'^update_profile/$', views.profileupdaterequest_create, name='profileupdate_request'),
 


### PR DESCRIPTION
This fixes #741 by allowing users to add a new person from ProfileUpdateRequest.

Button responsible for adding is located next to "Update" button on profile update request view.