### PR TITLE
Fix: missing import in extforms

### DIFF
--- a/extforms/views.py
+++ b/extforms/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.contrib import messages
+from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import render
 from django.template.loader import get_template
 from django.views.generic import TemplateView


### PR DESCRIPTION
`django.contrib.messages` was missing which caused the error when
someone submitted their form. The error thankfully didn't prevent data
from saving to the database.

The error was caused because I did not check the source code for missing
imports (new machine, no linter installed). This is now fixed.