### PR TITLE
Speeding up tests with --keepdb and --parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,11 @@ htmlerror
 *.pyc
 db.sqlite3
 db.sqlite3.bak
+# in-file test database used when --keepdb flag is set
 test_db.sqlite3
 test_db.sqlite3.bak
+# clones of in-file test database created while launching tests in parallel
+test_db*
 
 # coverage reports
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ htmlerror
 *.pyc
 db.sqlite3
 db.sqlite3.bak
+test_db.sqlite3
+test_db.sqlite3.bak
 
 # coverage reports
 .coverage

--- a/amy/settings.py
+++ b/amy/settings.py
@@ -177,8 +177,15 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'TEST': {},
     }
 }
+if '--keepdb' in sys.argv:
+    # By default, Django uses in-memory sqlite3 database, which is much
+    # faster than sqlite3 database in a file. However, we may want to keep
+    # database between test launches, so that we avoid the overhead of
+    # applying migrations on each test launch.
+    DATABASES['default']['TEST']['NAME'] = 'test_db.sqlite3'
 
 # Authentication
 AUTH_USER_MODEL = 'workshops.Person'

--- a/api/test/base.py
+++ b/api/test/base.py
@@ -1,0 +1,7 @@
+from rest_framework.test import APITestCase
+
+from workshops.test.base import DummySubTestWhenTestsLaunchedInParallelMixin
+
+
+class APITestBase(DummySubTestWhenTestsLaunchedInParallelMixin, APITestCase):
+    """Base class for AMY API test cases."""

--- a/api/test/test_api_structure.py
+++ b/api/test/test_api_structure.py
@@ -1,21 +1,21 @@
 import datetime
 
 from django.core.urlresolvers import reverse
-from rest_framework.test import APITestCase
+
+from api.test.base import APITestBase
 from workshops.models import (
     Person,
     Award,
     Badge,
     Event,
     Task,
-    TodoItem,
     Organization,
     Airport,
     Role,
 )
 
 
-class TestAPIStructure(APITestCase):
+class TestAPIStructure(APITestBase):
     def setUp(self):
         self.admin = Person.objects.create_superuser(
             username='admin', personal='Super', family='User',

--- a/api/test/test_events.py
+++ b/api/test/test_events.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from rest_framework import status
-from rest_framework.test import APITestCase
 
+from api.test.base import APITestBase
 from api.views import (
     PublishedEvents,
 )
@@ -17,7 +17,7 @@ from workshops.models import (
 from workshops.util import universal_date_format
 
 
-class TestListingPublishedEvents(APITestCase):
+class TestListingPublishedEvents(APITestBase):
     view = PublishedEvents
     serializer_class = PublishedEvents.serializer_class
     url = 'api:events-published'

--- a/api/test/test_export.py
+++ b/api/test/test_export.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 from django.core.urlresolvers import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
+from api.test.base import APITestBase
 from api.views import (
     ExportBadgesView,
     ExportInstructorLocationsView,
@@ -21,7 +21,7 @@ from workshops.models import (
 from workshops.util import universal_date_format
 
 
-class BaseExportingTest(APITestCase):
+class BaseExportingTest(APITestBase):
     def setUp(self):
         # remove all existing badges (this will be rolled back anyway)
         # including swc-instructor and dc-instructor introduced by migration

--- a/api/test/test_reports.py
+++ b/api/test/test_reports.py
@@ -5,12 +5,11 @@ from unittest.mock import MagicMock
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from rest_framework import status
-from rest_framework.test import APITestCase
 
+from api.test.base import APITestBase
 from api.views import (
     ReportsViewSet,
 )
-from api.serializers import InstructorNumTaughtSerializer
 from workshops.models import (
     Badge,
     Award,
@@ -23,7 +22,7 @@ from workshops.models import (
 from workshops.test.base import TestBase
 
 
-class BaseReportingTest(APITestCase):
+class BaseReportingTest(APITestBase):
 
     def setUp(self):
         self.login()

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group
 from django.contrib.sessions.serializers import JSONSerializer
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory
 
 import requests_mock
 
@@ -33,7 +33,7 @@ from ..util import (
 from .base import TestBase
 
 
-class UploadPersonTaskCSVTestCase(TestCase):
+class UploadPersonTaskCSVTestCase(TestBase):
 
     def compute_from_string(self, csv_str):
         ''' wrap up buffering the raw string & parsing '''
@@ -412,7 +412,7 @@ Harry,Potter,harry@hogwarts.edu,foobar,learner
         self.assertEqual(1, foobar.attendance)
 
 
-class TestHandlingEventMetadata(TestCase):
+class TestHandlingEventMetadata(TestBase):
     maxDiff = None
 
     html_content = """
@@ -935,7 +935,7 @@ class TestMembership(TestBase):
         self.assertEqual(len(members), 1)
 
 
-class TestAssignmentSelection(TestCase):
+class TestAssignmentSelection(TestBase):
     def setUp(self):
         """Set up RequestFactory and some users with different levels of
         privileges."""
@@ -998,7 +998,7 @@ class TestAssignmentSelection(TestCase):
         self.assertTrue(is_admin)
 
 
-class TestUsernameGeneration(TestCase):
+class TestUsernameGeneration(TestBase):
     def setUp(self):
         Person.objects.create_user(username='potter_harry', personal='Harry',
                                    family='Potter', email='hp@ministry.gov')
@@ -1034,7 +1034,7 @@ class TestUsernameGeneration(TestCase):
         self.assertEqual(username, 'blanking-crush_andy')
 
 
-class TestPaginatorSections(TestCase):
+class TestPaginatorSections(TestBase):
     def make_paginator(self, num_pages, page_index=None):
         # there's no need to initialize with real values
         p = Paginator(object_list=None, per_page=1)
@@ -1092,7 +1092,7 @@ class TestPaginatorSections(TestCase):
         )
 
 
-class TestAssignUtil(TestCase):
+class TestAssignUtil(TestBase):
     def setUp(self):
         """Set up RequestFactory for making fast fake requests."""
         Person.objects.create_user(username='test_user', email='user@test',


### PR DESCRIPTION
This PR introduces two improvements:

1. Use in-file database instead of in-memory one while running tests with `--keepdb`. This change lets us preserve database between test launches and, therefore, avoid the overhead of applying migrations during each test launch. Note that a new fresh in-memory database is still used by default, that is when you don't set `--keepdb` flag (i.e. `python3 manage.py test`).

2. `TestCase.subTest` cannot be used when tests are launched in parallel, that is with `--parallel` flag. To bypass this limitation, we use a dummy `subTest` mock when when tests are run in parallel.

The first improvement saves 30 seconds on my machine once the database is created. All test suite takes now 50 seconds instead of 80 seconds.

The second improvement in combination with the first one let you speed up tests twice (25 seconds instead of 50 seconds on my machine, my proc has 4 cores). 