### PR TITLE
Reveal IntegrityError raised in sync_usersocialauth view

### DIFF
--- a/workshops/test/test_person.py
+++ b/workshops/test/test_person.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from urllib.parse import urlencode
 
 from django.contrib.auth import authenticate
@@ -761,3 +761,18 @@ class TestPersonMerging(TestBase):
 
         rv = self.client.post(self.url, data=self.strategy)
         self.assertEqual(rv.status_code, 302)
+
+
+class TestSyncUserSocialAuthView(TestBase):
+    def setUp(self):
+        self._setUpUsersAndLogin()
+
+    def test_errors_are_not_hidden(self):
+        """ Test that errors occuring in synchronize_usersocialauth are not
+        hidden, that is you're not redirected to any other view. Regression
+        for #890. """
+        with patch.object(Person, 'synchronize_usersocialauth',
+                          side_effect=NotImplementedError):
+            with self.assertRaises(NotImplementedError):
+                self.client.get(reverse('sync_usersocialauth',
+                                        args=(self.admin.pk,)))

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1008,8 +1008,7 @@ def sync_usersocialauth(request, person_id):
                            'due to errors with GitHub API.'.format(person_id))
         else:
             messages.success(request, 'Sync UserSocialAuth successfully.')
-        finally:
-            return redirect(reverse('person_details', args=(person_id,)))
+        return redirect(reverse('person_details', args=(person_id,)))
 
 #------------------------------------------------------------
 


### PR DESCRIPTION
The redirect in `finally` clause was executed even when an non-`GithubException` (like `IntegrityError`) was raised. This hid the error. Now it results in loud error.