### PR TITLE
Bulk upload: fix #1000 ("use that person") and #1015 (list of roles)

### DIFF
--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -43,7 +43,18 @@
             </td>
             <td class="editable">
                 <span>{{ entry.role|default:"—" }}</span>
-                <input type="text" name="role" value="{{ entry.role|default:"" }}" class="hidden">
+                <select name="role" class="hidden">
+                {% if entry.role in possible_roles %}
+                    {% for role in possible_roles %}
+                    <option value="{{ role }}" {% if role == entry.role %}selected="selected"{% endif %}>{{ role }}</option>
+                    {% endfor %}
+                {% else %}
+                    <option selected="selected" value="{{ entry.role }}">{{ entry.role }}</option>
+                    {% for role in possible_roles %}
+                    <option value="{{ role }}">{{ role }}</option>
+                    {% endfor %}
+                {% endif %}
+                </select>
                 </td>
             <td class="text-danger">
             {% if entry.errors %}
@@ -100,8 +111,10 @@
             var cell = $(e.currentTarget).parent();
             var span = $(cell).find("span");
             var input = $(cell).find("input");
+            var select = $(cell).find("select");
             $(span).addClass("hidden");
             $(input).removeClass("hidden");
+            $(select).removeClass("hidden");
         }
     });
 

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -55,7 +55,7 @@
                     {% endfor %}
                 {% endif %}
                 </select>
-                </td>
+            </td>
             <td class="text-danger">
             {% if entry.errors %}
                 <ul>
@@ -70,6 +70,13 @@
                 <ul>
                 {% for info in entry.info %}
                     <li>{{ info }}</li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+            {% if entry.similar_persons %}
+                <ul>
+                {% for person in entry.similar_persons %}
+                    <li>Matching person: <a href="{% url 'person_details' person.id %}">{{ person.personal }} {{ person.middle }} {{ person.family }} &lt;{{ person.email|default:"—" }}&gt;</a>. <a href="{% url 'person_bulk_add_match_person' i person.id %}">Use that person</a>.</li>
                 {% endfor %}
                 </ul>
             {% endif %}

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -72,7 +72,7 @@
             {% if entry.similar_persons %}
                 <ul>
                 {% for person in entry.similar_persons %}
-                    <li>Matching person: <a href="{% url 'person_details' person.id %}">{{ person.personal }} {{ person.middle }} {{ person.family }} &lt;{{ person.email|default:"—" }}&gt;</a>. <a href="{% url 'person_bulk_add_match_person' i person.id %}">Use that person</a>.</li>
+                    <li>Matching person: <a href="{% url 'person_details' person.id %}">{{ person.personal }} {{ person.middle }} {{ person.family }} &lt;{{ person.email|default:"—" }}&gt;</a>. <a href="{% url 'person_bulk_add_match_person' i person.id %}">Use this person</a>.</li>
                 {% endfor %}
                 </ul>
             {% endif %}

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -65,7 +65,7 @@
             </td>
             <td>
             {% if persons_tasks|length > 1 %}
-            <a href="{% url 'person_bulk_add_remove_entry' i %}"><span class="glyphicon glyphicon-remove"></span></a>
+            <a href="{% url 'person_bulk_add_remove_entry' i %}" title='Remove this entry'><span class="glyphicon glyphicon-remove"></span></a>
             {% endif %}
             </td>
         {% endwith %}

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -44,16 +44,12 @@
             <td class="editable">
                 <span>{{ entry.role|default:"—" }}</span>
                 <select name="role" class="hidden">
-                {% if entry.role in possible_roles %}
-                    {% for role in possible_roles %}
-                    <option value="{{ role }}" {% if role == entry.role %}selected="selected"{% endif %}>{{ role }}</option>
-                    {% endfor %}
-                {% else %}
+                {% if entry.role not in possible_roles %}
                     <option selected="selected" value="{{ entry.role }}">{{ entry.role }}</option>
-                    {% for role in possible_roles %}
-                    <option value="{{ role }}">{{ role }}</option>
-                    {% endfor %}
                 {% endif %}
+                {% for role in possible_roles %}
+                    <option value="{{ role }}" {% if role == entry.role %}selected="selected"{% endif %}>{{ role }}</option>
+                {% endfor %}
                 </select>
             </td>
             <td class="text-danger">

