### PR TITLE
Allow requests from localhost while in DEBUG mode.

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -117,7 +117,8 @@ TEMPLATES = [
 ALLOWED_HOSTS = [
     'amy.software-carpentry.org',
 ]
-
+if DEBUG:
+    ALLOWED_HOSTS.append('127.0.0.1')
 
 # Application definition
 


### PR DESCRIPTION
From Django official docs:
> Changed in Django 1.10.3:
> In older versions, ALLOWED_HOSTS wasn’t checked if DEBUG=True.
> This was also changed in Django 1.9.11 and 1.8.16 to prevent a DNS rebinding attack.