### PR TITLE
Fix: remove duplicated names from AdminLookup query

### DIFF
--- a/workshops/lookups.py
+++ b/workshops/lookups.py
@@ -83,7 +83,7 @@ class AdminLookup(ModelLookup):
         admin_group = Group.objects.get(name='administrators')
         results = results.filter(
             Q(is_superuser=True) | Q(groups__in=[admin_group])
-        )
+        ).distinct()
         return results
 
 


### PR DESCRIPTION
Query was matching either superusers or people from administrators
group, but if someone was in both categories they ended up twice on
the list.

Switching query to distinct mode fixed this error.

This fixes #764.