--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -80,7 +80,7 @@
     stay the way they're now: "confirm" and "cancel".  Values can change.
     {% endcomment %}
     {% if any_errors %}
-    <input type="submit" name="confirm" value="Confirm and save" class="btn btn-success disabled">
+    <input type="button" name="confirm" value="Confirm and save" class="btn btn-success disabled">
     {% else %}
     <input type="submit" name="confirm" value="Confirm and save" class="btn btn-success">
     {% endif %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -40,14 +40,17 @@ urlpatterns = [
         url(r'^delete/$', views.AirportDelete.as_view(), name='airport_delete'),
     ])),
 
+    url(r'^bulk_upload/', include([
+        url(r'^$',views.person_bulk_add, name='person_bulk_add'),
+        url(r'^template/$',views.person_bulk_add_template, name='person_bulk_add_template'),
+        url(r'^confirm/$',views.person_bulk_add_confirmation, name='person_bulk_add_confirmation'),
+        url(r'^(?P<entry_id>\d+)/remove/$',views.person_bulk_add_remove_entry, name='person_bulk_add_remove_entry'),
+        url(r'^(?P<entry_id>\d+)/match_person/(?P<person_id>\d+)$',views.person_bulk_add_match_person, name='person_bulk_add_match_person'),
+    ])),
+
     url(r'^persons/', include([
         url(r'^$', views.AllPersons.as_view(), name='all_persons'),
         url(r'^add/$', views.PersonCreate.as_view(), name='person_add'),
-        url(r'^bulkadd/$',views.person_bulk_add, name='person_bulk_add'),
-        url(r'^bulkadd/template/$',views.person_bulk_add_template, name='person_bulk_add_template'),
-        url(r'^bulkadd/confirm/$',views.person_bulk_add_confirmation, name='person_bulk_add_confirmation'),
-        url(r'^bulkadd/(?P<entry_id>\d+)/remove/$',views.person_bulk_add_remove_entry, name='person_bulk_add_remove_entry'),
-        url(r'^bulkadd/(?P<entry_id>\d+)/match_person/(?P<person_id>\d+)$',views.person_bulk_add_match_person, name='person_bulk_add_match_person'),
         url(r'^merge/$', views.persons_merge, name='persons_merge'),
     ])),
     url(r'^person/(?P<person_id>\d+)/', include([

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
         url(r'^bulkadd/template/$',views.person_bulk_add_template, name='person_bulk_add_template'),
         url(r'^bulkadd/confirm/$',views.person_bulk_add_confirmation, name='person_bulk_add_confirmation'),
         url(r'^bulkadd/(?P<entry_id>\d+)/remove/$',views.person_bulk_add_remove_entry, name='person_bulk_add_remove_entry'),
+        url(r'^bulkadd/(?P<entry_id>\d+)/match_person/(?P<person_id>\d+)$',views.person_bulk_add_match_person, name='person_bulk_add_match_person'),
         url(r'^merge/$', views.persons_merge, name='persons_merge'),
     ])),
     url(r'^person/(?P<person_id>\d+)/', include([

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -174,7 +174,9 @@ def verify_upload_person_task(data):
             Q(email=email) & ~Q(email='') & Q(email__isnull=False)
         )
         # need to cast to list, otherwise it won't JSON-ify
-        item['similar_persons'] = list(similar_persons.values())
+        item['similar_persons'] = list(similar_persons.values(
+            'id', 'personal', 'middle', 'family', 'email', 'username',
+        ))
 
         if existing_event and person and existing_role:
             # person, their role and a corresponding event exist, so

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -155,9 +155,9 @@ def verify_upload_person_task(data):
 
         if person:
             # force details from existing record
-            item['personal'] = person.personal
-            item['family'] = person.family
-            item['email'] = person.email
+            item['personal'] = personal = person.personal
+            item['family'] = family = person.family
+            item['email'] = email = person.email
             item['username'] = person.username
             item['person_exists'] = True
         else:

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -570,12 +570,6 @@ def person_bulk_add_confirmation(request):
                                      "Please make sure to fix all errors "
                                      "listed below.")
 
-            context = {'title': 'Confirm uploaded data',
-                       'persons_tasks': persons_tasks,
-                       'any_errors': any_errors}
-            return render(request, 'workshops/person_bulk_add_results.html',
-                          context)
-
         # there must be "confirm" and no "cancel" in POST in order to save
         elif (request.POST.get('confirm', None) and
               not request.POST.get('cancel', None)):
@@ -591,12 +585,6 @@ def person_bulk_add_confirmation(request):
                                      "Please make sure to fix all errors "
                                      "listed below.".format(e))
                 any_errors = verify_upload_person_task(persons_tasks)
