### PR TITLE
Airport details page: fix wrong URL param causing 500

### DIFF
--- a/workshops/templates/workshops/airport.html
+++ b/workshops/templates/workshops/airport.html
@@ -21,7 +21,7 @@
   {% endif %}
   <div class="delete-object pull-right">
     {% if perms.workshops.delete_airport %}
-    <form action="{% url 'airport_delete' iata=airport.iata %}" onsubmit='return confirm("Are you sure you wish to remove  \"{{ airport }}\"?")' method="POST">
+    <form action="{% url 'airport_delete' airport_iata=airport.iata %}" onsubmit='return confirm("Are you sure you wish to remove  \"{{ airport }}\"?")' method="POST">
       {% csrf_token %}
       <button type="submit" class="btn btn-danger">Delete airport</button>
     </form>

--- a/workshops/test/test_airport.py
+++ b/workshops/test/test_airport.py
@@ -9,6 +9,11 @@ class TestAirport(TestBase):
         super().setUp()
         self._setUpUsersAndLogin()
 
+    def test_airport_details(self):
+        """Regression test: ensure airport details page renders correctly."""
+        rv = self.client.get(reverse('airport_details', args=['AAA']))
+        self.assertEqual(rv.status_code, 200)
+
     def test_airport_delete(self):
         """Make sure deleted airport is longer accessible.
 


### PR DESCRIPTION
This fixes #1008.

The error was: template used
`{% url 'airport_details' iata=airport.iata %}`
instead of
`{% url 'airport_details' airport_iata=airport.iata %}`
which caused 500 on every airport details page.