### PR TITLE
Add ability to import a PyData host from a conference site.

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -610,6 +610,11 @@ class HostForm(forms.ModelForm):
         model = Host
         fields = ['domain', 'fullname', 'country', 'notes']
 
+    class Media:
+        js = (
+            'import_host_from_url.js',
+        )
+
 
 class MembershipForm(forms.ModelForm):
     class Meta:

--- a/workshops/static/import_host_from_url.js
+++ b/workshops/static/import_host_from_url.js
@@ -1,0 +1,41 @@
+function import_from_url(domain) {
+  return $.get("/workshops/hosts/import/", {'domain': domain}, function(data) {
+    $("#event_import_url").parent().removeClass('has-error');
+    $('#import_url_modal').modal('hide');
+    $('#error_message').addClass('hidden');
+
+    $("#id_fullname").val(data.fullname);
+    $("#id_domain").val(domain)
+
+    $("#id_notes").val(
+      "START DATE: " + data.start_date + "\n\n" +
+      "END DATE: " + data.end_date
+    );
+  });
+}
+
+$('#import_url_button').click(function() {
+  $('#import_url_modal').modal();
+});
+$('#import_url_form').submit(function(e) {
+  e.preventDefault();
+
+  // indicate loading data
+  var btn = $(this).find('button[type=submit]');
+  btn.attr('disabled', true);
+
+  // load data from URL
+  import_from_url(
+    $(this).find(':input[name=domain]').val()
+  )
+  .fail(function(data) {
+    // something went wrong, let's indicate it
+    $("#event_import_url").parent().addClass('has-error');
+    $('#error_message').text(data.responseText);
+    $('#error_message').removeClass('hidden');
+  })
+  .always(function(data) {
+    // let's always reenable the form's submit when the request finishes
+    btn.attr('disabled', false);
+  });
+});

--- a/workshops/templates/workshops/host_create_form.html
+++ b/workshops/templates/workshops/host_create_form.html
@@ -1,0 +1,15 @@
+{% extends "base_nav_fixed.html" %}
+
+{% load crispy_forms_tags %}
+{% load selectable_tags %}
+
+{% block content %}
+<button type="button" class="btn btn-default" id="import_url_button">Import from URL</button>
+{% crispy form form_helper %}
+
+  {% include "workshops/host_import_update_from_url.html" with update=False %}
+{% endblock %}
+
+{% block extrajs %}
+{{ form.media }}
+{% endblock extrajs %}

--- a/workshops/templates/workshops/host_import_update_from_url.html
+++ b/workshops/templates/workshops/host_import_update_from_url.html
@@ -1,0 +1,60 @@
+{% if update %}
+  <!-- Event update from URL modal -->
+  <div class="modal fade" id="update_url_modal" tabindex="-1" role="dialog" aria-labelledby="update_url_modal_label" aria-hidden="true">
+{% else %}
+  <!-- Event import URL modal -->
+  <div class="modal fade" id="import_url_modal" tabindex="-1" role="dialog" aria-labelledby="import_url_modal_label" aria-hidden="true">
+{% endif %}
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+        {% if update %}
+          <h4 class="modal-title" id="update_url_modal_label">Update host data from URL</h4>
+        {% else %}
+          <h4 class="modal-title" id="import_url_modal_label">Import host data from URL</h4>
+        {% endif %}
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-danger hidden" id="error_message"></div>
+        {% if update %}
+          <form id="update_url_form">
+        {% else %}
+          <form id="import_url_form">
+        {% endif %}
+            {% csrf_token %}
+            <div class="form-group">
+            {% if update %}
+              <label for="event_update_url" class="control-label">Host Domain:</label>
+              <input type="text" id="event_update_url" name="domain" required="required" class="form-control" value="{{ object.url|default:"" }}" />
+            {% else %}
+              <label for="event_import_url" class="control-label">Host Domain:</label>
+              <input type="text" id="event_import_url" name="domain" required class="form-control" />
+            {% endif %}
+              <span class="help-block">Please enter only the domain (such as "math.esu.edu") without a leading "http://" or a trailing "/".</span>
+            </div>
+          {% if update %}
+            <div class="form-group">
+              <div class="radio">
+                <label>
+                  <input type="radio" name="event_update_action" value="skip" checked="checked" />
+                  Skip non-empty fields.
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="event_update_action" value="overwrite" />
+                  Overwrite existing values.
+                </label>
+              </div>
+            </div>
+          {% endif %}
+            <button type="submit" class="btn btn-primary" data-loading-text="Loading..." autocomplete="off">Update</button>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^host/(?P<host_domain>[\w\.-]+)/edit$', views.HostUpdate.as_view(), name='host_edit'),
     url(r'^host/(?P<host_domain>[\w\.-]+)/delete$', views.host_delete, name='host_delete'),
     url(r'^hosts/add/$', views.HostCreate.as_view(), name='host_add'),
+    url(r'^hosts/import/$', views.host_import, name='host_import'),
 
     url(r'membership/(?P<host_domain>[\w\.-]+)/add', views.membership_create, name='membership_add'),
     url(r'membership/(?P<membership_id>\d+)/edit', views.MembershipUpdate.as_view(), name='membership_edit'),


### PR DESCRIPTION
Since each PyData conference would exist as a Host, we would like to import details about the PyData conference into the `Host` model.

The API is can be found at  [#116](https://github.com/pydata/conf_site/pull/116).
```
{
    "title": "PyData",
    "start_date": "2040-01-01",
    "end_date": "2040-01-04"
}
```
The `country` field is not populated as it not saved as any field in the PyData instance.

@gvwilson Please review.

Fixes #829 