### PR TITLE
Clarify declaration in TrainingRequestForm

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -975,7 +975,7 @@ class TrainingRequestForm(forms.ModelForm):
     agreed_to_teach_workshops = forms.BooleanField(
         required=True,
         initial=False,
-        label='I agree to help teach a Software Carpentry or Data Carpentry '
+        label='I agree to teach a Software Carpentry or Data Carpentry '
               'workshop within 12 months of this Training Course',
     )
     captcha = ReCaptchaField()


### PR DESCRIPTION
Replace "I agree to help teach" with "I agree to teach", because we want
new instructors to actually teach as an instructor, not a helper.