### PR TITLE
Fix double instructors in API

### DIFF
--- a/api/test/test_export.py
+++ b/api/test/test_export.py
@@ -328,6 +328,13 @@ class TestExportingInstructorsRegression(BaseExportingTest):
                     {'name': 'Instructor2 Name', 'user': 'instructor2'},
                 ]
             },
+            {
+                'name': 'Airport2',
+                'country': 'US',
+                'latitude': 2.0,
+                'longitude': 1.0,
+                'instructors': []
+            },
         ]
 
     def test_serialization(self):

--- a/api/views.py
+++ b/api/views.py
@@ -206,7 +206,7 @@ class ExportInstructorLocationsView(ListAPIView):
                     'person_set',
                     queryset=person_qs.filter(
                         badges__in=Badge.objects.instructor_badges()
-                    ),
+                    ).distinct(),
                     to_attr='public_instructor_set',
                 )
             )

--- a/api/views.py
+++ b/api/views.py
@@ -170,6 +170,8 @@ class ExportInstructorLocationsView(ListAPIView):
 
     serializer_class = ExportInstructorLocationsSerializer
 
+    metadata_class = QueryMetadata
+
     def get_queryset(self):
         """This queryset uses a special object `Prefetch` to apply specific
         filters to the Airport.person_set objects; this way we can "filter" on
@@ -226,6 +228,8 @@ class ExportMembersView(ListAPIView):
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [CSVRenderer, ]
 
     serializer_class = PersonNameEmailUsernameSerializer
+
+    metadata_class = QueryMetadata
 
     def get_queryset(self):
         earliest_default, latest_default = default_membership_cutoff()

--- a/api/views.py
+++ b/api/views.py
@@ -199,7 +199,6 @@ class ExportInstructorLocationsView(ListAPIView):
         return (
             Airport.objects
             .exclude(person=None)
-            .filter(person__publish_profile=True)
             .distinct()
             .prefetch_related(
                 Prefetch(


### PR DESCRIPTION
This PR includes a number of commits that fix various things that were wrong with `export-instructors` API endpoint.