### PR TITLE
Fix #978 -- remove double-counting in display of instructor counts

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -107,7 +107,7 @@ class WorkshopsOverTimeSerializer(serializers.Serializer):
 
 
 class InstructorsOverTimeSerializer(serializers.Serializer):
-    date = serializers.DateField(format=None, source='awarded')
+    date = serializers.DateField(format=None)
     count = serializers.IntegerField()
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -260,11 +260,13 @@ class ReportsViewSet(ViewSet):
             prev_ = next(it)
         except StopIteration:
             return
+        next_ = None
         for next_ in it:
             if prev_['date'] != next_['date']:
                 yield prev_
             prev_ = next_
-        yield next_
+        if next_ is not None:
+            yield next_
 
     def listify(self, iterable, request, format=None):
         """Some renderers require lists instead of any iterables for rendering.


### PR DESCRIPTION
This:
```python
        qs = Person.objects.filter(badges__in=badges)  \
                           .annotate(date=Min('award__awarded'),
                                     count=Value(1,
                                                 output_field=IntegerField())) \
                           .order_by('date')
```

~~results in this SQL:~~
```SQL
SELECT ••• FROM "workshops_person" 
INNER JOIN "workshops_award" 
ON ("workshops_person"."id" = "workshops_award"."person_id") 
WHERE "workshops_award"."badge_id" IN (
    SELECT ••• FROM "workshops_badge" U0 
    WHERE U0."name" IN ('''dc-instructor''', '''swc-instructor''')) 
GROUP BY "workshops_person".•••
ORDER BY "date" ASC
```

@pbanaszkiewicz could you confirm that this counts in correct way?

@edit:

The SQL query is actually:
```SQL
SELECT workshop_person.•••, 
       MIN("workshops_award"."awarded") AS "date", 
       '1' AS count
FROM "workshops_person" 
INNER JOIN "workshops_award" 
ON ("workshops_person"."id" = "workshops_award"."person_id") 
WHERE "workshops_award"."badge_id" IN (
    SELECT ••• FROM "workshops_badge" U0 
    WHERE U0."name" IN ('''dc-instructor''', '''swc-instructor''')) 
GROUP BY "workshops_person".•••
ORDER BY "date" ASC
```