### PR TITLE
Change widgets in person permissions view

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -433,6 +433,14 @@ class PersonCreateForm(PersonForm):
 
 
 class PersonPermissionsForm(forms.ModelForm):
+    user_permissions = selectable.AutoCompleteSelectMultipleField(
+        lookup_class=lookups.PermissionLookup,
+        label='User permissions',
+        required=False,
+        help_text=AUTOCOMPLETE_HELP_TEXT,
+        widget=selectable.AutoComboboxSelectMultipleWidget,
+    )
+
     class Meta:
         model = Person
         # only display administration-related fields: groups, permissions,
@@ -443,6 +451,9 @@ class PersonPermissionsForm(forms.ModelForm):
             'user_permissions',
             'groups',
         ]
+        widgets = {
+            'groups': CheckboxSelectMultiple,
+        }
 
 
 class PersonsSelectionForm(forms.Form):

--- a/workshops/lookups.py
+++ b/workshops/lookups.py
@@ -2,7 +2,7 @@ from functools import reduce
 import operator
 import re
 
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.db.models import Q, Count
 
 from selectable.base import ModelLookup
@@ -112,9 +112,18 @@ class LanguageLookup(ModelLookup):
                 .order_by('-person_count')
 
 
+@lookup_only_for_admins
+class PermissionLookup(ModelLookup):
+    model = Permission
+    search_fields = (
+        'name__icontains',
+    )
+
+
 registry.register(EventLookup)
 registry.register(HostLookup)
 registry.register(PersonLookup)
 registry.register(AdminLookup)
 registry.register(AirportLookup)
 registry.register(LanguageLookup)
+registry.register(PermissionLookup)


### PR DESCRIPTION
Use `AutoCompleteSelectMultipleField` and `CheckboxSelectMultiple` instead of `SelectMultiple`. 

Reason: I have no idea how can I unselect all items in `SelectMultiple` widget.