### PR TITLE
Add test for instructor badge eligibility

### DIFF
--- a/workshops/test/test_person.py
+++ b/workshops/test/test_person.py
@@ -900,8 +900,12 @@ class TestGetMissingSWCInstructorRequirements(TestBase):
                          set())
 
     def test_some_requirements_are_fulfilled(self):
+        # Homework was accepted, the second time.
+        TrainingProgress.objects.create(trainee=self.person, state='f',
+                                        requirement=self.swc_homework)
         TrainingProgress.objects.create(trainee=self.person, state='p',
                                         requirement=self.swc_homework)
+        # Dc-demo records should be ignored
         TrainingProgress.objects.create(trainee=self.person, state='p',
                                         requirement=self.dc_demo)
         # Not passed progress should be ignored.
@@ -947,9 +951,12 @@ class TestGetMissingDCInstructorRequirements(TestBase):
                          set())
 
     def test_some_requirements_are_fulfilled(self):
+        # Homework was accepted, the second time.
+        TrainingProgress.objects.create(trainee=self.person, state='f',
+                                        requirement=self.dc_homework)
         TrainingProgress.objects.create(trainee=self.person, state='p',
                                         requirement=self.dc_homework)
-
+        # Swc-demo should be ignored
         TrainingProgress.objects.create(trainee=self.person, state='p',
                                         requirement=self.swc_demo)
         # Not passed progress should be ignored.


### PR DESCRIPTION
Modify two tests (one for SWC and one for DC) to cover the following
scenario:

- add a "SWC/DC Homework" training progress record for Person XYZ that
  they failed.

- then add "SWC/DC Homework" training progress record for the same person
  that they passed (because they did a second demo and it worked).

- now "SWC/DC Homework" should be not listed in the list of missing
  SWC/DC requirements

Ref discussion on amy-dev mailing list:
http://lists.software-carpentry.org/pipermail/amy-dev/2016-September/000170.html