### PR TITLE
Install django debug toolbar

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -141,11 +141,13 @@ INSTALLED_APPS = (
     'captcha',
     'compressor',
     'social.apps.django_app.default',
+    'debug_toolbar',
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 MIDDLEWARE_CLASSES = (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'reversion.middleware.RevisionMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -340,3 +342,14 @@ if DEBUG and 'test' in sys.argv:
     PASSWORD_HASHERS = (
         'django.contrib.auth.hashers.MD5PasswordHasher',
     )
+
+# Debug Toolbar
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+INTERNAL_IPS = ['127.0.0.1', '::1']
+DEBUG_TOOLBAR_CONFIG = {
+    # Disable all panels (except for timer) by default in order not to slow
+    # down page loading.
+    'DISABLE_PANELS': [
+        'debug_toolbar.panels.sql.SQLPanel',
+    ],
+}

--- a/amy/urls.py
+++ b/amy/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
@@ -44,3 +45,10 @@ urlpatterns = [
     # Login with GitHub credentials
     url('', include('social.apps.django_app.urls', namespace='social')),
 ]
+
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ python-social-auth>=0.2.19,<0.3
 Requests-OAuthlib>=0.6.1,<0.7
 django-app-namespace-template-loader>=0.4
 django-webtest==1.8.0
+django-debug-toolbar==1.5


### PR DESCRIPTION
The toolbar is enabled only when `DEBUG == True`. By default, almost all its functionality is disabled in order not to slow down page reloads. They can be turned on using checkboxes in the toolbox. The only one functionality that is turned on is "timing panel" that shows how long it took to process the last request.

The most useful feature of the toolbar is SQL panel which shows how many queries have been executed and how long did they take. It's important to track how long they execute to ensure that AMY scales up with growing database. In addition, it's much easier to make performance experiments now.