### PR TITLE
Restyle login page so that GitHub login button is next to the login form

### DIFF
--- a/workshops/templates/account/login.html
+++ b/workshops/templates/account/login.html
@@ -1,46 +1,42 @@
 {% extends "account/base.html" %}
 
 {% block content %}
-<div class="row">
-  <div class="col-md-12">
     {% if form.errors %}
     <div class="alert alert-danger" role="alert"><strong>Error:</strong>
     Your username and password didn't match.</div>
     {% endif %}
 
-    <form class="form-horizontal" method="post" action="{% url 'login' %}">
-      {% csrf_token %}
-      <div class="form-group">
-        <label for="id_username" class="col-sm-2 control-label">Username or email:</label>
-        <div class="col-sm-10">
-          {{ form.username }}
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="id_password" class="col-sm-2 control-label">Password:</label>
-        <div class="col-sm-10">
-          {{ form.password }}
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <input type="submit" class="btn btn-default" value="Log in">
-        </div>
-      </div>
+    <div class="row">
+      <div class="col-sm-12 col-md-6">
+        <form class="form-horizontal" method="post" action="{% url 'login' %}">
+          {% csrf_token %}
+          <div class="form-group">
+            <label for="id_username" class="col-sm-4 control-label">Username or email:</label>
+            <div class="col-sm-8">
+              <input id="id_username" maxlength="254" name="username" type="text" class="form-control" />
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="id_password" class="col-sm-4 control-label">Password:</label>
+            <div class="col-sm-8">
+              <input id="id_password" name="password" type="password" class="form-control" />
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8">
+              <input type="submit" class="btn btn-default" value="Log in">
+            </div>
+          </div>
 
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <a class="btn btn-default" id="github-button" name="github" href="/login/github/">
-            Log in with your GitHub account
-          </a>
-        </div>
+          <input type="hidden" name="next" value="{{ next }}" />
+        </form>
+        <p><a href="{% url 'password_reset' %}">Forgotten your password?</a></p>
       </div>
-
-      <div class="form-group">
-        <a href="{% url 'password_reset' %}">Forgotten your password?</a>
+      <div class="col-sm-12 col-md-1">
+        <p class="text-center"><strong>OR</strong></p>
       </div>
-      <input type="hidden" name="next" value="{{ next }}" />
-    </form>
-  </div>
-</div>
+      <div class="col-sm-12 col-md-5">
+        <p><a class="btn btn-default" id="github-button" name="github" href="/login/github/">Log in with your GitHub account</a></p>
+      </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Login page was restyled so that the GitHub login button is placed
next to the form with a world "OR" in bold between them.

This highlights that users can use one or the other to actually sign in.