### PR TITLE
Fix double display of (un)published events

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -764,13 +764,13 @@ class EventQuerySet(models.query.QuerySet):
         """Return events considered as unpublished (see
         `unpublished_conditional` above)."""
         conditional = self.unpublished_conditional()
-        return self.filter(conditional).order_by('slug', 'id')
+        return self.filter(conditional).order_by('slug', 'id').distinct()
 
     def published_events(self):
         """Return events considered as published (see `unpublished_conditional`
         above)."""
         conditional = self.unpublished_conditional()
-        return self.exclude(conditional).order_by('-start', 'id')
+        return self.exclude(conditional).order_by('-start', 'id').distinct()
 
     def uninvoiced_events(self):
         '''Return a queryset for events that have not yet been invoiced.
@@ -787,7 +787,7 @@ class EventQuerySet(models.query.QuerySet):
 
     def ttt(self):
         """Return only TTT events."""
-        return self.filter(tags__name='TTT')
+        return self.filter(tags__name='TTT').distinct()
 
 
 @reversion.register

--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -110,6 +110,25 @@ class TestEvent(TestBase):
         self.assertNotIn(event_considered_published,
                          Event.objects.unpublished_events())
 
+    def test_unpublished_events_displayed_once(self):
+        """Regression test: unpublished events can't be displayed more than
+        once on the dashboard.  Refer to #977."""
+        self._setUpTags()
+        unpublished_event = Event.objects.create(
+            slug='2016-10-20-unpublished',
+            start=date(2016, 10, 20),
+            end=date(2016, 10, 21),
+            host=Organization.objects.first(),
+            administrator=Organization.objects.first(),
+        )
+        unpublished_event.tags = Tag.objects.filter(name__in=['TTT', 'online'])
+
+        unpublished = Event.objects.unpublished_events().select_related('host')
+        self.assertIn(unpublished_event, unpublished)
+        self.assertEqual(
+            1, len(unpublished.filter(slug='2016-10-20-unpublished'))
+        )
+
     def test_delete_event(self):
         """Make sure deleted event and its tasks are no longer accessible."""
         event = Event.objects.get(slug="starts-today-ongoing")


### PR DESCRIPTION
This fixes #977.
The reason for this issue is: when using Q(tags__name="asd") on events
with multiple tags, they may be counted as N separate objects, where N
is equal to the number of tags.