### PR TITLE
Fix #907 -- leakage of email addresses in "bulk email" buttons

### DIFF
--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -126,7 +126,7 @@
 
 {% if tasks %}
 <h3>Tasks</h3>
-{% if all_emails %}<p><a href="mailto:{{ all_emails|join:',' }}" class="btn btn-primary">Mail everyone</a></p>{% endif %}
+{% if all_emails %}<p><a href="mailto:?bcc={{ all_emails|join:',' }}" class="btn btn-primary">Mail everyone</a></p>{% endif %}
 <table class="table table-striped">
   <tr>
     <th width="25">DC?</th>

--- a/workshops/templates/workshops/instructors_by_date.html
+++ b/workshops/templates/workshops/instructors_by_date.html
@@ -22,7 +22,7 @@
     {% endfor %}
     </table>
     <p><a href="{% url 'api:reports-instructors-by-time' %}?start={{ start_date|date:'Y-m-d' }}&amp;end={{ end_date|date:'Y-m-d' }}&amp;format=csv">Download as CSV</a></p>
-    {% if emails %}<p><a class="btn btn-primary" href="mailto:{{ emails|join:',' }}">Send email</a></p>{% endif %}
+    {% if emails %}<p><a class="btn btn-primary" href="mailto:?bcc={{ emails|join:',' }}">Send email</a></p>{% endif %}
 {% else %}
     <p>No instructors for debrief section.</p>
 {% endif %}

--- a/workshops/templates/workshops/workshop_staff.html
+++ b/workshops/templates/workshops/workshop_staff.html
@@ -43,7 +43,7 @@
       </tr>
     {% endfor %}
     </table>
-    <p><a href="mailto:{{ emails|join:',' }}" class="btn btn-primary">Contact all</a></p>
+    <p><a href="mailto:?bcc={{ emails|join:',' }}" class="btn btn-primary">Contact all</a></p>
     {% pagination persons %}
   {% else %}
     <p>No matches.</p>


### PR DESCRIPTION
In a few places, there were links with href=`mailto:bunch,of,emails` instead of `mailto:?bcc=bunch,of,emails`. Those email addresses ended up in "To" field instead of "BCC" (blind copy), resulting in recipients seeing other recipients' email addresses.