### PR TITLE
Fix #981 -- add more ways to issue a badge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pygithub>=1.26,<=1.27
 python-social-auth>=0.2.19,<0.3
 Requests-OAuthlib>=0.6.1,<0.7
 django-app-namespace-template-loader>=0.4
+django-webtest==1.8.0

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -464,7 +464,7 @@ class PersonForm(forms.ModelForm):
         widget=selectable.AutoComboboxSelectMultipleWidget,
     )
 
-    helper = bootstrap_helper
+    helper = BootstrapHelper(form_id='person-edit-form')
 
     class Meta:
         model = Person
@@ -647,7 +647,7 @@ class PersonAwardForm(forms.ModelForm):
         widget=selectable.AutoComboboxSelectWidget,
     )
 
-    helper = BootstrapHelper(submit_label='Add')
+    helper = BootstrapHelper(submit_label='Add', form_id='person-awards-form')
 
     class Meta:
         model = Award
@@ -664,7 +664,7 @@ class PersonTaskForm(forms.ModelForm):
         widget=selectable.AutoComboboxSelectWidget,
     )
 
-    helper = BootstrapHelper(submit_label='Add')
+    helper = BootstrapHelper(submit_label='Add', form_id='person-tasks-form')
 
     class Meta:
         model = Task
@@ -1338,9 +1338,6 @@ class BulkDiscardProgressesForm(forms.Form):
         HTML('&nbsp;<a bulk-email-on-click class="btn btn-primary">'
              'Mail selected trainees</a>'),
     )
-
-    class Meta:
-        model = TrainingProgress
 
 
 class BulkChangeTrainingRequestForm(forms.Form):

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -44,7 +44,8 @@ class BootstrapHelper(FormHelper):
                  additional_form_class='',
                  form_tag=True,
                  display_labels=True,
