### PR TITLE
Fix #834 with a function for YYYY-MM-DD dates formatting

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -359,6 +359,7 @@ class EventForm(forms.ModelForm):
         # thanks to this, {{ form.media }} in the template will generate
         # a <link href=""> (for CSS files) or <script src=""> (for JS files)
         js = (
+            'date_yyyymmdd.js',
             'import_from_url.js', 'update_from_url.js',
             'online_country.js',
         )

--- a/workshops/static/date_yyyymmdd.js
+++ b/workshops/static/date_yyyymmdd.js
@@ -1,0 +1,9 @@
+Date.prototype.yyyymmdd = function() {
+    // adapted from http://stackoverflow.com/a/3067896
+    var yyyy = this.getFullYear();
+    var mm_aux = this.getMonth() + 1;  // getMonth() is zero-based
+    var mm = mm_aux < 10 ? "0" + mm_aux : mm_aux;
+    var dd_aux = this.getDate();
+    var dd  = dd_aux < 10 ? "0" + dd_aux : dd_aux;
+    return "".concat(yyyy, "-", mm, "-", dd);
+};

--- a/workshops/static/update_from_url.js
+++ b/workshops/static/update_from_url.js
@@ -106,9 +106,7 @@ $('#update_url_form').submit(function(e) {
         }
         // append notes
         var today = new Date();
-        var today_str = "\n\n---------\nUPDATE " +
-          today.getFullYear() + "-" + today.getMonth() + "-" + today.getDay() +
-          ":\n";
+        var today_str = "\n\n---------\nUPDATE " + today.yyyymmdd() + ":\n";
         $("#id_event-notes").val(
           $("#id_event-notes").val() + today_str +
           "INSTRUCTORS: " + data.instructors.join(", ") + "\n\n" +


### PR DESCRIPTION
The JavaScript `Date` object was extended with a prototype function
`yyymmdd` (adapted from http://stackoverflow.com/a/3067896) to display
zeros before month and day number when they consist of single digits.