### PR TITLE
Fix bug when accepting training request

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -1449,7 +1449,7 @@ class BulkMatchTrainingRequestForm(forms.Form):
                                   'and match with a trainee.')
 
 
-class AcceptTrainingRequestForm(forms.ModelForm):
+class AcceptTrainingRequestForm(forms.Form):
     person = selectable.AutoCompleteSelectField(
         lookup_class=lookups.PersonLookup,
         label='Trainee Account',
@@ -1486,7 +1486,6 @@ class AcceptTrainingRequestForm(forms.ModelForm):
             raise ValidationError({'person': 'No person was selected.'})
 
     class Meta:
-        model = TrainingRequest
         fields = [
             'person',
         ]


### PR DESCRIPTION
It wasn't possible to "accept & match to selected trainee account", because validation on the model was triggered. `TrainingRequest` requires that there is no matched person when the state is "pending", while the form, as submitted, has a trainee chosen.
    
Fixed by disabling model validation.
