### PR TITLE
Display SWC/DC instructor status in names

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -1159,8 +1159,14 @@ class BadgeQuerySet(models.query.QuerySet):
 
     INSTRUCTOR_BADGES = ('dc-instructor', 'swc-instructor')
 
-    def instructor_badges(self):
-        """Filter for instructor badges only."""
+    def instructor_badges(self, *extras):
+        """Filter for instructor badges."""
+
+        # Caller has specified which badge(s).
+        if extras:
+            return self.filter(name__in=extras)
+
+        # Caller hasn't specified, so look for instructor badges.
         return self.filter(name__in=self.INSTRUCTOR_BADGES)
 
 

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -2,6 +2,7 @@
 
 {% load crispy_forms_tags %}
 {% load pagination %}
+{% load tags %}
 
 {% block sidebar %}
     <h3>Filter</h3>
@@ -25,8 +26,8 @@
       </tr>
     {% for person in all_persons %}
       <tr>
-        <td class="text-center">{% if person.pk in dc_instructors %}Ⓓ{% endif %}</td>
-        <td class="text-center">{% if person.pk in swc_instructors %}Ⓢ{% endif %}</td>
+        <td class="text-center">{% if person.pk in dc_instructors %}{% bootstrap_tag "DC" %}{% endif %}</td>
+        <td class="text-center">{% if person.pk in swc_instructors %}{% bootstrap_tag "SWC" %}{% endif %}</td>
         <td><a href="{% url 'person_details' person.id %}">{{ person.get_full_name }}</a></td>
         <td>{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.email }}</a>{% else %}—{% endif %}</td>
         <td>

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -17,14 +17,16 @@
 {% if all_persons %}
     <table class="table table-striped">
       <tr>
-        <th width="50">Instructor?</th>
+        <th width="25">DC?</th>
+        <th width="25">SWC?</th>
         <th>Name</th>
         <th>Email</th>
         <th class="additional-links"></th>
       </tr>
     {% for person in all_persons %}
       <tr>
-        <td class="text-center">{% if person.pk in instructors %}✓{% endif %}</td>
+        <td class="text-center">{% if person.pk in dc_instructors %}Ⓓ{% endif %}</td>
+        <td class="text-center">{% if person.pk in swc_instructors %}Ⓢ{% endif %}</td>
         <td><a href="{% url 'person_details' person.id %}">{{ person.get_full_name }}</a></td>
         <td>{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.email }}</a>{% else %}—{% endif %}</td>
         <td>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -135,8 +135,8 @@
   </tr>
   {% for t in tasks %}
   <tr>
-    <td class="text-center">{% if t.person.pk in dc_instructors %}Ⓓ{% endif %}</td>
-    <td class="text-center">{% if t.person.pk in swc_instructors %}Ⓢ{% endif %}</td>
+    <td class="text-center">{% if t.person.pk in dc_instructors %}{% bootstrap_tag "DC" %}{% endif %}</td>
+    <td class="text-center">{% if t.person.pk in swc_instructors %}{% bootstrap_tag "SWC" %}{% endif %}</td>
     <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.get_full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
     <td>{{ t.role.name }}</td>
   </tr>

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -128,11 +128,15 @@
 <h3>Tasks</h3>
 <table class="table table-striped">
   <tr>
+    <th width="25">DC?</th>
+    <th width="25">SWC?</th>
     <th>person</th>
     <th>role</th>
   </tr>
   {% for t in tasks %}
   <tr>
+    <td class="text-center">{% if t.person.pk in dc_instructors %}Ⓓ{% endif %}</td>
+    <td class="text-center">{% if t.person.pk in swc_instructors %}Ⓢ{% endif %}</td>
     <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.get_full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
     <td>{{ t.role.name }}</td>
   </tr>

--- a/workshops/templates/workshops/instructors.html
+++ b/workshops/templates/workshops/instructors.html
@@ -13,23 +13,23 @@
   {% if persons %}
     <table class="table table-striped">
       <tr>
+	<th>DC?</th>
+	<th>SWC?</th>
         <th>person</th>
         <th>taught</th>
         <th>airport</th>
-        <th style="width: 150px">country</th>
-        <th>instructor badge</th>
+        <th>country</th>
         <th>lessons</th>
         <th>affiliation</th>
       </tr>
     {% for p in persons %}
       <tr>
