### PR TITLE
Add event notes on tasks tab pane in event edit view

### DIFF
--- a/workshops/templates/workshops/event_edit_form.html
+++ b/workshops/templates/workshops/event_edit_form.html
@@ -21,6 +21,14 @@
   </div>
   <div role="tabpanel" class="tab-pane" id="tasks">
     {% block task_tab %}
+
+    <div class="row">
+      <div class="col-xs-9 col-xs-offset-1">
+        <p>Notes regarding this event may include instructor and helper names:</p>
+        <pre>{{ event.notes }}</pre>
+      </div>
+    </div>
+
     <form class="form-horizontal" role="form" method="POST" action="{% url 'task_add' %}?next={{ request.get_full_path|urlencode }}#tasks">
       {% crispy task_form %}
     </form>


### PR DESCRIPTION
This fixes #943 by moving task notes (that may include event instructor
or helper names) closer to the tasks form (used to add instructor and
helper roles to the event).