### PR TITLE
Install django_extensions

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -158,6 +158,7 @@ INSTALLED_APPS += [
     'compressor',
     'social.apps.django_app.default',
     'debug_toolbar',
+    'django_extensions',
 ]
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,3 @@ django-app-namespace-template-loader>=0.4
 django-webtest==1.8.0
 django-debug-toolbar==1.5
 django-extensions>=1.7,<1.8
-jupyter>=1.0,<1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ Requests-OAuthlib>=0.6.1,<0.7
 django-app-namespace-template-loader>=0.4
 django-webtest==1.8.0
 django-debug-toolbar==1.5
+django-extensions>=1.7,<1.8
+jupyter>=1.0,<1.1


### PR DESCRIPTION
`django_extensions` provide `shell_plus --notebook` command that open jupyter notebook in a browser, which is IMO much more convenient than command line shell.