### PR TITLE
host_details: fix 500 instead of 404 when no matching host

### DIFF
--- a/workshops/test/test_views_404.py
+++ b/workshops/test/test_views_404.py
@@ -54,7 +54,12 @@ class TestViewsFor404ing(TestBase):
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)
 
-    def todos_add(self):
+    def test_todos_add(self):
         url = reverse('todos_add', args=['non-existing-event'])
+        rv = self.client.get(url)
+        self.assertEqual(rv.status_code, 404)
+
+    def test_host_details(self):
+        url = reverse('host_details', args=['non-existing-host'])
         rv = self.client.get(url)
         self.assertEqual(rv.status_code, 404)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -291,7 +291,7 @@ def all_hosts(request):
 @login_required
 def host_details(request, host_domain):
     '''List details of a particular host.'''
-    host = Host.objects.get(domain=host_domain)
+    host = get_object_or_404(Host, domain=host_domain)
     events = Event.objects.filter(host=host)
     context = {'title' : 'Host {0}'.format(host),
                'host' : host,


### PR DESCRIPTION
The issue was: we should have used `get_object_or_404` instead of
`Host.objects.get` because the latter throws error 500 when specific
host cannot be found.

Additionally changed one test's name so that it's discovered by the test
runner.