-                 form_action=None):
+                 form_action=None,
+                 form_id=None):
         """
         `duplicate_buttons_on_top` -- Whether submit buttons should be
         displayed on both top and bottom of the form.
@@ -114,11 +115,16 @@ class BootstrapHelper(FormHelper):
         if form_action is not None:
             self.form_action = form_action
 
+        if form_id is not None:
+            self.form_id = form_id
+
+
 
 class BootstrapHelperFilter(FormHelper):
     """A differently shaped forms (more space-efficient) for use in sidebar as
     filter forms."""
     form_method = 'get'
+    form_id = 'filter-form'
 
     def __init__(self, form=None):
         super().__init__(form)

--- a/workshops/templates/navigation_fixed.html
+++ b/workshops/templates/navigation_fixed.html
@@ -70,7 +70,7 @@
               </ul>
             </li>
           </ul>
-          <form class="navbar-form navbar-left" role="search" method="post" action="{% url "search" %}">
+          <form class="navbar-form navbar-left" id="search-form" role="search" method="post" action="{% url "search" %}">
             {% csrf_token %}
             <input type="hidden" name="in_organizations" value="on" />
             <input type="hidden" name="in_events" value="on" />

--- a/workshops/templates/workshops/all_trainees.html
+++ b/workshops/templates/workshops/all_trainees.html
@@ -97,35 +97,41 @@
             <span class="label label-primary" data-toggle="popover"
                   data-content="This person is SWC instructor">SWC</span>
           {% elif trainee.get_missing_swc_instructor_requirements %}
-            <span class="label label-default" data-toggle="popover" data-html="true"
-                  data-content="
-                    Not eligible to be certified as Software Carpentry Instructor. Needs to pass:
-                      <ul>
-                        {% for requirement in trainee.get_missing_swc_instructor_requirements %}
-                          <li>{{ requirement }}</li>
-                        {% endfor %}
-                      </ul>
-                  ">SWC</span>
+            <a class="label label-default" data-toggle="popover" data-html="true"
+               data-content="
+                 Not eligible to be certified as Software Carpentry Instructor. Needs to pass:
+                   <ul>
+                     {% for requirement in trainee.get_missing_swc_instructor_requirements %}
+                       <li>{{ requirement }}</li>
+                     {% endfor %}
+                   </ul>
+                 Click to start awarding the badge.
+               "
+               href="{% url 'person_edit' trainee.pk %}?badge=swc-instructor&amp;find-training&amp;next={{ request.get_full_path|urlencode }}#awards">SWC</a>
           {% else %}
-            <span class="label label-success" data-toggle="popover"
-                  data-content="Eligible to be certified as Software Carpentry Instructor.">SWC</span>
+          <a class="label label-success" data-toggle="popover"
+                 data-content="Eligible to be certified as Software Carpentry Instructor. Click to start awarding the badge."
+                 href="{% url 'person_edit' trainee.pk %}?badge=swc-instructor&amp;find-training&amp;next={{ request.get_full_path|urlencode }}#awards">SWC</a>
           {% endif %}
           {% if trainee.is_dc_instructor %}
-            <span class="label label-primary" data-toggle="popover"
-                  data-content="This person is DC Instructor.">DC</span>
-          {% elif trainee.get_missing_dc_instructor_requirements %}
-            <span class="label label-default" data-toggle="popover" data-html="true"
-                  data-content="
-                    Not eligible to be certified as Data Carpentry Instructor. Needs to pass:
-                    <ul>
-                      {% for requirement in trainee.get_missing_dc_instructor_requirements %}
-                        <li>{{ requirement }}</li>
-                      {% endfor %}
-                    </ul>
-                  ">DC</span>
+              <span class="label label-primary" data-toggle="popover"
+                    data-content="This person is DC Instructor.">DC</span>
+            {% elif trainee.get_missing_dc_instructor_requirements %}
+              <a class="label label-default" data-toggle="popover" data-html="true"
+                 data-content="
+                   Not eligible to be certified as Data Carpentry Instructor. Needs to pass:
+                   <ul>
+                     {% for requirement in trainee.get_missing_dc_instructor_requirements %}
+                       <li>{{ requirement }}</li>
+                     {% endfor %}
+                   </ul>
+                   Click to start awarding the badge.
+                 "
+                 href="{% url 'person_edit' trainee.pk %}?badge=dc-instructor&amp;find-training&amp;next={{ request.get_full_path|urlencode }}#awards">DC</a>
           {% else %}
-            <span class="label label-success" data-toggle="popover"
-                  data-content="Eligible to be certified as Data Carpentry Instructor.">DC</span>
+          <a class="label label-success" data-toggle="popover"
+                 data-content="Eligible to be certified as Data Carpentry Instructor. Click to start awarding the badge."
+                 href="{% url 'person_edit' trainee.pk %}?badge=dc-instructor&amp;find-training&amp;next={{ request.get_full_path|urlencode }}#awards">DC</a>
           {% endif %}
         </td>
         <td>

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -23,7 +23,8 @@ from django.db.models import Q
 from django.http import Http404
 from django.http.response import HttpResponse
 from django.http.response import HttpResponseForbidden
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.utils.http import is_safe_url
 from selectable.decorators import results_decorator
 
 from workshops.models import Event, Role, Person, Task, Badge, is_admin
@@ -946,3 +947,20 @@ def homework2state(homework):
     else:  # failed homework
         assert homework.state == 'f'
         return 'none'
+
+
+def redirect_with_next_support(request, *args, **kwargs):
+    """Works in the same way as `redirect` except when there is GET parameter
+    named "next". In that case, user is redirected to the URL from that
+    parameter. If you have a class-based view, use RedirectSupportMixin that
+    does the same. """
+
+    next_url = request.GET.get('next', None)
+    if next_url is not None and is_safe_url(next_url):
+        return redirect(next_url)
+    else:
+        return redirect(*args, **kwargs)
+
+
+def dict_without_Nones(**keys):
+    return {k: v for k, v in keys.items() if v is not None}


### PR DESCRIPTION
"SWC" and "DC" labels in "eligible" column in trainees list view are
now clickable when a person is eligible to become SWC/DC instructor, but
doesn't have a swc/dc-instructor badge yet. The user is moved to person
edit view where the badge can be awarded.