### PR TITLE
Event form tags: bigger list; resizable <select>s

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.forms import (
     HiddenInput,
+    SelectMultiple,
     CheckboxSelectMultiple,
     TextInput,
     modelformset_factory,
@@ -435,6 +436,7 @@ class EventForm(forms.ModelForm):
             'latitude': TextInput,
             'longitude': TextInput,
             'invoice_status': RadioSelect,
+            'tags': SelectMultiple(attrs={'size': 10}),
         }
 
     class Media:

--- a/workshops/static/css/amy.css
+++ b/workshops/static/css/amy.css
@@ -208,3 +208,8 @@ table ul {
 .glyphicon-question-sign {
     color: rgb(51, 122, 183);
 }
+
+/* Make select lists resizable */
+select {
+    resize: vertical;
+}


### PR DESCRIPTION
This fixes #898 by:

* changing default size of "Tags" field on Event add/edit forms to 10
  (the current number of tags in the database),
* adding "resize: vertical" option to CSS3 for <select> tags; therefore
  making any <select> resizable in vertical if user wants to just see
  more of the options.