### PR TITLE
Speedup Travis builds by caching pip directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+cache: pip 
 python:
   - 3.5
 install:


### PR DESCRIPTION
Reduction of build time from 188 seconds to 96 seconds (**2x speedup**).

This works. Compare [the first build](https://travis-ci.org/swcarpentry/amy/builds/143161913) of this PR with [the second one](https://travis-ci.org/swcarpentry/amy/builds/143163940).