### PR TITLE
Use create_superuser instead of createsuperuser in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ before starting work on new features.
     $ make dev_database
     ~~~
     
-5.  Create an administrator account:
+5.  Create an administrator account (username: `admin`, password: `admin`):
 
     ~~~
-    $ python3 manage.py createsuperuser
+    $ python3 manage.py create_superuser
     ~~~
 
 6.  Start a local Django development server by running:


### PR DESCRIPTION
This is our custom command and it's not documented and hard to discover. Why not using it in Getting Started section?

BTW, do we want a new label for documentation issues?