### PR TITLE
Navigation bar for trainee accessible views

### DIFF
--- a/workshops/templates/base_nav_fixed.html
+++ b/workshops/templates/base_nav_fixed.html
@@ -2,5 +2,7 @@
 {% block navbar %}
   {% if user.is_admin %}
     {% include 'navigation_fixed.html' %}
+  {% elif not user.is_admin and not user.is_anonymous %}
+    {% include 'navigation_trainee_fixed.html' %}
   {% endif %}
 {% endblock %}

--- a/workshops/templates/navigation_trainee_fixed.html
+++ b/workshops/templates/navigation_trainee_fixed.html
@@ -1,0 +1,41 @@
+{% load navigation %}
+{% block navbar %}
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <div class="container{% block fluid-navbar %}{% endblock %}">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="{% url 'admin-dashboard' %}">AMY</a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            {% if user.is_admin %}
+              {% navbar_element "Dashboard" "admin-dashboard" %}
+            {% endif %}
+            {% navbar_element "Your profile" "trainee-dashboard" %}
+            {% navbar_element "Update data" "autoupdate_profile" %}
+            {% navbar_element "Training progress" "training-progress" %}
+          </ul>
+
+          <ul class="nav navbar-nav navbar-right">
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Hi, {{ user.get_short_name }} <span class="caret"></span></a>
+              <ul class="dropdown-menu" role="menu">
+                <li><a href="{% url 'api:export-person-data' %}?format=json">Download your data</a></li>
+                <li><a href="{% url 'person_password' user.id %}">Change password</a></li>
+                <li class="divider"></li>
+                <li><a href="{% url 'logout' %}">Log out</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div><!-- /.navbar-collapse -->
+      </div><!-- /.container-fluid -->
+    </nav>
+{% endblock %}

--- a/workshops/templates/workshops/autoupdate_profile.html
+++ b/workshops/templates/workshops/autoupdate_profile.html
@@ -1,4 +1,7 @@
 {% extends "base_nonav_fixed.html" %}
+{% block navbar %}
+  {% include 'navigation_trainee_fixed.html' %}
+{% endblock %}
 
 {% load crispy_forms_tags %}
 

--- a/workshops/templates/workshops/trainee_dashboard.html
+++ b/workshops/templates/workshops/trainee_dashboard.html
@@ -1,193 +1,98 @@
 {% extends "base_nonav_fixed.html" %}
+{% block navbar %}
+  {% include 'navigation_trainee_fixed.html' %}
+{% endblock %}
 
 {% load crispy_forms_tags %}
 
 {% block content %}
 
-{% if swc_form.errors or dc_form.errors %}
-  <div class="alert alert-danger" role="alert">Fix errors in your homework submission.</div>
-{% endif %}
-
 <div>
