### PR TITLE
Fixing inconsistencies when importing/updating events from URL

### DIFF
--- a/workshops/templates/workshops/event_import_update_from_url.html
+++ b/workshops/templates/workshops/event_import_update_from_url.html
@@ -32,7 +32,6 @@
               <input type="url" id="event_import_url" name="url" required class="form-control" />
             {% endif %}
             <p class="help-block">Either URL to the event's website or to it's repository will work.</p>
-            <p class="help-block">Use the URL of the event's website, e.g. <code>http://swcarpentry.github.io/workshop-template/</code> or <code>http://www.datacarpentry.org/workshop/</code>, and not the URL of its GitHub repository.</p>
             </div>
           {% if update %}
             <div class="form-group">
@@ -49,8 +48,10 @@
                 </label>
               </div>
             </div>
-          {% endif %}
             <button type="submit" class="btn btn-primary" data-loading-text="Loading..." autocomplete="off">Update</button>
+          {% else %}
+            <button type="submit" class="btn btn-primary" data-loading-text="Loading..." autocomplete="off">Import</button>
+          {% endif %}
           </form>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
This fixes #1169 by making sure the issue mentioned in
[here](https://github.com/swcarpentry/amy/issues/1169#issuecomment-290912257)
is not present anymore.

Additionally a confusing help text from import/update modal was removed,
and "Update" button was changed to "Import" on import modal (it's still
"Update" on update modal).