### PR TITLE
Fix API error with embedded iterator

### DIFF
--- a/api/test/test_reports.py
+++ b/api/test/test_reports.py
@@ -20,6 +20,7 @@ from workshops.models import (
     Task,
     Event,
 )
+from workshops.test.base import TestBase
 
 
 class BaseReportingTest(APITestCase):
@@ -131,3 +132,21 @@ class TestCSVYAMLListSerialization(BaseReportingTest):
         result = rvs.listify(self.iterable, mock_request,
                              format=format_)
         self.assertNotEqual(type(result), type(list()))
+
+    def test_embedded_iterator_listified(self):
+        """Regression: test if advanced structure, generated e.g. by
+        `all_activity_over_time` report, doesn't raise RepresenterError when
+        used with YAML renderer."""
+        t = TestBase()
+        t.setUp()
+        t._setUpTags()
+
+        format_ = 'yaml'
+        self.assertIn(format_, self.formats)
+
+        rvs = ReportsViewSet()
+        mock_request = MagicMock()
+        mock_request.query_params = QueryDict()
+        data = rvs.all_activity_over_time(mock_request, format=format_).data
+        self.assertEqual(type(data['missing']['attendance']), type([]))
+        self.assertEqual(type(data['missing']['instructors']), type([]))

--- a/api/views.py
+++ b/api/views.py
@@ -368,8 +368,8 @@ class ReportsViewSet(ViewSet):
     def all_activity_over_time(self, request, format=None):
         """Workshops, instructors, and missing data in specific periods."""
         start, end = self._default_start_end_dates(
-            start=self.request.query_params.get('start', None),
-            end=self.request.query_params.get('end', None))
+            start=request.query_params.get('start', None),
+            end=request.query_params.get('end', None))
 
         events_qs = Event.objects.filter(start__gte=start, start__lte=end)
         swc_tag = Tag.objects.get(name='SWC')

--- a/api/views.py
+++ b/api/views.py
@@ -449,8 +449,12 @@ class ReportsViewSet(ViewSet):
                 'DC': dc_total_learners,
             },
             'missing': {
-                'attendance': missing_attendance,
-                'instructors': missing_instructors,
+                # qs.values_list returns an iterator, so we need to listify it
+                # for YAML
+                'attendance': self.listify(missing_attendance, request,
+                                           format),
+                'instructors': self.listify(missing_instructors, request,
+                                            format),
             }
         })
 


### PR DESCRIPTION
When using CSV/YAML renderers in API, one view was prone to error because it contained a non-representable values (ie. `ValuesQuerySet`). This PR fixes the bug by using `listify()` on the vulnerable entries.