### PR TITLE
Fix Select2 widget not being loaded

### DIFF
--- a/workshops/static/amy_utils.js
+++ b/workshops/static/amy_utils.js
@@ -55,7 +55,10 @@ function updateTrainingProgressForm() {
     training_div.show();
   } else {
     training_div.hide();
-    training_div.find('#id_event').val().trigger('change');
+    var value = training_div.find('#id_event').val();
+    if (value != undefined) {
+      value.trigger('change');
+    }
   }
 
   if (type == 'SWC Homework' || type == 'DC Homework') {


### PR DESCRIPTION
This fixes #1255. The error was: due to some JS error, the browser
was unable to continue using the script, which further disabled
Select2 code.