### PR TITLE
Fix: example of website URL for update from URL form

### DIFF
--- a/workshops/templates/workshops/event_import_update_from_url.html
+++ b/workshops/templates/workshops/event_import_update_from_url.html
@@ -31,7 +31,7 @@
               <label for="event_import_url" class="control-label">Event URL:</label>
               <input type="url" id="event_import_url" name="url" required class="form-control" />
             {% endif %}
-            <p class="help-block">Use the URL of the event's website, e.g. <code>http://swcarpentry.github.io/workshop-template/</code>, and not the URL of its GitHub repository.</p>
+            <p class="help-block">Use the URL of the event's website, e.g. <code>http://swcarpentry.github.io/workshop-template/</code> or <code>http://www.datacarpentry.org/workshop/</code>, and not the URL of its GitHub repository.</p>
             </div>
           {% if update %}
             <div class="form-group">


### PR DESCRIPTION
This was confusing to admins as if they could not use other URLs
than `username.github.io/workshop`.

This fixes #757.