### PR TITLE
Use linear interpolation to eliminate backward bends on charts

### DIFF
--- a/workshops/templates/workshops/time_series.html
+++ b/workshops/templates/workshops/time_series.html
@@ -25,6 +25,7 @@
                 width: 800,
                 height: 600,
                 target: document.getElementById('chart'),
+                interpolate: 'linear',
                 x_accessor: 'date',
                 y_accessor: 'count'
             });


### PR DESCRIPTION
If using linear interpolation is not an option, we can set `interpolate_tension` to a high value (i.e. 0.95).

EDIT (@pbanaszkiewicz): this fixes #779.