### PR TITLE
Fix event validion: check format for required or non-empty tags

### DIFF
--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -756,6 +756,27 @@ Other content.
         assert len(errors) == 12
         assert all([error.startswith('Missing') for error in errors])
 
+    def test_validating_empty_metadata(self):
+        metadata = {
+            'slug': '',
+            'language': '',
+            'startdate': '',
+            'enddate': '',
+            'country': '',
+            'venue': '',
+            'address': '',
+            'latlng': '',
+            'instructor': '',
+            'helper': '',
+            'contact': '',
+            'eventbrite': '',
+        }
+        expected_errors = ['slug', 'startdate', 'country', 'latlng',
+                           'instructor', 'helper', 'contact']
+        errors = validate_metadata_from_event_website(metadata)
+        for error, key in zip(errors, expected_errors):
+            self.assertIn(key, error)
+
     def test_validating_default_metadata(self):
         metadata = {
             'slug': 'FIXME',

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -615,10 +615,11 @@ def validate_metadata_from_event_website(metadata):
         name_ = ('{display} ({name})'.format(**d_)
                  if requirement.display
                  else '{name}'.format(**d_))
-        type_ = 'required' if requirement.required else 'optional'
+        required_ = requirement.required
+        type_ = 'required' if required_ else 'optional'
         value_ = metadata.get(requirement.name)
 
-        if not value_:
+        if value_ is None:
             errors.append('Missing {} metadata {}.'.format(type_, name_))
 
         if value_ == 'FIXME':
@@ -626,12 +627,14 @@ def validate_metadata_from_event_website(metadata):
                           .format(type_, name_))
         else:
             try:
-                if not re.match(requirement.match_format, value_):
-                    errors.append(
-                        'Invalid value "{}" for {} metadata {}: should be in '
-                        'format "{}".'
-                        .format(value_, type_, name_, requirement.match_format)
-                    )
+                if required_ or value_:
+                    if not re.match(requirement.match_format, value_):
+                        errors.append(
+                            'Invalid value "{}" for {} metadata {}: should be'
+                            ' in format "{}".'
+                            .format(value_, type_, name_,
+                                    requirement.match_format)
+                        )
             except (re.error, TypeError):
                 pass
 


### PR DESCRIPTION
Changed event validation. It now checks expected format only for tags
that are required or that have a non-empty value.

This fixes #813.