### PR TITLE
Remove unresponsive workshops from workshop issues

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2191,8 +2191,9 @@ def workshop_issues(request):
             )
         )
     )
+    no_attendance = Q(attendance=None) | Q(attendance=0)
     events = events.filter(
-        Q(attendance=None) | Q(attendance=0) |
+        (no_attendance & ~Q(tags__name='unresponsive')) |
         Q(country=None) |
         Q(venue=None) | Q(venue__exact='') |
         Q(address=None) | Q(address__exact='') |


### PR DESCRIPTION
This fixes #936.

Actually the fix removes unresponsive workshops only from the attendance
part of report from "Workshop issues" page.