### PR TITLE
Fix the delete button on the TrainingProgressUpdate view.

### DIFF
--- a/workshops/templates/workshops/trainingprogress_form.html
+++ b/workshops/templates/workshops/trainingprogress_form.html
@@ -4,7 +4,7 @@
 {% load selectable_tags %}
 
 {% block content %}
-<form action="delete?next={{ request.GET.next|urlencode }}" method="POST" id="delete-form">
+<form action="{% url 'trainingprogress_delete' object.pk %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}" method="POST" id="delete-form">
   {% csrf_token %}
 </form>
 {% crispy form %}

--- a/workshops/test/test_training_progress.py
+++ b/workshops/test/test_training_progress.py
@@ -256,3 +256,16 @@ class TestCRUDViews(TestBase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, 'all_trainees')
         self.assertEqual(set(TrainingProgress.objects.all()), set())
+
+    def test_delete_trainingprogress_from_edit_view(self):
+        """Regression test for issue #1085."""
+        trainingprogress_edit = self.app.get(
+            reverse('trainingprogress_edit', args=[self.progress.pk]),
+            user='admin'
+        )
+        self.assertRedirects(
+            trainingprogress_edit.forms['delete-form'].submit(),
+            reverse('all_trainees')
+        )
+        with self.assertRaises(TrainingProgress.DoesNotExist):
+            self.progress.refresh_from_db()

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3088,7 +3088,7 @@ class TrainingProgressUpdate(RedirectSupportMixin, OnlyForAdminsMixin,
                              AMYUpdateView):
     model = TrainingProgress
     form_class = TrainingProgressForm
-    template_name = 'workshops/generic_form.html'
+    template_name = 'workshops/trainingprogress_form.html'
 
 
 class TrainingProgressDelete(RedirectSupportMixin, OnlyForAdminsMixin,


### PR DESCRIPTION
`delete-form` now submits to the delete view of the object.

Fixes #1085 