### PR TITLE
Delete broken iata link in airport_details view

### DIFF
--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -7,7 +7,7 @@
 
 <table class="table table-striped">
   <tr><td>full name:</td><td>{{ airport.fullname }}</td></tr>
-  <tr><td>iata:</td><td><a href="http://{{ airport.iata }}">{{ airport.iata }}</a></td></tr>
+  <tr><td>iata:</td><td>{{ airport.iata }}</td></tr>
   <tr><td>country:</td><td>{{ airport.country.name }} <img src="{{ airport.country.flag }}" alt="{{ airport.country }}" class="country-flag" /></td></tr>
   <tr><td>latitude:</td><td>{{ airport.latitude }}</td></tr>
   <tr><td>longitude:</td><td>{{ airport.longitude }}</td></tr>


### PR DESCRIPTION
For example, when airport iata is CVG, it generated an invalid link to `http://cvg`. This patch makes the airport iata a static text instead of a hyperlink.