### PR TITLE
Export "created-on" field for training requests

### DIFF
--- a/workshops/test/test_training_request.py
+++ b/workshops/test/test_training_request.py
@@ -303,13 +303,13 @@ class TestDownloadCSVView(TestBase):
         self._setUpUsersAndLogin()
 
     def test_basic(self):
-        create_training_request(state='p', person=None)
+        tr = create_training_request(state='p', person=None)
         rv = self.client.get(reverse('download_trainingrequests'))
         self.assertEqual(rv.status_code, 200)
         got = rv.content.decode('utf-8')
         expected = (
-            'State,Matched Trainee,Group Name,Personal,Family,Email,GitHub username,Occupation,Occupation (other),Affiliation,Location,Country,Expertise areas,Expertise areas (other),Under-represented,Previous Involvement,Previous Training in Teaching,Previous Training (other),Previous Training (explanation),Programming Language Usage,Reason,Teaching Frequency Expectation,Teaching Frequency Expectation (other),Max Travelling Frequency,Max Travelling Frequency (other),Comment\r\n'
-            'Pending,—,,John,Smith,john@smith.com,,Other:,,AGH University of Science and Technology,Cracow,PL,,,No,,None,,,Every day,Just for fun.,Several times a year,,Once a year,,\r\n'
+            'Created-on,State,Matched Trainee,Group Name,Personal,Family,Email,GitHub username,Occupation,Occupation (other),Affiliation,Location,Country,Expertise areas,Expertise areas (other),Under-represented,Previous Involvement,Previous Training in Teaching,Previous Training (other),Previous Training (explanation),Programming Language Usage,Reason,Teaching Frequency Expectation,Teaching Frequency Expectation (other),Max Travelling Frequency,Max Travelling Frequency (other),Comment\r\n'
+            '{:%Y-%m-%d %H:%M}'.format(tr.created_at) + ',Pending,—,,John,Smith,john@smith.com,,Other:,,AGH University of Science and Technology,Cracow,PL,,,No,,None,,,Every day,Just for fun.,Several times a year,,Once a year,,\r\n'
         )
         self.assertEqual(got, expected)
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3018,6 +3018,7 @@ def download_trainingrequests(request):
 
     writer = csv.writer(response)
     writer.writerow([
+        'Created-on',
         'State',
         'Matched Trainee',
         'Group Name',
@@ -3047,6 +3048,7 @@ def download_trainingrequests(request):
     ])
     for req in TrainingRequest.objects.all():
         writer.writerow([
+            '{:%Y-%m-%d %H:%M}'.format(req.created_at),
             req.get_state_display(),
             '—' if req.person is None else req.person.get_full_name(),
             req.group_name,


### PR DESCRIPTION
This fixes #1225 by adding a timestamp column to CSV export of training
requests.