### PR TITLE
Fix IntegrityError when merging people with similar M2M related objects

### DIFF
--- a/workshops/test/test_person.py
+++ b/workshops/test/test_person.py
@@ -705,3 +705,17 @@ class TestPersonMerging(TestBase):
         for key, value in assertions.items():
             self.assertEqual(set(getattr(self.person_b, key).all()), value,
                              key)
+
+    def test_merging_m2m_with_similar_attributes(self):
+        """Regression test: merging people with the same M2M objects, e.g. when
+        both people have task 'learner' in event 'ABCD', would result in unique
+        constraint violation and cause IntegrityError."""
+        self.person_b.task_set.create(
+            event=Event.objects.get(slug='ends-tomorrow-ongoing'),
+            role=Role.objects.get(name='instructor'),
+        )
+
+        self.strategy['task_set'] = 'combine'
+
+        rv = self.client.post(self.url, data=self.strategy)
+        self.assertEqual(rv.status_code, 302)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -939,8 +939,14 @@ def persons_merge(request):
                          'task_set')
 
             try:
-                merge_objects(obj_a, obj_b, easy, difficult, choices=data,
-                              base_a=base_a)
+                _, integrity_errors = merge_objects(obj_a, obj_b, easy,
+                                                    difficult, choices=data,
+                                                    base_a=base_a)
+
+                if integrity_errors:
+                    msg = ('There were integrity errors when merging related '
+                           'objects:\n' '\n'.join(integrity_errors))
+                    messages.warning(request, msg)
 
             except ProtectedError as e:
                 return failed_to_delete(request, object=merging_obj,
@@ -1294,15 +1300,21 @@ def events_merge(request):
                 'administrator', 'url', 'reg_key', 'admin_fee',
                 'invoice_status', 'attendance', 'contact', 'country', 'venue',
                 'address', 'latitude', 'longitude', 'learners_pre',
-                'learners_post',  'instructors_pre', 'instructors_post',
+                'learners_post', 'instructors_pre', 'instructors_post',
                 'learners_longterm', 'notes',
             )
             # M2M relationships
             difficult = ('tags', 'task_set', 'todoitem_set')
 
             try:
-                merge_objects(obj_a, obj_b, easy, difficult, choices=data,
-                              base_a=base_a)
+                _, integrity_errors = merge_objects(obj_a, obj_b, easy,
+                                                    difficult, choices=data,
+                                                    base_a=base_a)
+
+                if integrity_errors:
+                    msg = ('There were integrity errors when merging related '
+                           'objects:\n' '\n'.join(integrity_errors))
+                    messages.warning(request, msg)
 
             except ProtectedError as e:
                 return failed_to_delete(request, object=merging_obj,


### PR DESCRIPTION
For example: merging two people with similar task of being a learner at
the event '2016-05-29-copacabana' would yield IntegrityError when trying
to use "combine" strategy since after merging there would be two
identical tasks (both learner, event '2016-05-29-copacabana' and the
same person) - and that violates the uniqueness constraint.

This fixes #755.