### PR TITLE
Speed up person details & update, and admin dashboard pages

### DIFF
--- a/workshops/templates/workshops/admin_dashboard.html
+++ b/workshops/templates/workshops/admin_dashboard.html
@@ -68,23 +68,16 @@
       <tr>
         <th>#I</th>
         <th>dates</th>
-        <th>domain</th>
         <th>slug</th>
+        <th>host</th>
       </tr>
       {% for event in unpublished_events %}
       <tr>
-        {% with num_instructors=event.task_set.instructors.count %}
-        <td {% if num_instructors == 0 %}class="warning"{% endif %}>
-          {{ num_instructors }}
+        <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
+          {{ event.num_instructors }}
         </td>
-        {% endwith %}
         <td>
           {% if event.start %}✓{% endif %}
-        </td>
-        <td>
-          <a href="{% url 'organization_details' event.host.domain %}">
-            {{ event.host }}
-          </a>
         </td>
         <td {% if not event.slug %}class="warning"{% endif %}>
           {% if not event.slug %}
@@ -94,6 +87,11 @@
             {{ event.slug }}
           </a>
           {% endif %}
+        </td>
+        <td>
+          <a href="{% url 'organization_details' event.host.domain %}">
+            {{ event.host }}
+          </a>
         </td>
       </tr>
       {% endfor %}

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -443,7 +443,10 @@ class PersonDetails(OnlyForAdminsMixin, AMYDetailView):
                 output_field=IntegerField()
             )
         )
-    )
+    ).prefetch_related(
+        'award_set__badge', 'award_set__awarded_by', 'award_set__event',
+        'task_set__role', 'task_set__event',
+    ).select_related('airport')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -728,9 +728,11 @@ class PersonUpdate(OnlyForAdminsMixin, UserPassesTestMixin,
             'widgets': {'person': HiddenInput()},
         }
         context.update({
-            'awards': self.object.award_set.order_by('badge__name'),
+            'awards': self.object.award_set.select_related('event', 'badge')
+                          .order_by('badge__name'),
             'award_form': AwardForm(**kwargs),
-            'tasks': self.object.task_set.order_by('-event__slug'),
+            'tasks': self.object.task_set.select_related('role', 'event')
+                         .order_by('-event__slug'),
             'task_form': TaskForm(**kwargs),
         })
         return context

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -183,6 +183,10 @@ def admin_dashboard(request):
     ).active().prefetch_related('tags')
 
     uninvoiced_events = Event.objects.active().uninvoiced_events()
+
+    # This annotation may produce wrong number of instructors when 
+    # `unpublished_events` filters out events that contain a specific tag.
+    # The bug was fixed in #1130.
     unpublished_events = Event.objects \
         .active().unpublished_events().select_related('host').annotate(
             num_instructors=Count(

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -183,8 +183,15 @@ def admin_dashboard(request):
     ).active().prefetch_related('tags')
 
     uninvoiced_events = Event.objects.active().uninvoiced_events()
-    unpublished_events = Event.objects.active().unpublished_events() \
-                                      .select_related('host')
+    unpublished_events = Event.objects \
+        .active().unpublished_events().select_related('host').annotate(
+            num_instructors=Count(
+                Case(
+                    When(task__role__name='instructor', then=Value(1)),
+                    output_field=IntegerField()
+                )
+            ),
+        )
 
     assigned_to, is_admin = assignment_selection(request)
 


### PR DESCRIPTION
On a test person (@gvwilson) profile pages get to ~20 queries from >220.

Similarly dashboard is now O(const) instead of O(n) due to annotation of `num_instructors`.