### PR TITLE
Trainee dashboard enhancements

### DIFF
--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -1201,13 +1201,14 @@ class AutoUpdateProfileForm(PrivacyConsentMixin, forms.ModelForm):
             'domains',
             'lessons',
             'languages',
+            'occupation',
+            'orcid',
         ]
         readonly_fields = (
             'username',
             'github',
         )
         widgets = {
-            'occupation': forms.RadioSelect(),
             'gender': forms.RadioSelect(),
             'domains': forms.CheckboxSelectMultiple(),
             'lessons': forms.CheckboxSelectMultiple(),

--- a/workshops/templates/workshops/trainee_dashboard.html
+++ b/workshops/templates/workshops/trainee_dashboard.html
@@ -64,6 +64,15 @@
       </ul>
       <p>If you think that you're missing a badge, please email us at <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a></p>
   </td></tr>
+  <tr><th>workshops you taught at</th><td>
+      <ul>
+        {% for workshop in workshops %}
+          <li>{{ workshop.event }}</li>
+        {% empty %}
+          <li>No workshops taught.</li>
+        {% endfor %}
+      </ul>
+  </td></tr>
 </table>
 
 <p><a href="{% url 'autoupdate_profile' %}" class="btn btn-primary">Update your profile</a></p>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2932,6 +2932,9 @@ def trainee_dashboard(request):
     request.user.is_dc_instructor = request.user.award_set.filter(
         badge__name='dc-instructor').exists()
 
+    # Workshops person taught at
+    workshops = request.user.task_set.filter(role__name='instructor')
+
     if request.method == 'POST' and 'swc-submit' in request.POST:
         requirement = TrainingRequirement.objects.get(name='SWC Homework')
         progress = TrainingProgress(trainee=request.user,
@@ -2969,6 +2972,7 @@ def trainee_dashboard(request):
         'title': 'Your profile',
         'swc_form': swc_form,
         'dc_form': dc_form,
+        'workshops': workshops,
     }
     return render(request, 'workshops/trainee_dashboard.html', context)
 


### PR DESCRIPTION
1. Added list of workshops user taught at (trainee-dashboard)
2. Added ORCID and occupation fields to the form (autoupdate_profile)

The workshop listed in the `trainee-dashboard` consists only of workshops names, they aren't links to workshop pages.