### PR TITLE
Refactor views to allow better form prepopulation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML
 requests>=2.0
 requests-mock>=0.7,<0.8
 django-crispy-forms>=1.6,<1.7
-django-selectable>=0.9.0,<1.0
+git+https://github.com/mlavin/django-selectable.git@45b0dc8c4e6351afc9986b7edf2e45c3416cd66e#egg=django-selectable
 django-countries>=3.4,<3.5
 django-filter>=0.12,<0.13
 django-reversion>=1.10,<1.11

--- a/workshops/base_views.py
+++ b/workshops/base_views.py
@@ -206,3 +206,19 @@ class RedirectSupportMixin:
             return next_url
         else:
             return default_url
+
+
+class PrepopulationSupportMixin:
+
+    def get_initial(self):
+        return {
+            field: self.request.GET.get(field) for field in self.populate_fields
+        }
+
+    def get_form(self, *args, **kwargs):
+        """Disable fields that are pre-populated."""
+        form = super().get_form(*args, **kwargs)
+        for field in self.populate_fields:
+            if field in self.request.GET:
+                form.fields[field].disabled = True
+        return form

--- a/workshops/templates/workshops/organization.html
+++ b/workshops/templates/workshops/organization.html
@@ -118,7 +118,7 @@
 {% endif %}
 
 {% if perms.workshops.add_membership and perms.workshops.change_organization %}
-  <a href="{% url 'membership_add' organization.domain %}" class="btn btn-success">Add a membership</a>
+  <a href="{% url 'membership_add' %}?organization={{ organization.pk }}" class="btn btn-success">Add a membership</a>
 {% else %}
   <a href="#" class="btn btn-success disabled">Add a membership</a>
 {% endif %}

--- a/workshops/templates/workshops/training_progresses_inline.html
+++ b/workshops/templates/workshops/training_progresses_inline.html
@@ -12,6 +12,6 @@
   </a>
   &nbsp;
 {% endfor %}
-<a href="{% url 'trainingprogress_add' person.id %}?next={{ request.get_full_path|urlencode }}"
+<a href="{% url 'trainingprogress_add' %}?trainee={{ person.id|urlencode }}&amp;next={{ request.get_full_path|urlencode }}"
    class="label label-default"
    data-toggle="popover" data-content="Click to add new progress">+</a>

--- a/workshops/test/test_training_progress.py
+++ b/workshops/test/test_training_progress.py
@@ -219,11 +219,12 @@ class TestCRUDViews(TestBase):
         self.assertEqual(rv.context['form'].initial['evaluated_by'], self.admin)
 
     def test_create_view_works_with_initial_trainee(self):
-        rv = self.client.get(reverse('trainingprogress_add',
-                                     args=[self.ironman.pk]))
+        rv = self.client.get(reverse('trainingprogress_add'), {
+            'trainee': self.ironman.pk
+        })
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.context['form'].initial['evaluated_by'], self.admin)
-        self.assertEqual(rv.context['form'].initial['trainee'], self.ironman)
+        self.assertEqual(int(rv.context['form'].initial['trainee']), self.ironman.pk)
 
     def test_create_view_works(self):
         data = {

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -23,7 +23,6 @@ urlpatterns = [
     url(r'^memberships/', include([
         url(r'^$', views.AllMemberships.as_view(), name='all_memberships'),
         url(r'^add/$', views.MembershipCreate.as_view(), name='membership_add'),
-        url(r'^add/(?P<org_domain>[\w\.-]+)/$', views.MembershipCreate.as_view(), name='membership_add'),
     ])),
     url(r'^membership/(?P<membership_id>\d+)/', include([
         url(r'^$', views.MembershipDetails.as_view(), name='membership_details'),
@@ -179,7 +178,6 @@ urlpatterns = [
     url(r'^trainees/$', views.all_trainees, name='all_trainees'),
 
     url(r'^training_progresses/add/$', views.TrainingProgressCreate.as_view(), name='trainingprogress_add'),
-    url(r'^training_progresses/add/(?P<trainee_id>\d+)/$', views.TrainingProgressCreate.as_view(), name='trainingprogress_add'),
     url(r'^training_progress/(?P<pk>\d+)/', include([
         url(r'^edit/$', views.TrainingProgressUpdate.as_view(), name='trainingprogress_edit'),
         url(r'^delete/$', views.TrainingProgressDelete.as_view(), name='trainingprogress_delete'),


### PR DESCRIPTION
Changes:
1. Adds a `PrepopulationSupportMixin` view.
   The mixin prepopulates and disables fields based on GET parameters.
2. Refactor `MembershipCreate` view to use `PrepopulationSupportMixin`

@pbanaszkiewicz @chrismedrela please review.