### PR TITLE
Repair M2M merging bug that removed `SWC` tag from AMY

### DIFF
--- a/workshops/test/test_event.py
+++ b/workshops/test/test_event.py
@@ -893,6 +893,26 @@ class TestEventMerging(TestBase):
         for key, value in assertions.items():
             self.assertEqual(set(getattr(self.event_a, key).all()), value, key)
 
+    def test_merging_m2m_not_removed(self):
+        """Regression test: merging events could result in M2M fields being
+        removed, for example this could happen to Tags.
+        This tests makes sure no M2M relation objects are being removed."""
+        # update strategy
+        self.strategy.update({
+            'id': 'obj_b',
+            'tags': 'obj_b',
+        })
+        # merge
+        rv = self.client.post(self.url, data=self.strategy)
+        self.assertEqual(rv.status_code, 302)
+
+        # ensure no Tags were removed
+        self.assertEqual(
+            Tag.objects.filter(name__in=['LC', 'DC', 'SWC']).count(),
+            3
+        )
+
+
 
 class TestEventImport(TestBase):
     def setUp(self):

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -844,16 +844,22 @@ def merge_objects(object_a, object_b, easy_fields, difficult_fields,
                 manager.set(list(related_b.all()))
 
             elif value == 'obj_a' and manager == related_a:
-                # since we're keeping current values, try to remove opposite
-                # (obj_b) - they may not be removable via on_delete=CASCADE,
-                # so try manually
-                related_b.all().delete()
+                # since we're keeping current values, try to remove (or clear
+                # if possible) opposite (obj_b) - they may not be removable
+                # via on_delete=CASCADE, so try manually
+                if hasattr(related_b, 'clear'):
+                    related_b.clear()
+                else:
+                    related_b.all().delete()
 
             elif value == 'obj_b' and manager == related_b:
-                # since we're keeping current values, try to remove opposite
-                # (obj_a) - they may not be removable via on_delete=CASCADE,
-                # so try manually
-                related_a.all().delete()
+                # since we're keeping current values, try to remove (or clear
+                # if possible) opposite (obj_a) - they may not be removable
+                # via on_delete=CASCADE, so try manually
+                if hasattr(related_a, 'clear'):
+                    related_a.clear()
+                else:
+                    related_a.all().delete()
 
             elif value == 'combine':
                 to_add = None


### PR DESCRIPTION
Bug: with new addition in v1.11.3, the merging function was extended
to help with uniqueness errors (by removing related objects).
Unfortunately this caused a bug that removed one tag from AMY when an
admin decided to merge two events.

Fix: new code tries to use `.clear` if possible (for clearing M2M
relations), if it can't - then uses `.remove`.