-
-<p><a href="{% url 'logout' %}" class="btn btn-primary">Log out</a></p>
-
-<table class="table table-striped">
-  <tr><th>personal name</th><td>{{ user.personal|default:"—" }}</td></tr>
-  <tr><th>middle name</th><td>{{ user.middle|default:"—" }}</td></tr>
-  <tr><th>family name</th><td>{{ user.family|default:"—" }}</td></tr>
-  <tr><th>email</th><td>{{ user.email|default:"—" }}</td></tr>
-  <tr><th>gender</th><td>{{ user.get_gender_display }}</td></tr>
-  <tr><th>can we contact you?</th><td>{{ user.may_contact|yesno }}</td></tr>
-  <tr><th>do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ user.publish_profile|yesno }}</td></tr>
-  <tr><th>airport</th><td>{{ user.airport|default:"—"  }}</td></tr>
-  <tr><th>github</th><td>{{ user.github|default:"—" }}</td></tr>
-  <tr><th>twitter</th><td>{{ user.twitter|default:"—" }}</td></tr>
-  <tr><th>url</th><td>{{ user.url|default:"—" }}</td></tr>
-  <tr><th>username</th><td>{{ user.username|default:"—" }}</td></tr>
-  <tr><th>affiliation</th><td>{{ user.affiliation|default:"—" }}</td></tr>
-  <tr><th>occupation</th><td>{{ user.occupation|default:"—" }}</td></tr>
-  <tr><th>orcid</th><td>{{ user.orcid|default:"—" }}</td></tr>
-  <tr><th>areas of expertise</th><td>
-      <ul>
-        {% for domain in user.domains.all %}
-          <li>{{ domain }}</li>
-        {% empty %}
-          <li>No areas of expertise.</li>
-        {% endfor %}
-      </ul>
-  </td></tr>
-  <tr><th>lessons that you can teach</th><td>
-      <ul>
-        {% for lesson in user.lessons.all %}
-          <li>{{ lesson }}</li>
-        {% empty %}
-          <li>No lesson chosen.</li>
-        {% endfor %}
-      </ul>
-  </td></tr>
-  <tr><th>languages</th><td>
-      <ul>
-        {% for language in user.languages.all %}
-          <li>{{ language }}</li>
-        {% empty %}
-          <li>No languages.</li>
-        {% endfor %}
-      </ul>
-  </td></tr>
-  <tr><th>your badges</th><td>
-      <ul>
-        {% for badge in user.badges.all %}
-          <li>{{ badge }}</li>
-        {% empty %}
-          <li>No badges awarded.</li>
-        {% endfor %}
-      </ul>
-      <p>If you think that you're missing a badge, please email us at <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a></p>
-  </td></tr>
-  <tr><th>your workshop activity</th><td>
-      {% if workshops %}
-      <table class="table">
-        <tr>
-          <th>Workshop name</th>
-          <th>Dates</th>
-          <th>Venue</th>
-          <th>Your role</th>
-        </tr>
-        {% for task in workshops %}
+  <table class="table table-striped">
+    <tr><th>personal name</th><td>{{ user.personal|default:"—" }}</td></tr>
+    <tr><th>middle name</th><td>{{ user.middle|default:"—" }}</td></tr>
+    <tr><th>family name</th><td>{{ user.family|default:"—" }}</td></tr>
+    <tr><th>email</th><td>{{ user.email|default:"—" }}</td></tr>
+    <tr><th>gender</th><td>{{ user.get_gender_display }}</td></tr>
+    <tr><th>can we contact you?</th><td>{{ user.may_contact|yesno }}</td></tr>
+    <tr><th>do you consent to publish your profile<br>on The Carpentries website?</th><td>{{ user.publish_profile|yesno }}</td></tr>
+    <tr><th>airport</th><td>{{ user.airport|default:"—"  }}</td></tr>
+    <tr><th>github</th><td>{{ user.github|default:"—" }}</td></tr>
+    <tr><th>twitter</th><td>{{ user.twitter|default:"—" }}</td></tr>
+    <tr><th>url</th><td>{{ user.url|default:"—" }}</td></tr>
+    <tr><th>username</th><td>{{ user.username|default:"—" }}</td></tr>
+    <tr><th>affiliation</th><td>{{ user.affiliation|default:"—" }}</td></tr>
+    <tr><th>occupation</th><td>{{ user.occupation|default:"—" }}</td></tr>
+    <tr><th>orcid</th><td>{{ user.orcid|default:"—" }}</td></tr>
+    <tr><th>areas of expertise</th><td>
+        <ul>
+          {% for domain in user.domains.all %}
+            <li>{{ domain }}</li>
+          {% empty %}
+            <li>No areas of expertise.</li>
+          {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>lessons that you can teach</th><td>
+        <ul>
+          {% for lesson in user.lessons.all %}
+            <li>{{ lesson }}</li>
+          {% empty %}
+            <li>No lesson chosen.</li>
+          {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>languages</th><td>
+        <ul>
+          {% for language in user.languages.all %}
+            <li>{{ language }}</li>
+          {% empty %}
+            <li>No languages.</li>
+          {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>your badges</th><td>
+        <ul>
+          {% for badge in user.badges.all %}
+            <li>{{ badge }}</li>
+          {% empty %}
+            <li>No badges awarded.</li>
+          {% endfor %}
+        </ul>
+        <p>If you think that you're missing a badge, please email us at <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a></p>
+    </td></tr>
+    <tr><th>your workshop activity</th><td>
+        {% if workshops %}
+        <table class="table">
           <tr>
-          {% if task.event.website_url %}
-            <td><a href="{{ task.event.website_url }}" target="_blank">{{ task.event.slug }}</a></td>
-          {% else %}
-            <td>{{ task.event.slug }}</td>
-          {% endif %}
-            <td>{{ task.event.start|date:'Y-m-d' }} &mdash; {{ task.event.end|date:'Y-m-d' }}</td>
-            <td>{{ task.event.venue|default:'—' }}</td>
-            <td>{{ task.role }}</td>
+            <th>Workshop name</th>
+            <th>Dates</th>
+            <th>Venue</th>
+            <th>Your role</th>
           </tr>
-        {% endfor %}
-      </table>
-      {% else %}
-      No workshops to show.
-      {% endif %}
-  </td></tr>
-</table>
+          {% for task in workshops %}
+            <tr>
+            {% if task.event.website_url %}
+              <td><a href="{{ task.event.website_url }}" target="_blank">{{ task.event.slug }}</a></td>
+            {% else %}
+              <td>{{ task.event.slug }}</td>
+            {% endif %}
+              <td>{{ task.event.start|date:'Y-m-d' }} &mdash; {{ task.event.end|date:'Y-m-d' }}</td>
+              <td>{{ task.event.venue|default:'—' }}</td>
+              <td>{{ task.role }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+        {% else %}
+        No workshops to show.
+        {% endif %}
+    </td></tr>
+  </table>
 
-<p>
-  <a href="{% url 'autoupdate_profile' %}" class="btn btn-primary">Update your profile</a>
-  <a href="{% url 'api:export-person-data' %}?format=json" class="btn btn-default pull-right">Download your data</a>
-</p>
-
-<h2>Your progress of becoming Software Carpentry (SWC) and Data Carpentry (DC) Instructor</h2>
-
-{% if user.is_swc_instructor and user.is_dc_instructor %}
-  <p>Congratulations, you're certified both Software Carpentry and Data Carpentry Instructor!</p>
-{% elif user.is_swc_instructor %}
-  <p>Congratulations, you're certified Software Carpentry Instructor!</p>
-{% elif user.is_dc_instructor %}
-  <p>Congratulations, you're certified Data Carpentry Instructor!</p>
-{% endif %}
-
-<table class="table table-striped">
-  <tr>
-    <th>1. Training</th>
-    <td>
-      {% if user.passed_training %}
-        <p><span class="label label-success">Training passed</span></p>
-      {% else %}
-        <p><span class="label label-default">Training not passed yet</span></p>
-      {% endif %}
-    </td>
-  </tr>
-  <tr>
-    <th>2. Homework</th>
-    <td>
-      {% if user.passed_swc_homework %}
-        <p><span class="label label-success">SWC Homework accepted</span></p>
-      {% elif user.swc_homework_in_evaluation %}
-        <p><span class="label label-warning">SWC Homework not evaluated yet</span></p>
-        <p>Please wait while we evaluate your homework.</p>
-      {% else %}
-        <p><span class="label label-default">SWC Homework not submitted yet</span> </p>
-        <p>This step is necessary only if you want to become Software Carpentry Instructor.</p>
-        <p>
-          Submit link to your Pull Request:
-        </p>
-        {% crispy swc_form %}
-      {% endif %}
-
-      <hr />
-
-      {% if user.passed_dc_homework %}
-        <p><span class="label label-success">DC Homework accepted</span></p>
-      {% elif user.dc_homework_in_evaluation %}
-        <p><span class="label label-warning">DC Homework not evaluated yet</span></p>
-        <p>Please wait while we evaluate your homework.</p>
-      {% else %}
-        <p><span class="label label-default">DC Homework not submitted yet</span></p>
-        <p>This step is necessary only if you want to become Data Carpentry Instructor.</p>
-        <p>
-          Submit link to your Homework:
-        </p>
-        {% crispy dc_form %}
-      {% endif %}
-
-    </td>
-  </tr>
-  <tr>
-    <th>3. Discussion Session</th>
-    <td>
-      {% if user.passed_discussion %}
-        <p><span class="label label-success">Discussion Session passed</span></p>
-      {% else %}
-        <p><span class="label label-default">Discussion Session not passed yet</span></p>
-        <p>Register for Discussion Session on <a href="http://pad.software-carpentry.org/instructor-discussion">this Etherpad</a>. Register for only one session even if you want to become both SWC and DC Instructor. </p>
-      {% endif %}
-    </td>
-  </tr>
-  <tr>
-    <th>4. Demo Session</th>
-    <td>
-      {% if user.passed_swc_demo %}
-        <p><span class="label label-success">SWC Demo Session passed</span></p>
-      {% else %}
-        <p><span class="label label-default">SWC Demo Session not passed yet</span> </p>
-      {% endif %}
-
-      {% if user.passed_dc_demo %}
-        <p><span class="label label-success">DC Demo Session passed</span></p>
-      {% else %}
-        <p><span class="label label-default">DC Demo Session not passed yet</span></p>
-      {% endif %}
-
-      {% if not user.passed_swc_demo or not user.passed_dc_demo %}
-        <p> Register for Demo Session on <a href="http://pad.software-carpentry.org/teaching-demos">this Etherpad</a>. If you want to become both SWC and DC Instructor, you have to teach <b>two</b> 5-minutes sessions during one or two sessions. </p>
-      {% endif %}
-    </td>
-  </tr>
-</table>
-
-<p>In the case of any questions, please send us email at <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a></p>
+  <p>
+    <a href="{% url 'autoupdate_profile' %}" class="btn btn-primary">Update your profile</a>
+    <a href="{% url 'api:export-person-data' %}?format=json" class="btn btn-default pull-right">Download your data</a>
+  </p>
 
 </div>
 

--- a/workshops/templates/workshops/training_progress.html
+++ b/workshops/templates/workshops/training_progress.html
@@ -1,0 +1,107 @@
+{% extends "base_nonav_fixed.html" %}
+{% block navbar %}
+  {% include 'navigation_trainee_fixed.html' %}
+{% endblock %}
+
+{% load crispy_forms_tags %}
+
+{% block content %}
+
+{% if swc_form.errors or dc_form.errors %}
+  <div class="alert alert-danger" role="alert">Fix errors in your homework submission.</div>
+{% endif %}
+
+<div>
+  <h2>Your progress of becoming Software Carpentry (SWC) and Data Carpentry (DC) Instructor</h2>
+
+  {% if user.is_swc_instructor and user.is_dc_instructor %}
+    <p>Congratulations, you're certified both Software Carpentry and Data Carpentry Instructor!</p>
+  {% elif user.is_swc_instructor %}
+    <p>Congratulations, you're certified Software Carpentry Instructor!</p>
+  {% elif user.is_dc_instructor %}
+    <p>Congratulations, you're certified Data Carpentry Instructor!</p>
+  {% endif %}
+
+  <table class="table table-striped">
+    <tr>
+      <th>1. Training</th>
+      <td>
+        {% if user.passed_training %}
+          <p><span class="label label-success">Training passed</span></p>
+        {% else %}
+          <p><span class="label label-default">Training not passed yet</span></p>
+        {% endif %}
+      </td>
+    </tr>
+    <tr>
+      <th>2. Homework</th>
+      <td>
+        {% if user.passed_swc_homework %}
+          <p><span class="label label-success">SWC Homework accepted</span></p>
+        {% elif user.swc_homework_in_evaluation %}
+          <p><span class="label label-warning">SWC Homework not evaluated yet</span></p>
+          <p>Please wait while we evaluate your homework.</p>
+        {% else %}
+          <p><span class="label label-default">SWC Homework not submitted yet</span> </p>
+          <p>This step is necessary only if you want to become Software Carpentry Instructor.</p>
+          <p>
+            Submit link to your Pull Request:
+          </p>
+          {% crispy swc_form %}
+        {% endif %}
+
+        <hr />
+
+        {% if user.passed_dc_homework %}
+          <p><span class="label label-success">DC Homework accepted</span></p>
+        {% elif user.dc_homework_in_evaluation %}
+          <p><span class="label label-warning">DC Homework not evaluated yet</span></p>
+          <p>Please wait while we evaluate your homework.</p>
+        {% else %}
+          <p><span class="label label-default">DC Homework not submitted yet</span></p>
+          <p>This step is necessary only if you want to become Data Carpentry Instructor.</p>
+          <p>
+            Submit link to your Homework:
+          </p>
+          {% crispy dc_form %}
+        {% endif %}
+
+      </td>
+    </tr>
+    <tr>
+      <th>3. Discussion Session</th>
+      <td>
+        {% if user.passed_discussion %}
+          <p><span class="label label-success">Discussion Session passed</span></p>
+        {% else %}
+          <p><span class="label label-default">Discussion Session not passed yet</span></p>
+          <p>Register for Discussion Session on <a href="http://pad.software-carpentry.org/instructor-discussion">this Etherpad</a>. Register for only one session even if you want to become both SWC and DC Instructor. </p>
+        {% endif %}
+      </td>
+    </tr>
+    <tr>
+      <th>4. Demo Session</th>
+      <td>
+        {% if user.passed_swc_demo %}
+          <p><span class="label label-success">SWC Demo Session passed</span></p>
+        {% else %}
+          <p><span class="label label-default">SWC Demo Session not passed yet</span> </p>
+        {% endif %}
+
+        {% if user.passed_dc_demo %}
+          <p><span class="label label-success">DC Demo Session passed</span></p>
+        {% else %}
+          <p><span class="label label-default">DC Demo Session not passed yet</span></p>
+        {% endif %}
+
+        {% if not user.passed_swc_demo or not user.passed_dc_demo %}
+          <p> Register for Demo Session on <a href="http://pad.software-carpentry.org/teaching-demos">this Etherpad</a>. If you want to become both SWC and DC Instructor, you have to teach <b>two</b> 5-minutes sessions during one or two sessions. </p>
+        {% endif %}
+      </td>
+    </tr>
+  </table>
+
+  <p>In the case of any questions, please send us email at <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a></p>
+</div>
+
+{% endblock %}

--- a/workshops/test/test_security.py
+++ b/workshops/test/test_security.py
@@ -210,8 +210,8 @@ class TestViews(TestBase):
         'password_reset_done',
         'password_reset_confirm',
         'password_reset_complete',
-        'password_change',
-        'password_change_done',
+        # 'password_change',
+        # 'password_change_done',
 
         # python-social-auth
         'begin',

--- a/workshops/test/test_trainee_dashboard.py
+++ b/workshops/test/test_trainee_dashboard.py
@@ -33,6 +33,7 @@ class TestInstructorStatus(TestBase):
         self._setUpUsersAndLogin()
         self.swc_instructor = Badge.objects.get(name='swc-instructor')
         self.dc_instructor = Badge.objects.get(name='dc-instructor')
+        self.progress_url = reverse('training-progress')
 
     def test_swc_instructor_and_dc_instructor(self):
         """When the trainee is awarded both Carpentry Instructor badge,
@@ -42,7 +43,7 @@ class TestInstructorStatus(TestBase):
                              awarded=datetime(2016, 6, 1, 15, 00))
         Award.objects.create(person=self.admin, badge=self.dc_instructor,
                              awarded=datetime(2016, 6, 1, 15, 00))
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Congratulations, you\'re certified both '
                                 'Software Carpentry and Data Carpentry '
                                 'Instructor!')
@@ -50,21 +51,21 @@ class TestInstructorStatus(TestBase):
     def test_swc_instructor(self):
         Award.objects.create(person=self.admin, badge=self.swc_instructor,
                              awarded=datetime(2016, 6, 1, 15, 00))
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Congratulations, you\'re certified '
                                 'Software Carpentry Instructor!')
 
     def test_dc_instructor(self):
         Award.objects.create(person=self.admin, badge=self.dc_instructor,
                              awarded=datetime(2016, 6, 1, 15, 00))
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Congratulations, you\'re certified '
                                 'Data Carpentry Instructor!')
 
     def test_neither_swc_nor_dc_instructor(self):
         """Check that we don't display that the trainee is an instructor if
         they don't have appropriate badge."""
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertNotContains(rv, 'Congratulations, you\'re certified both '
                                    'Software Carpentry and Data Carpentry '
                                    'Instructor!')
@@ -89,7 +90,7 @@ class TestInstructorStatus(TestBase):
         assert admin.get_missing_swc_instructor_requirements() == []
         assert admin.get_missing_dc_instructor_requirements() == []
 
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
 
         self.assertNotContains(rv, 'Congratulations, you\'re certified both '
                                    'Software Carpentry and Data Carpentry '
@@ -107,17 +108,18 @@ class TestInstructorTrainingStatus(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()
         self.training = TrainingRequirement.objects.get(name='Training')
+        self.progress_url = reverse('training-progress')
 
     def test_training_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.training)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Training passed')
 
     def test_training_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.training, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Training not passed yet')
 
     def test_last_training_discarded_but_another_is_passed(self):
@@ -125,17 +127,17 @@ class TestInstructorTrainingStatus(TestBase):
             trainee=self.admin, requirement=self.training)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.training, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Training passed')
 
     def test_training_failed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.training, state='f')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Training not passed yet')
 
     def test_training_not_finished(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Training not passed yet')
 
 
@@ -146,27 +148,28 @@ class TestSWCHomeworkStatus(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()
         self.homework = TrainingRequirement.objects.get(name='SWC Homework')
+        self.progress_url = reverse('training-progress')
 
     def test_homework_not_submitted(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Homework not submitted yet')
 
     def test_homework_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, state='n')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Homework not evaluated yet')
 
     def test_homework_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Homework accepted')
 
     def test_homework_not_accepted_when_homework_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Homework not submitted yet')
 
     def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(self):
@@ -174,7 +177,7 @@ class TestSWCHomeworkStatus(TestBase):
             trainee=self.admin, requirement=self.homework)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Homework accepted')
 
     def test_submission_form(self):
@@ -182,9 +185,9 @@ class TestSWCHomeworkStatus(TestBase):
             'url': 'http://example.com',
             'swc-submit': '',
         }
-        rv = self.client.post(reverse('trainee-dashboard'), data, follow=True)
+        rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'trainee-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, 'training-progress')
         self.assertContains(rv, 'Your homework submission will be evaluated '
                                 'soon.')
         got = list(TrainingProgress.objects.values_list(
@@ -205,27 +208,28 @@ class TestDCHomeworkStatus(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()
         self.homework = TrainingRequirement.objects.get(name='DC Homework')
+        self.progress_url = reverse('training-progress')
 
     def test_homework_not_submitted(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Homework not submitted yet')
 
     def test_homework_waiting_to_be_evaluated(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, state='n')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Homework not evaluated yet')
 
     def test_homework_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Homework accepted')
 
     def test_homework_not_accepted_when_homework_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Homework not submitted yet')
 
     def test_homework_is_accepted_when_last_homework_is_discarded_but_other_one_is_passed(self):
@@ -233,7 +237,7 @@ class TestDCHomeworkStatus(TestBase):
             trainee=self.admin, requirement=self.homework)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.homework, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Homework accepted')
 
     def test_submission_form(self):
@@ -241,9 +245,9 @@ class TestDCHomeworkStatus(TestBase):
             'url': 'http://example.com',
             'dc-submit': '',
         }
-        rv = self.client.post(reverse('trainee-dashboard'), data, follow=True)
+        rv = self.client.post(self.progress_url, data, follow=True)
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(rv.resolver_match.view_name, 'trainee-dashboard')
+        self.assertEqual(rv.resolver_match.view_name, 'training-progress')
         self.assertContains(rv, 'Your homework submission will be evaluated '
                                 'soon.')
         got = list(TrainingProgress.objects.values_list(
@@ -265,17 +269,18 @@ class TestDiscussionSessionStatus(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()
         self.discussion = TrainingRequirement.objects.get(name='Discussion')
+        self.progress_url = reverse('training-progress')
 
     def test_session_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.discussion)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Discussion Session passed')
 
     def test_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.discussion, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Discussion Session not passed yet')
 
     def test_last_session_discarded_but_another_is_passed(self):
@@ -283,17 +288,17 @@ class TestDiscussionSessionStatus(TestBase):
             trainee=self.admin, requirement=self.discussion)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.discussion, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Discussion Session passed')
 
     def test_session_failed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.discussion, state='f')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Discussion Session not passed yet')
 
     def test_no_participation_in_a_session_yet(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'Discussion Session not passed yet')
 
 
@@ -306,18 +311,19 @@ class TestDemoSessionStatus(TestBase):
         self._setUpUsersAndLogin()
         self.swc_demo = TrainingRequirement.objects.get(name='SWC Demo')
         self.dc_demo = TrainingRequirement.objects.get(name='DC Demo')
+        self.progress_url = reverse('training-progress')
 
     def test_swc_session_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.swc_demo)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session passed')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_swc_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.swc_demo, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
@@ -326,33 +332,33 @@ class TestDemoSessionStatus(TestBase):
             trainee=self.admin, requirement=self.swc_demo)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.swc_demo, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session passed')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_swc_session_failed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.swc_demo, state='f')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_no_participation_in_a_swc_session_yet(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_dc_session_passed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.dc_demo)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Demo Session passed')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_dc_session_passed_but_discarded(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.dc_demo, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
@@ -361,19 +367,19 @@ class TestDemoSessionStatus(TestBase):
             trainee=self.admin, requirement=self.dc_demo)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.dc_demo, discarded=True)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Demo Session passed')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_dc_session_failed(self):
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.dc_demo, state='f')
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
     def test_no_participation_in_a_dc_session_yet(self):
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'DC Demo Session not passed yet')
         self.assertContains(rv, 'Register for Demo Session on')
 
