### PR TITLE
Add trainings dashboard

### DIFF
--- a/workshops/management/commands/fake_database.py
+++ b/workshops/management/commands/fake_database.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 import itertools
 import random
 
@@ -232,6 +232,42 @@ class Command(BaseCommand):
         for event, person, role in random.sample(list(all_possible), count):
             Task.objects.create(event=event, person=person, role=role)
 
+    def fake_trainees(self, faker):
+        host = Host.objects.all()[0]
+        tag = Tag.objects.get(name='TTT')
+        learner = Role.objects.get(name='learner')
+        swc_instructor = Badge.objects.get(name='swc-instructor')
+        dc_instructor = Badge.objects.get(name='dc-instructor')
+
+        # events
+        first_event = Event.objects.create(host=host, slug='first-ttt-event')
+        first_event.tags.add(tag)
+        first_event.save()
+
+        second_event = Event.objects.create(host=host, slug='second-ttt-event')
+        second_event.tags.add(tag)
+        second_event.save()
+
+        third_event = Event.objects.create(host=host, slug='third-ttt-event')
+        third_event.tags.add(tag)
+        third_event.save()
+
+        # persons
+        bob = Person.objects.create(username='bob-trainee')
+        alice = Person.objects.create(username='alice-trainee')
+        john = Person.objects.create(username='john-trainee')
+
+        # tasks
+        Task.objects.create(event=first_event, person=bob, role=learner)
+        Task.objects.create(event=first_event, person=alice, role=learner)
+        Task.objects.create(event=second_event, person=john, role=learner)
+
+        # awards
+        Award.objects.create(event=first_event, person=bob, badge=swc_instructor,
+                             awarded=datetime(2016, 4, 1))
+        Award.objects.create(event=third_event, person=bob, badge=dc_instructor,
+                             awarded=datetime(2016, 4, 1))
+
     def handle(self, *args, **options):
         faker = Faker()
 
@@ -251,3 +287,4 @@ class Command(BaseCommand):
         self.fake_unpublished_events(faker)
         self.fake_self_organized_events(faker)
         self.fake_tasks(faker)
+        self.fake_trainees(faker)

--- a/workshops/templates/navigation_fixed.html
+++ b/workshops/templates/navigation_fixed.html
@@ -25,6 +25,7 @@
               <ul class="dropdown-menu" role="menu">
                 {% navbar_element "Tasks" "all_tasks" %}
                 {% navbar_element "Badges" "all_badges" %}
+                {% navbar_element "Trainings" "all_trainings" %}
                 {% navbar_element "Airports" "all_airports" %}
                 {% navbar_element "Workshop requests" "all_eventrequests" %}
                 {% navbar_element "Workshop submissions" "all_eventsubmissions" %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -64,6 +64,8 @@ urlpatterns = [
     url(r'^badge/(?P<badge_name>[\w\.=-]+)/?$', views.badge_details, name='badge_details'),
     url(r'^badge/(?P<badge_name>[\w\.=-]+)/award/?$', views.badge_award, name='badge_award'),
 
+    url(r'^trainings/?$', views.all_trainings, name='all_trainings'),
+
     url(r'^instructors/?$', views.instructors, name='instructors'),
 
     url(r'^search/?$', views.search, name='search'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1524,6 +1524,30 @@ def badge_award(request, badge_name):
 
 #------------------------------------------------------------
 
+@login_required
+def all_trainings(request):
+    '''List all Instructor Trainings.'''
+
+    learner = Role.objects.get(name='learner')
+    ttt = Tag.objects.get(name='TTT')
+
+    finished = Award.objects.filter(badge__in=Badge.objects.instructor_badges(), event__tags=ttt) \
+        .values('event').annotate(finished=Count('person'))
+    finished = {f['event']: f['finished'] for f in finished}
+
+    trainings = Task.objects.filter(role=learner).filter(event__tags=ttt).order_by('event__start') \
+        .values('event', 'event__slug').annotate(trainees=Count('person'))
+    for t in trainings:
+        event_id = t['event']
+        t['finished'] = finished.get(event_id, 0)
+
+    trainings = get_pagination_items(request, trainings)
+    context = {'title': 'All Instructor Trainings',
+               'all_trainings': trainings}
+    return render(request, 'workshops/all_trainings.html', context)
+
+#------------------------------------------------------------
+
 
 @login_required
 def instructors(request):


### PR DESCRIPTION
The training dashboard is available in the nav bar: more -> Trainings. The dashboard displays list of recent instructor training along with number of all participants and number of participants who has become SWC/DC instructors.