### PR TITLE
Prevents duplication of frequency for instructors with both DC and SWC badges.

### DIFF
--- a/api/test/test_reports.py
+++ b/api/test/test_reports.py
@@ -1,0 +1,83 @@
+import datetime
+import json
+
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.views import (
+    ReportsViewSet,
+)
+from api.serializers import InstructorNumTaughtSerializer
+from workshops.models import (
+    Badge,
+    Award,
+    Person,
+    Role,
+    Host,
+    Task,
+    Event,
+)
+
+
+class BaseReportingTest(APITestCase):
+
+    def setUp(self):
+        self.login()
+
+    def login(self):
+        self.admin = Person.objects.create_superuser(
+                username="admin", personal="Super", family="User",
+                email="sudo@example.org", password='admin')
+        self.client.login(username='admin', password='admin')
+
+
+class TestReportingInstructorNumTaught(BaseReportingTest):
+    def setUp(self):
+        super().setUp()
+
+        # get instructor badges
+        swc_instructor, _ = Badge.objects.get_or_create(
+            name='swc-instructor'
+        )
+        dc_instructor, _ = Badge.objects.get_or_create(
+            name='dc-instructor'
+        )
+        # set up an event
+        host = Host.objects.create(domain='host.edu', fullname='Host EDU')
+        event = Event.objects.create(slug='event1', host=host)
+        instructor = Person.objects.create(
+            username='harrypotter', personal='Harry', family='Potter',
+            email='user1@name.org',
+        )
+        instructor_role, _ = Role.objects.get_or_create(name='instructor')
+        Task.objects.create(
+            event=event,
+            person=instructor,
+            role=instructor_role
+        )
+        # Award a SWC Badge
+        Award.objects.create(person=instructor, badge=swc_instructor,
+                             awarded=datetime.date.today())
+        # Award a DC Badge
+        Award.objects.create(person=instructor, badge=dc_instructor,
+                             awarded=datetime.date.today())
+
+        # make sure we *do not* get twice the number expected
+        self.expecting = [
+            {
+                'person': 'http://testserver/api/v1/persons/{}/?format=json'.format(
+                    instructor.pk,
+                ),
+                'name': 'Harry Potter',
+                'num_taught': 1,
+            },
+        ]
+
+    def test_view(self):
+        # test only JSON output
+        url = reverse('api:reports-instructor-num-taught')
+        response = self.client.get(url, {'format': 'json'})
+        content = response.content.decode('utf-8')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(content), self.expecting)

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,7 @@
 import datetime
 from itertools import accumulate
 
-from django.db.models import Count, Sum, Case, When, Value, IntegerField
+from django.db.models import Count, Sum, Case, F, When, Value, IntegerField
 from rest_framework import viewsets
 from rest_framework.decorators import list_route
 from rest_framework.filters import DjangoFilterBackend
@@ -329,12 +329,12 @@ class ReportsViewSet(ViewSet):
                 Case(
                     When(
                         task__role__name='instructor',
-                        then=Value(1)
+                        then=F('task'),
                     ),
-                    output_field=IntegerField()
-                )
+                ),
+                distinct=True
             )
-        ).filter(may_contact=True).order_by('-num_taught')
+        ).order_by('-num_taught')
         serializer = InstructorNumTaughtSerializer(
             persons, many=True, context=dict(request=request))
         return Response(serializer.data)


### PR DESCRIPTION
Fixes #787

This solution makes a change to the list of instructors displayed.
Earlier, the instructors with SWC/DC badges who didn't teach (as an instructor) in any workshop were also listed with their corresponding count being zero.
Now, only instructors with non-zero frequency are listed.

Is that fine?