@@ -382,7 +388,7 @@ class TestDemoSessionStatus(TestBase):
             trainee=self.admin, requirement=self.swc_demo)
         TrainingProgress.objects.create(
             trainee=self.admin, requirement=self.dc_demo)
-        rv = self.client.get(reverse('trainee-dashboard'))
+        rv = self.client.get(self.progress_url)
         self.assertContains(rv, 'SWC Demo Session passed')
         self.assertContains(rv, 'DC Demo Session passed')
         self.assertNotContains(rv, 'Register for Demo Session on')

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     url(r'^$', views.dispatch, name='dispatch'),
     url(r'^admin-dashboard/$', views.admin_dashboard, name='admin-dashboard'),
     url(r'^trainee-dashboard/$', views.trainee_dashboard, name='trainee-dashboard'),
+    url(r'^trainee-dashboard/training_progress/$', views.training_progress, name='training-progress'),
 
     url(r'^log/$', views.changes_log, name='changes_log'),
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2949,69 +2949,11 @@ def trainingrequest_details(request, pk):
 
 @login_required
 def trainee_dashboard(request):
-    swc_form = SendHomeworkForm(submit_name='swc-submit')
-    dc_form = SendHomeworkForm(submit_name='dc-submit')
-
-    # Add information about instructor training progress to request.user.
-    request.user = Person.objects.annotate_with_instructor_eligibility() \
-                                 .get(pk=request.user.pk)
-
-    progresses = request.user.trainingprogress_set.filter(discarded=False)
-    last_swc_homework = progresses.filter(
-        requirement__name='SWC Homework').order_by('-created_at').first()
-    request.user.swc_homework_in_evaluation = (
-        last_swc_homework is not None and last_swc_homework.state == 'n')
-    last_dc_homework = progresses.filter(
-        requirement__name='DC Homework').order_by('-created_at').first()
-    request.user.dc_homework_in_evaluation = (
-        last_dc_homework is not None and last_dc_homework.state == 'n')
-
-    # Add information about awarded instructor badges to request.user.
-    request.user.is_swc_instructor = request.user.award_set.filter(
-        badge__name='swc-instructor').exists()
-    request.user.is_dc_instructor = request.user.award_set.filter(
-        badge__name='dc-instructor').exists()
-
     # Workshops person taught at
     workshops = request.user.task_set.all()
 