-                context = {'title': 'Confirm uploaded data',
-                           'persons_tasks': persons_tasks,
-                           'any_errors': any_errors}
-                return render(request,
-                              'workshops/person_bulk_add_results.html',
-                              context, status=400)
 
             else:
                 request.session['bulk-add-people'] = None
@@ -616,11 +604,11 @@ def person_bulk_add_confirmation(request):
         # alters persons_tasks via reference
         any_errors = verify_upload_person_task(persons_tasks)
 
-        context = {'title': 'Confirm uploaded data',
-                   'persons_tasks': persons_tasks,
-                   'any_errors': any_errors}
-        return render(request, 'workshops/person_bulk_add_results.html',
-                      context)
+    context = {'title': 'Confirm uploaded data',
+               'persons_tasks': persons_tasks,
+               'any_errors': any_errors}
+    return render(request, 'workshops/person_bulk_add_results.html',
+                  context)
 
 
 @admin_required

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -544,12 +544,14 @@ def person_bulk_add_confirmation(request):
                           roles)
         for k, record in enumerate(data_update):
             personal, family, username, email, event, role = record
+            existing_person_id = persons_tasks[k].get('existing_person_id')
             # "field or None" converts empty strings to None values
             persons_tasks[k] = {
                 'personal': personal,
                 'family': family,
                 'username': username,
-                'email': email or None
+                'email': email or None,
+                'existing_person_id': existing_person_id,
             }
             # when user wants to drop related event they will send empty string
             # so we should unconditionally accept new value for event even if
@@ -626,6 +628,32 @@ def person_bulk_add_remove_entry(request, entry_id):
         entry_id = int(entry_id)
         try:
             del persons_tasks[entry_id]
+            request.session['bulk-add-people'] = persons_tasks
+
+        except IndexError:
+            messages.warning(request, 'Could not find specified entry #{}'
+                                      .format(entry_id))
+
+        return redirect(person_bulk_add_confirmation)
+
+    else:
+        messages.warning(request, 'Could not locate CSV data, please try the '
+                                  'upload again.')
+        return redirect('person_bulk_add')
+
+
+@admin_required
+@permission_required('workshops.add_person', raise_exception=True)
+def person_bulk_add_match_person(request, entry_id, person_id):
+    """Save information about matched person in the session-saved data."""
+    persons_tasks = request.session.get('bulk-add-people')
+
+    if persons_tasks:
+        entry_id = int(entry_id)
+        person_id = int(person_id)
+
+        try:
+            persons_tasks[entry_id]['existing_person_id'] = person_id
             request.session['bulk-add-people'] = persons_tasks
 
         except IndexError:

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -604,9 +604,14 @@ def person_bulk_add_confirmation(request):
         # alters persons_tasks via reference
         any_errors = verify_upload_person_task(persons_tasks)
 
-    context = {'title': 'Confirm uploaded data',
-               'persons_tasks': persons_tasks,
-               'any_errors': any_errors}
+    roles = Role.objects.all().values_list('name', flat=True)
+
+    context = {
+        'title': 'Confirm uploaded data',
+        'persons_tasks': persons_tasks,
+        'any_errors': any_errors,
+        'possible_roles': roles,
+    }
     return render(request, 'workshops/person_bulk_add_results.html',
                   context)
 


### PR DESCRIPTION
This PR fixes #1000 and #1015 (in one of the commits).

88c3e1e, c0ecdfa, e28c85e and fa96e0e are cleaning up and / or fixing small bugs. Other commits change the workflow for bulk-upload (slightly). Some parts, like magic-matching or showing if `personal` or `family` is different in DB/uploaded file, were removed; it looks like we ended up with slightly more maintainable code.