### PR TITLE
Improved instructors' emails list generation in instructor_by_date view

### DIFF
--- a/workshops/templates/workshops/instructors_by_date.html
+++ b/workshops/templates/workshops/instructors_by_date.html
@@ -22,7 +22,7 @@
     {% endfor %}
     </table>
     <p><a href="{% url 'api:reports-instructors-by-time' %}?start={{ start_date|date:'Y-m-d' }}&amp;end={{ end_date|date:'Y-m-d' }}&amp;format=csv">Download as CSV</a></p>
-    <p><a href="mailto:{% for task in all_tasks %}{% if task.person.email %}{{ task.person.email }}{% if not forloop.last %},{% endif %}{% endif %}{% endfor %}">Send email</a></p>
+    {% if emails %}<p><a class="btn btn-primary" href="mailto:{{ emails|join:',' }}">Send email</a></p>{% endif %}
 {% else %}
     <p>No instructors for debrief section.</p>
 {% endif %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1747,9 +1747,6 @@ def search(request):
 @login_required
 def instructors_by_date(request):
     '''Show who taught between begin_date and end_date.'''
-    tasks = None
-
-    start_date = end_date = None
 
     form = DebriefForm()
     if 'begin_date' in request.GET and 'end_date' in request.GET:
@@ -1760,11 +1757,20 @@ def instructors_by_date(request):
         end_date = form.cleaned_data['end_date']
         rvs = ReportsViewSet()
         tasks = rvs.instructors_by_time_queryset(start_date, end_date)
+        emails = tasks.filter(person__may_contact=True)\
+                      .exclude(person__email=None)\
+                      .values_list('person__email', flat=True)
+    else:
+        start_date = None
+        end_date = None
+        tasks = None
+        emails = None
 
     context = {'title': 'List of instructors by time period',
                'form': form,
                'form_helper': bootstrap_helper_get,
                'all_tasks': tasks,
+               'emails': emails,
                'start_date': start_date,
                'end_date': end_date}
     return render(request, 'workshops/instructors_by_date.html', context)


### PR DESCRIPTION
Two bugs were fixed:
    
- There might be dangling commas if we don't know email of some
  instructors, that is "john@example.com,,,bob@example.com," could be
  generated. See #766 issue.
    
- Instructors who don't want to be contacted (that is, may_contact
  is False) were included in the list.