-    if request.method == 'POST' and 'swc-submit' in request.POST:
-        requirement = TrainingRequirement.objects.get(name='SWC Homework')
-        progress = TrainingProgress(trainee=request.user,
-                                    state='n',  # not-evaluated yet
-                                    requirement=requirement)
-        swc_form = SendHomeworkForm(data=request.POST, instance=progress,
-                                    submit_name='swc-submit')
-        dc_form = SendHomeworkForm(submit_name='dc-submit')
-
-        if swc_form.is_valid():
-            swc_form.save()
-            messages.success(request, 'Your homework submission will be '
-                                      'evaluated soon.')
-            return redirect(reverse('trainee-dashboard'))
-
-    elif request.method == 'POST' and 'dc-submit' in request.POST:
-        requirement = TrainingRequirement.objects.get(name='DC Homework')
-        progress = TrainingProgress(trainee=request.user,
-                                    state='n',  # not-evaluated yet
-                                    requirement=requirement)
-        swc_form = SendHomeworkForm(submit_name='swc-submit')
-        dc_form = SendHomeworkForm(data=request.POST, instance=progress,
-                                    submit_name='dc-submit')
-
-        if dc_form.is_valid():
-            dc_form.save()
-            messages.success(request, 'Your homework submission will be '
-                                      'evaluated soon.')
-            return redirect(reverse('trainee-dashboard'))
-
-    else:  # GET request
-        pass
-
     context = {
         'title': 'Your profile',
-        'swc_form': swc_form,
-        'dc_form': dc_form,
         'workshops': workshops,
     }
     return render(request, 'workshops/trainee_dashboard.html', context)
