### PR TITLE
Fix #1047 -- optimize SQL queries on trainees list view

### DIFF
--- a/workshops/templates/workshops/all_trainees.html
+++ b/workshops/templates/workshops/all_trainees.html
@@ -66,7 +66,7 @@
           {% include "workshops/training_progresses_inline.html" with person=trainee %}
         </td>
         <td>
-          {% for task in trainee.get_training_tasks %}
+          {% for task in trainee.training_tasks %}
             <a href="{% url 'event_details' task.event.slug %}">{{ task.event }}</a><br />
           {% empty %}
             —

--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -92,7 +92,7 @@
           </td>
           <td>
             {% if req.person %}
-              {% for task in req.person.get_training_tasks %}
+              {% for task in req.person.training_tasks %}
                 <a href="{% url 'event_details' task.event.slug %}">{{ task.event }}</a><br />
               {% empty %}
                 —

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2746,7 +2746,12 @@ def duplicates(request):
 def all_trainingrequests(request):
     filter = TrainingRequestFilter(
         request.GET,
-        queryset=TrainingRequest.objects.all()
+        queryset=TrainingRequest.objects.all().prefetch_related(
+            Prefetch('person__task_set',
+                     to_attr='training_tasks',
+                     queryset=Task.objects.filter(role__name='learner',
+                                                  event__tags__name='TTT')),
+        )
     )
 
     requests = get_pagination_items(request, filter)


### PR DESCRIPTION
So that it always results in constant number of queries (16) and all queries execute in 500 ms with debug toolbar enabled (which makes everything much, much slower).

@narayanaditya95 or @pbanaszkiewicz please review.