### PR TITLE
Allow users without `add_todoitem` permission to view an event

### DIFF
--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -148,9 +148,11 @@
 </div>
 
 <h3 id="todos">TODOs</h3>
+{% if perms.workshops.add_todoitem %}
 <p>
   <a href="{% url 'todos_add' event.get_ident %}" class="btn btn-primary">Add standard TODOs</a>
 </p>
+{% endif %}
 {% if todos %}
 <table class="table">
   <thead>
@@ -186,8 +188,10 @@
 {% else %}
 <p>No TODOs.</p>
 {% endif %}
+{% if perms.workshops.add_todoitem %}
 <h4 id="newtodo">New TODO</h4>
 {% crispy todo_form helper %}
+{% endif %}
 {% endblock %}
 
 {% block extrajs %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -937,7 +937,6 @@ def all_events(request):
 
 
 @login_required
-@permission_required('workshops.add_todoitem', raise_exception=True)
 def event_details(request, event_ident):
     '''List details of a particular event.'''
     try:
@@ -953,7 +952,8 @@ def event_details(request, event_ident):
         'event': event,
     })
 
-    if request.method == "POST":
+    if request.method == "POST" and request.user.has_perm('workshops.add_todoitem'):
+        # Create ToDo items on todo_form submission only when user has permission
         todo_form = SimpleTodoForm(request.POST, prefix='todo', initial={
             'event': event,
         })


### PR DESCRIPTION
This fixes #754.

@pbanaszkiewicz Please review.