@@ -3037,6 +2979,8 @@ def autoupdate_profile(request):
 
             person = form.save()
 
+            messages.success(request, 'Your profile was updated.')
+
             return redirect(reverse('trainee-dashboard'))
         else:
             messages.error(request, 'Fix errors below.')
@@ -3045,7 +2989,74 @@ def autoupdate_profile(request):
         'title': 'Update Your Profile',
         'form': form,
     }
-    return render(request, 'workshops/generic_form_nonav.html', context)
+    return render(request, 'workshops/autoupdate_profile.html', context)
+
+
+@login_required
+def training_progress(request):
+    swc_form = SendHomeworkForm(submit_name='swc-submit')
+    dc_form = SendHomeworkForm(submit_name='dc-submit')
+
+    # Add information about instructor training progress to request.user.
+    request.user = Person.objects.annotate_with_instructor_eligibility() \
+                                 .get(pk=request.user.pk)
+
+    progresses = request.user.trainingprogress_set.filter(discarded=False)
+    last_swc_homework = progresses.filter(
+        requirement__name='SWC Homework').order_by('-created_at').first()
+    request.user.swc_homework_in_evaluation = (
+        last_swc_homework is not None and last_swc_homework.state == 'n')
+    last_dc_homework = progresses.filter(
+        requirement__name='DC Homework').order_by('-created_at').first()
+    request.user.dc_homework_in_evaluation = (
+        last_dc_homework is not None and last_dc_homework.state == 'n')
+
+    # Add information about awarded instructor badges to request.user.
+    request.user.is_swc_instructor = request.user.award_set.filter(
+        badge__name='swc-instructor').exists()
+    request.user.is_dc_instructor = request.user.award_set.filter(
+        badge__name='dc-instructor').exists()
+
+    if request.method == 'POST' and 'swc-submit' in request.POST:
+        requirement = TrainingRequirement.objects.get(name='SWC Homework')
+        progress = TrainingProgress(trainee=request.user,
+                                    state='n',  # not-evaluated yet
+                                    requirement=requirement)
+        swc_form = SendHomeworkForm(data=request.POST, instance=progress,
+                                    submit_name='swc-submit')
+        dc_form = SendHomeworkForm(submit_name='dc-submit')
+
+        if swc_form.is_valid():
+            swc_form.save()
+            messages.success(request, 'Your homework submission will be '
+                                      'evaluated soon.')
+            return redirect(reverse('training-progress'))
+
+    elif request.method == 'POST' and 'dc-submit' in request.POST:
+        requirement = TrainingRequirement.objects.get(name='DC Homework')
+        progress = TrainingProgress(trainee=request.user,
+                                    state='n',  # not-evaluated yet
+                                    requirement=requirement)
+        swc_form = SendHomeworkForm(submit_name='swc-submit')
+        dc_form = SendHomeworkForm(data=request.POST, instance=progress,
+                                    submit_name='dc-submit')
+
+        if dc_form.is_valid():
+            dc_form.save()
+            messages.success(request, 'Your homework submission will be '
+                                      'evaluated soon.')
+            return redirect(reverse('training-progress'))
+
+    else:  # GET request
+        pass
+
+    context = {
+        'title': 'Your training progress',
+        'swc_form': swc_form,
+        'dc_form': dc_form,
+    }
+    return render(request, 'workshops/training_progress.html', context)
+
 
 # ------------------------------------------------------------
 # Instructor Training related views

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -774,7 +774,7 @@ class PersonPermissions(OnlyForAdminsMixin, PermissionRequiredMixin,
     pk_url_kwarg = 'person_id'
 
 
-@admin_required
+@login_required
 def person_password(request, person_id):
     user = get_object_or_404(Person, pk=person_id)
 


### PR DESCRIPTION
This PR fixes #1274 by adding an altered top navigation bar to some views accessible by trainees:
* `trainee-dashboard`
* `training-progress` (new view split from `trainee-dashboard`)
* `autoupdate_profile`.

Additionally if the user is logged in, and not an admin, they will be displayed a navigation bar in externally accessible forms. Admins are still displayed "their" navbar in these pages.

Password changing form is now accessible for logged-in users who aren't admins.