### PR TITLE
Fix #1185 -- correct permission codename

### DIFF
--- a/workshops/views.py
+++ b/workshops/views.py
@@ -727,7 +727,7 @@ class PersonUpdate(OnlyForAdminsMixin, UserPassesTestMixin,
     template_name = 'workshops/person_edit_form.html'
 
     def test_func(self):
-        if not (self.request.user.has_perm('workshops.edit_person') or \
+        if not (self.request.user.has_perm('workshops.change_person') or \
             self.request.user == self.get_object()):
             raise PermissionDenied
         return True


### PR DESCRIPTION
Non-superuser admins with 'change_person' permission could not edit other people, because the person edit view required 'edit_person' permission instead of 'change_person'.

Fixes #1185.