+	<td class="text-center">{% if p.pk in dc_instructors %}{% bootstrap_tag "DC" %}{% endif %}</td>
+	<td class="text-center">{% if p.pk in swc_instructors %}{% bootstrap_tag "SWC" %}{% endif %}</td>
         <td><a href="{{ p.get_absolute_url }}">{{ p.get_full_name }}</a>{% if p.email and p.may_contact %} &lt;{{ p.email|urlize }}&gt;{% endif %}</td>
         <td>{{ p.num_taught }}</td>
         <td>{% if p.airport %}<a href="{{ p.airport.get_absolute_url }}">{{ p.airport }}</a>{% else %}—{% endif %}</td>
         <td>{% if p.airport %}{{ p.airport.country.name }}{% else %}—{% endif %}</td>
-        <td>{% for badge in p.badges.instructor_badges %}
-        {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
-        {% endfor %}</td>
         <td>
         {% for lesson in p.lessons.all %}
           {% if lesson in lessons %}<strong>{{ lesson }}</strong>{% else %}{{ lesson }}{% endif %}{% if not forloop.last%}, {% endif %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -985,11 +985,17 @@ def event_details(request, event_ident):
     person_lookup_helper = BootstrapHelper()
     person_lookup_helper.form_action = reverse('event_assign',
                                                args=[event_ident])
+    swc_instructors = Badge.objects.instructor_badges('swc-instructor') \
+                                   .values_list('person', flat=True)
+    dc_instructors = Badge.objects.instructor_badges('dc-instructor') \
+                                  .values_list('person', flat=True)
 
     context = {
         'title': 'Event {0}'.format(event),
         'event': event,
         'tasks': tasks,
+        'swc_instructors': swc_instructors,
+        'dc_instructors': dc_instructors,
         'todo_form': todo_form,
         'todos': todos,
         'helper': bootstrap_helper,

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -438,12 +438,15 @@ def all_persons(request):
         queryset=Person.objects.all().defer('notes')  # notes are too large
     )
     # faster method
-    instructors = Badge.objects.instructor_badges() \
-                               .values_list('person', flat=True)
+    swc_instructors = Badge.objects.instructor_badges('swc-instructor') \
+                                   .values_list('person', flat=True)
+    dc_instructors = Badge.objects.instructor_badges('dc-instructor') \
+                                  .values_list('person', flat=True)
     persons = get_pagination_items(request, filter)
     context = {'title' : 'All Persons',
                'all_persons' : persons,
-               'instructors': instructors,
+               'swc_instructors': swc_instructors,
+               'dc_instructors': dc_instructors,
                'filter': filter,
                'form_helper': bootstrap_helper_filter}
     return render(request, 'workshops/all_persons.html', context)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1614,11 +1614,18 @@ def instructors(request):
     form = InstructorsForm()
 
     lessons = list()
+    swc_instructors = list()
+    dc_instructors = list()
 
     if 'submit' in request.GET:
         form = InstructorsForm(request.GET)
         if form.is_valid():
             data = form.cleaned_data
+
+            swc_instructors = Badge.objects.instructor_badges('swc-instructor') \
+                .values_list('person', flat=True)
+            dc_instructors = Badge.objects.instructor_badges('dc-instructor') \
+                .values_list('person', flat=True)
 
             if data['lessons']:
                 lessons = data['lessons']
@@ -1665,6 +1672,8 @@ def instructors(request):
         'title': 'Find Instructors',
         'form': form,
         'persons': instructors,
+        'swc_instructors': swc_instructors,
+        'dc_instructors': dc_instructors,
         'lessons': lessons,
     }
     return render(request, 'workshops/instructors.html', context)


### PR DESCRIPTION
Closes #759.

1.  Modified `BadgeQuerySet.instructor_badges` to take extra positional argument(s) specifying which badges to interrogate. (Default behavior unchanged.)
2.  Modifying display of all persons to distinguish Software Carpentry and Data Carpentry instructors.
3.  Modifying display of tasks associated with Event to distinguish Software Carpentry and Data Carpentry instructors.

This is getting pretty hacky:

1.  Collecting all SWC and DC instructors, then doing an `in` test, seems inefficient.
2.  Manually specifying the `'swc-instructor'` and `'dc-instructor'` labels seems clumsy too - we should add fields to the `Badge` class to identify badges that are instructor-related and filter on that.

@chrismedrela, can you think of ways to improve this?