### PR TITLE
Event import: Prefer GET `url` from POST one

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -1367,7 +1367,8 @@ def event_import(request):
     This is used to read metadata from workshop website and then fill up fields
     on event_create form."""
 
-    url = request.GET.get('url', '').strip()
+    url = (request.POST.get('url', '').strip() or
+           request.GET.get('url', '').strip())
 
     try:
         metadata = fetch_event_metadata(url)


### PR DESCRIPTION
This fixes #999.

The error in #999 was that somehow the `url` parameter sent to
`fetch_event_metadata` function was received from GET, while we used the
POST method.

This fix makes sure we accept any `url` (GET is still preferred).