### PR TITLE
Fix #1154 -- autocomplete fields no longer ignore invalid values

### DIFF
--- a/workshops/static/amy_utils.js
+++ b/workshops/static/amy_utils.js
@@ -130,4 +130,18 @@ $(document).ready(function() {
   var selectField = $('form.training-progress #id_requirement')
   selectField.change(updateTrainingProgressForm);
   updateTrainingProgressForm.call(selectField);
+
+  /*
+  When there is any autocomplete field with invalid value, prevent form
+  submission. Focus on the invalid field when user tries to submit the form.
+  */
+
+  $('form').submit(function (event) {
+    var invalidAutocompleteFields = $('.ui-autocomplete-input.ui-state-error');
+    if (invalidAutocompleteFields.length > 0) {
+      var firstInvalidField = invalidAutocompleteFields.first();
+      firstInvalidField.focus();
+      event.preventDefault();  // prevent submission
+    }
+  });
  });


### PR DESCRIPTION
Fixes #1154.

When you entered an invalid vaue into an autocomplete field (so that the field is red) and submit the form, invalid value is ignored and NULL was saved. No warning was displayed. This was confusing.

This commit prevents form submission if there is an invalid value in any autocomplete field. On top of that, the invalid field is focused on form submission.

There is no regression test, because we don't have end-to-end tests with javascript support (like Selenium).