### PR TITLE
Training requests API endpoint

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -1,0 +1,50 @@
+from rest_framework_csv.renderers import CSVRenderer
+
+from .serializers import (
+    TrainingRequestWithPersonSerializer,
+)
+
+
+class TrainingRequestCSVRenderer(CSVRenderer):
+    # sets the columns ordering
+    header = TrainingRequestWithPersonSerializer.Meta.fields
+    labels = {
+        'created_at': 'Created at',
+        'last_updated_at': 'Last updated at',
+        'state': 'State',
+        'person': 'Matched Trainee',
+        'group_name': 'Group Name',
+        'personal': 'Personal',
+        'middle': 'Middle',
+        'family': 'Family',
+        'email': 'Email',
+        'github': 'GitHub username',
+        'underrepresented': 'Underrepresented (reason)',
+        'occupation': 'Occupation',
+        'occupation_other': 'Occupation (other)',
+        'affiliation': 'Affiliation',
+        'location': 'Location',
+        'country': 'Country',
+        'underresourced': 'Underresourced institution',
+        'domains': 'Expertise areas',
+        'domains_other': 'Expertise areas (other)',
+        'nonprofit_teaching_experience': 'Non-profit teaching experience',
+        'previous_involvement': 'Previous Involvement',
+        'previous_training': 'Previous Training in Teaching',
+        'previous_training_other': 'Previous Training (other)',
+        'previous_training_explanation': 'Previous Training (explanation)',
+        'previous_experience': 'Previous Experience in Teaching',
+        'previous_experience_other': 'Previous Experience (other)',
+        'previous_experience_explanation': 'Previous Experience (explanation)',
+        'programming_language_usage_frequency': 'Programming Language Usage',
+        'teaching_frequency_expectation': 'Teaching Frequency Expectation',
+        'teaching_frequency_expectation_other': 'Teaching Frequency Expectation (other)',
+        'max_travelling_frequency': 'Max Travelling Frequency',
+        'max_travelling_frequency_other': 'Max Travelling Frequency (other)',
+        'reason': 'Reason for undertaking training',
+        'comment': 'Comment',
+        'training_completion_agreement': 'Training completion agreement (yes/no)',
+        'workshop_teaching_agreement': 'Workshop teaching agreement (yes/no)',
+        'data_privacy_agreement': 'Data privacy agreement (yes/no)',
+        'code_of_conduct_agreement': 'Code of Conduct agreement (yes/no)',
+    }

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -17,7 +17,7 @@ from workshops.models import (
 
 
 class AwardPersonSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='person.get_full_name')
+    name = serializers.CharField(source='person.full_name')
     user = serializers.CharField(source='person.username')
 
     class Meta:
@@ -26,7 +26,7 @@ class AwardPersonSerializer(serializers.ModelSerializer):
 
 
 class PersonUsernameSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='get_full_name')
+    name = serializers.CharField(source='full_name')
     user = serializers.CharField(source='username')
 
     class Meta:
@@ -35,7 +35,7 @@ class PersonUsernameSerializer(serializers.ModelSerializer):
 
 
 class PersonNameEmailUsernameSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='get_full_name')
+    name = serializers.CharField(source='full_name')
 
     class Meta:
         model = Person
@@ -43,7 +43,7 @@ class PersonNameEmailUsernameSerializer(serializers.ModelSerializer):
 
 
 class PersonNameSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='get_full_name')
+    name = serializers.CharField(source='full_name')
 
     class Meta:
         model = Person
@@ -141,13 +141,13 @@ class InstructorNumTaughtSerializer(serializers.Serializer):
     person = serializers.HyperlinkedRelatedField(
         read_only=True, view_name='api:person-detail', lookup_field='pk',
         source='*')
-    name = serializers.CharField(source='get_full_name')
+    name = serializers.CharField(source='full_name')
     num_taught = serializers.IntegerField()
 
 
 class InstructorsByTimePeriodSerializer(serializers.ModelSerializer):
     event_slug = serializers.CharField(source='event.slug')
-    person_name = serializers.CharField(source='person.get_full_name')
+    person_name = serializers.CharField(source='person.full_name')
     person_email = serializers.EmailField(source='person.email')
     num_taught = serializers.SerializerMethodField()
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -317,6 +317,43 @@ class TrainingRequestSerializer(serializers.ModelSerializer):
         )
 
 
+class TrainingRequestWithPersonSerializer(TrainingRequestSerializer):
+    person = serializers.SlugRelatedField(many=False, read_only=True,
+                                          slug_field='full_name')
+    domains = serializers.SerializerMethodField()
+    previous_involvement = serializers.SerializerMethodField()
+
+    def get_domains(self, obj):
+        return ", ".join(map(lambda x: getattr(x, 'name'),
+                             obj.domains.all()))
+
+    def get_previous_involvement(self, obj):
+        return ", ".join(map(lambda x: getattr(x, 'name'),
+                             obj.previous_involvement.all()))
+
+    class Meta:
+        model = TrainingRequest
+        fields = (
+            'created_at', 'last_updated_at', 'state',
+            'person', 'group_name', 'personal', 'middle', 'family', 'email',
+            'github', 'underrepresented',
+            'occupation', 'occupation_other', 'affiliation',
+            'location', 'country', 'underresourced',
+            'domains', 'domains_other', 'nonprofit_teaching_experience',
+            'previous_involvement', 'previous_training',
+            'previous_training_other', 'previous_training_explanation',
+            'previous_experience', 'previous_experience_other',
+            'previous_experience_explanation',
+            'programming_language_usage_frequency',
+            'teaching_frequency_expectation',
+            'teaching_frequency_expectation_other',
+            'max_travelling_frequency', 'max_travelling_frequency_other',
+            'reason', 'comment',
+            'training_completion_agreement', 'workshop_teaching_agreement',
+            'data_privacy_agreement', 'code_of_conduct_agreement',
+        )
+
+
 # The serializers below are meant to help display user's data without any
 # links in relational fields; instead, either an expanded model is displayed,
 # or - if it's simple enough - its' string representation.

--- a/api/test/test_trainingrequests.py
+++ b/api/test/test_trainingrequests.py
@@ -1,0 +1,282 @@
+import datetime
+import json
+from unittest.mock import patch
+
+from django.http import QueryDict
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from api.test.base import APITestBase
+from api.views import (
+    TrainingRequests,
+)
+
+from workshops.models import (
+    Person,
+    Role,
+    KnowledgeDomain,
+    TrainingRequest,
+)
+
+
+class TestListingTrainingRequests(APITestBase):
+    view = TrainingRequests
+    serializer_class = TrainingRequests.serializer_class
+    url = 'api:training-requests'
+    maxDiff = None
+
+    def setUp(self):
+        # admin
+        self.admin = Person.objects.create_superuser(
+                username="admin", personal="Super", family="User",
+                email="sudo@example.org", password='admin')
+        self.admin.data_privacy_agreement = True
+        self.admin.save()
+
+        # some roles don't exist
+        Role.objects.create(name='learner', verbose_name='Learner')
+        Role.objects.create(name='helper', verbose_name='Helper')
+
+        # first training request (pending)
+        self.tr1 = TrainingRequest(
+            state='p',
+            person=None,
+            group_name='GummiBears',
+            personal='Zummi',
+            middle='',
+            family='Gummi-Glen',
+            email='zummi@gummibears.com',
+            github=None,
+            occupation='',
+            occupation_other='Magician',
+            affiliation='Gummi-Glen',
+            location='Forest',
+            country='US',
+            underresourced=True,
+            domains_other='Magic',
+            underrepresented='Yes',
+            nonprofit_teaching_experience='None',
+            previous_training='none',
+            previous_training_other='',
+            previous_training_explanation='I have no formal education',
+            previous_experience='hours',
+            previous_experience_other='',
+            previous_experience_explanation='I taught other Gummies',
+            programming_language_usage_frequency='not-much',
+            teaching_frequency_expectation='monthly',
+            teaching_frequency_expectation_other='',
+            max_travelling_frequency='not-at-all',
+            max_travelling_frequency_other='',
+            reason='I hope to pass on the Gummi Wisdom one day, and to do that'
+                   ' I must know how to do it efficiently.',
+            comment='',
+            training_completion_agreement=True,
+            workshop_teaching_agreement=True,
+            data_privacy_agreement=True,
+            code_of_conduct_agreement=True,
+        )
+        self.tr1.save()
+        self.tr1.domains.set(
+            KnowledgeDomain.objects.filter(name__in=['Chemistry', 'Medicine'])
+        )
+        # no previous involvement
+        self.tr1.previous_involvement.clear()
+
+        # second training request (accepted)
+        self.tr2 = TrainingRequest(
+            state='a',
+            person=self.admin,
+            group_name='GummiBears',
+            personal='Grammi',
+            middle='',
+            family='Gummi-Glen',
+            email='grammi@gummibears.com',
+            github=None,
+            occupation='',
+            occupation_other='Cook',
+            affiliation='Gummi-Glen',
+            location='Forest',
+            country='US',
+            underresourced=True,
+            domains_other='Cooking',
+            underrepresented='Yes',
+            nonprofit_teaching_experience='None',
+            previous_training='none',
+            previous_training_other='',
+            previous_training_explanation='I have no formal education',
+            previous_experience='hours',
+            previous_experience_other='',
+            previous_experience_explanation='I taught other Gummies',
+            programming_language_usage_frequency='not-much',
+            teaching_frequency_expectation='monthly',
+            teaching_frequency_expectation_other='',
+            max_travelling_frequency='not-at-all',
+            max_travelling_frequency_other='',
+            reason='I need to pass on the Gummiberry juice recipe one day, and'
+                   ' to do that I must know how to do it efficiently.',
+            comment='',
+            training_completion_agreement=True,
+            workshop_teaching_agreement=True,
+            data_privacy_agreement=True,
+            code_of_conduct_agreement=True,
+        )
+        self.tr2.save()
+        self.tr2.domains.set(
+            KnowledgeDomain.objects.filter(name__in=['Chemistry'])
+        )
+        self.tr2.previous_involvement.set(
+            Role.objects.filter(name__in=['learner', 'helper'])
+        )
+
+        current_tz = timezone.get_current_timezone()
+
+        # prepare expecting dataset
+        self.expecting = [
+            {
+                'created_at':
+                    self.tr1.created_at.astimezone(current_tz).isoformat(),
+                'last_updated_at':
+                    self.tr1.last_updated_at.astimezone(current_tz).isoformat(),
+                'state': 'Pending',
+                'person': None,
+                'group_name': 'GummiBears',
+                'personal': 'Zummi',
+                'middle': '',
+                'family': 'Gummi-Glen',
+                'email': 'zummi@gummibears.com',
+                'github': None,
+                'underrepresented': 'Yes',
+                'occupation': '',
+                'occupation_other': 'Magician',
+                'affiliation': 'Gummi-Glen',
+                'location': 'Forest',
+                'country': 'US',
+                'underresourced': True,
+                'domains': 'Chemistry, Medicine',
+                'domains_other': 'Magic',
+                'nonprofit_teaching_experience': 'None',
+                'previous_involvement': '',
+                'previous_training': 'None',
+                'previous_training_other': '',
+                'previous_training_explanation': 'I have no formal education',
+                'previous_experience': 'A few hours',
+                'previous_experience_other': '',
+                'previous_experience_explanation': 'I taught other Gummies',
+                'programming_language_usage_frequency':
+                    'Never or almost never',
+                'teaching_frequency_expectation': 'Several times a year',
+                'teaching_frequency_expectation_other': '',
+                'max_travelling_frequency': 'Not at all',
+                'max_travelling_frequency_other': '',
+                'reason':
+                    'I hope to pass on the Gummi Wisdom one day, and to do '
+                    'that I must know how to do it efficiently.',
+                'comment': '',
+                'training_completion_agreement': True,
+                'workshop_teaching_agreement': True,
+                'data_privacy_agreement': True,
+                'code_of_conduct_agreement': True,
+            },
+            {
+                'created_at':
+                    self.tr2.created_at.astimezone(current_tz).isoformat(),
+                'last_updated_at':
+                    self.tr2.last_updated_at.astimezone(current_tz).isoformat(),
+                'state': 'Accepted',
+                'person': 'Super User',
+                'group_name': 'GummiBears',
+                'personal': 'Grammi',
+                'middle': '',
+                'family': 'Gummi-Glen',
+                'email': 'grammi@gummibears.com',
+                'github': None,
+                'underrepresented': 'Yes',
+                'occupation': '',
+                'occupation_other': 'Cook',
+                'affiliation': 'Gummi-Glen',
+                'location': 'Forest',
+                'country': 'US',
+                'underresourced': True,
+                'domains': 'Chemistry',
+                'domains_other': 'Cooking',
+                'nonprofit_teaching_experience': 'None',
+                'previous_involvement': 'learner, helper',
+                'previous_training': 'None',
+                'previous_training_other': '',
+                'previous_training_explanation': 'I have no formal education',
+                'previous_experience': 'A few hours',
+                'previous_experience_other': '',
+                'previous_experience_explanation':
+                    'I taught other Gummies',
+                'programming_language_usage_frequency':
+                    'Never or almost never',
+                'teaching_frequency_expectation': 'Several times a year',
+                'teaching_frequency_expectation_other': '',
+                'max_travelling_frequency': 'Not at all',
+                'max_travelling_frequency_other': '',
+                'reason':
+                    'I need to pass on the Gummiberry juice recipe one day,'
+                    ' and to do that I must know how to do it efficiently.',
+                'comment': '',
+                'training_completion_agreement': True,
+                'workshop_teaching_agreement': True,
+                'data_privacy_agreement': True,
+                'code_of_conduct_agreement': True,
+            },
+        ]
+
+    @patch.object(TrainingRequests, 'request', query_params=QueryDict(),
+                  create=True)
+    def test_serialization(self, mock_request):
+        # we're mocking a request here because it's not possible to create
+        # a fake request context for the view
+        response = self.serializer_class(self.view().get_queryset(), many=True)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0], self.expecting[0])
+        self.assertEqual(response.data[1], self.expecting[1])
+
+    def test_CSV_renderer(self):
+        """Test columns order and labels in the resulting CSV file."""
+        url = reverse(self.url)
+
+        # get CSV-formatted output
+        self.client.login(username='admin', password='admin')
+        response = self.client.get(url, {'format': 'csv'})
+        content = response.content.decode('utf-8')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        firstline = content.splitlines()[0]
+        expected_firstline = (
+            'Created at,Last updated at,State,Matched Trainee,Group Name,'
+            'Personal,Middle,Family,Email,GitHub username,'
+            'Underrepresented (reason),Occupation,Occupation (other),'
+            'Affiliation,Location,Country,Underresourced institution,'
+            'Expertise areas,Expertise areas (other),'
+            'Non-profit teaching experience,Previous Involvement,'
+            'Previous Training in Teaching,Previous Training (other),'
+            'Previous Training (explanation),Previous Experience in Teaching,'
+            'Previous Experience (other),Previous Experience (explanation),'
+            'Programming Language Usage,Teaching Frequency Expectation,'
+            'Teaching Frequency Expectation (other),Max Travelling Frequency,'
+            'Max Travelling Frequency (other),Reason for undertaking training,'
+            'Comment,Training completion agreement (yes/no),'
+            'Workshop teaching agreement (yes/no),'
+            'Data privacy agreement (yes/no),'
+            'Code of Conduct agreement (yes/no)'
+        )
+
+        self.assertEqual(firstline, expected_firstline)
+
+    @patch.object(TrainingRequests, 'request', query_params=QueryDict(),
+                  create=True)
+    def test_M2M_columns(self, mock_request):
+        """Some columns are M2M fields, but should be displayed as a string,
+        not array /list/."""
+        # the same mocking as in test_serialization
+        response = self.serializer_class(self.view().get_queryset(), many=True)
+        self.assertEqual(len(response.data), 2)
+
+        self.assertEqual(response.data[0]['domains'], 'Chemistry, Medicine')
+        self.assertEqual(response.data[1]['previous_involvement'],
+                         'learner, helper')

--- a/api/urls.py
+++ b/api/urls.py
@@ -50,6 +50,9 @@ urlpatterns = [
     url('^todos/user/$',
         views.UserTodoItems.as_view(),
         name='user-todos'),
+    url('^training_requests/$',
+        views.TrainingRequests.as_view(),
+        name='training-requests'),
 
     url('^', include(router.urls)),
     url('^', include(awards_router.urls)),

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -1441,7 +1441,7 @@ class BulkChangeTrainingRequestForm(forms.Form):
                    formnovalidate='formnovalidate'),
             HTML('<a bulk-email-on-click class="btn btn-primary">'
                  'Mail selected trainees</a>&nbsp;'),
-            HTML('<a class="btn btn-primary" href="{% url \'download_trainingrequests\' %}">'
+            HTML('<a class="btn btn-primary" href="{% url \'api:training-requests\' %}?format=csv">'
                  'Download all requests as CSV</a>&nbsp;'),
             HTML('<a href="{% url \'training_request\' %}" class="btn btn-success">'
                  'Create new request</a>'),

--- a/workshops/management/commands/check_certificates.py
+++ b/workshops/management/commands/check_certificates.py
@@ -59,14 +59,14 @@ class Command(BaseCommand):
             except Person.DoesNotExist as e:
                 self.stderr.write('{0} does not exist'.format(username))
             else:
-                name = receiver.get_full_name()
+                name = receiver.full_name
 
                 if uid in records:
                     event = records[uid]['event']
                     awarded = records[uid]['awarded']
                     username = records[uid]['awarded_by']
                     try:
-                        awarded_by = Person.objects.get(username=username).get_full_name()
+                        awarded_by = Person.objects.get(username=username).full_name
                     except Person.DoesNotExist as e:
                         self.stderr.write(
                             'Person with username={0} who awarded {1} '

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -472,21 +472,18 @@ class Person(AbstractBaseUser, PermissionsMixin, DataPrivacyAgreementMixin):
              'Can this user access the restricted API endpoints?'),
         ]
 
-    def get_full_name(self):
+    @cached_property
+    def full_name(self):
         middle = ''
         if self.middle:
             middle = ' {0}'.format(self.middle)
         return '{0}{1} {2}'.format(self.personal, middle, self.family)
 
-    @cached_property
-    def full_name(self):
-        return self.get_full_name()
-
     def get_short_name(self):
         return self.personal
 
     def __str__(self):
-        result = self.get_full_name()
+        result = self.full_name
         if self.email:
             result += ' <' + self.email + '>'
         return result

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -478,6 +478,10 @@ class Person(AbstractBaseUser, PermissionsMixin, DataPrivacyAgreementMixin):
             middle = ' {0}'.format(self.middle)
         return '{0}{1} {2}'.format(self.personal, middle, self.family)
 
+    @cached_property
+    def full_name(self):
+        return self.get_full_name()
+
     def get_short_name(self):
         return self.personal
 

--- a/workshops/templates/mailing/instructor_activity.txt
+++ b/workshops/templates/mailing/instructor_activity.txt
@@ -29,7 +29,7 @@ working with you.
 
 ----------------------------------------
 
-Name: {{ person.get_full_name }}
+Name: {{ person.full_name }}
 Preferred email: {{ person.email }}{% for award in instructor_awards %}
 You became {{ award.badge }} on: {{ award.awarded }}{% endfor %}
 Closest airport: {% if person.airport %}{{ person.airport.iata }}{% else %}—{% endif %}
@@ -37,4 +37,4 @@ Twitter handle: {{ person.twitter|default:"—" }}
 GitHub handle: {{ person.github|default:"—" }}
 Lessons you can teach: {{ lessons|join:', ' }}
 You were:{% for own, foreign in tasks %}
-- {{ own.role }} at {{ own.event }} with {% for task in foreign %}{{ task.person.get_full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endfor %}
+- {{ own.role }} at {{ own.event }} with {% for task in foreign %}{{ task.person.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endfor %}

--- a/workshops/templates/workshops/all_persons.html
+++ b/workshops/templates/workshops/all_persons.html
@@ -22,13 +22,13 @@
       <tr>
         <td class="text-center">{% if person.is_dc_instructor %}{% bootstrap_tag "DC" %}{% endif %}</td>
         <td class="text-center">{% if person.is_swc_instructor %}{% bootstrap_tag "SWC" %}{% endif %}</td>
-        <td><a href="{% url 'person_details' person.id %}">{{ person.get_full_name }}</a></td>
+        <td><a href="{% url 'person_details' person.id %}">{{ person.full_name }}</a></td>
         <td>{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.email }}</a>{% else %}—{% endif %}</td>
         <td>
-          <a href="{% url 'person_details' person.pk %}" title="View {{ person.get_full_name }}"><span class="glyphicon glyphicon-info-sign"></span></a>
+          <a href="{% url 'person_details' person.pk %}" title="View {{ person.full_name }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;
           {% if perms.workshops.change_person %}
-          <a href="{% url 'person_edit' person.pk %}" title="Edit {{ person.get_full_name }}"><span class="glyphicon glyphicon-pencil"></span></a>
+          <a href="{% url 'person_edit' person.pk %}" title="Edit {{ person.full_name }}"><span class="glyphicon glyphicon-pencil"></span></a>
           {% endif %}
         </td>
       </tr>

--- a/workshops/templates/workshops/all_tasks.html
+++ b/workshops/templates/workshops/all_tasks.html
@@ -22,7 +22,7 @@
     {% for task in all_tasks %}
         <tr>
             <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
-            <td><a href="{{ task.person.get_absolute_url }}">{{ task.person.get_full_name }}</a>{% if task.person.email and task.person.may_contact %} &lt;{{ task.person.email|urlize }}&gt;{% endif %}</td>
+            <td><a href="{{ task.person.get_absolute_url }}">{{ task.person.full_name }}</a>{% if task.person.email and task.person.may_contact %} &lt;{{ task.person.email|urlize }}&gt;{% endif %}</td>
             <td>{{ task.title|default:"—" }}</td>
             <td>{{ task.url|default:"—"|urlize_newtab }}</td>
             <td>{{ task.role }}</td>

--- a/workshops/templates/workshops/all_trainees.html
+++ b/workshops/templates/workshops/all_trainees.html
@@ -58,7 +58,7 @@
         </td>
         <td>
           <a href="{% url 'person_details' trainee.id %}">
-            {{ trainee.get_full_name }}
+            {{ trainee.full_name }}
           </a>
           {% if trainee.email %}<br /> &lt;{{ trainee.email|urlize }}&gt; {% endif %}
         </td>
@@ -120,10 +120,10 @@
           {% endif %}
         </td>
         <td>
-          <a href="{% url 'person_details' trainee.pk %}" title="View {{ trainee.get_full_name }}"><span class="glyphicon glyphicon-info-sign"></span></a>
+          <a href="{% url 'person_details' trainee.pk %}" title="View {{ trainee.full_name }}"><span class="glyphicon glyphicon-info-sign"></span></a>
           &nbsp;
           {% if perms.workshops.change_person %}
-          <a href="{% url 'person_edit' trainee.pk %}" title="Edit {{ trainee.get_full_name }}"><span class="glyphicon glyphicon-pencil"></span></a>
+          <a href="{% url 'person_edit' trainee.pk %}" title="Edit {{ trainee.full_name }}"><span class="glyphicon glyphicon-pencil"></span></a>
           {% endif %}
         </td>
       </tr>

--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -83,7 +83,7 @@
           <td>
             {% if req.person %}
               <a href="{% url 'person_details' req.person.pk %}">
-                {{ req.person.get_full_name }}
+                {{ req.person.full_name }}
               </a>
               {% if req.person.email %}
                 <br />&lt;{{ req.person.email|urlize }}&gt;

--- a/workshops/templates/workshops/badge.html
+++ b/workshops/templates/workshops/badge.html
@@ -27,10 +27,10 @@
     </tr>
     {% for award in awards %}
     <tr>
-      <td><a href="{{ award.person.get_absolute_url }}">{{ award.person.get_full_name }}</a>{% if award.person.email and award.person.may_contact %} &lt;{{ award.person.email|urlize }}&gt;{% endif %}</td>
+      <td><a href="{{ award.person.get_absolute_url }}">{{ award.person.full_name }}</a>{% if award.person.email and award.person.may_contact %} &lt;{{ award.person.email|urlize }}&gt;{% endif %}</td>
       <td>{{ award.awarded }}</td>
       <td>{% if award.event %}<a href="{% url 'event_details' award.event.slug %}">{{ award.event }}</a>{% else %}—{% endif %}</td>
-      <td>{% if award.awarded_by %}<a href="{{ award.awarded_by.get_absolute_url }}">{{ award.awarded_by.get_full_name }}</a>{% else %}—{% endif %}</td>
+      <td>{% if award.awarded_by %}<a href="{{ award.awarded_by.get_absolute_url }}">{{ award.awarded_by.full_name }}</a>{% else %}—{% endif %}</td>
       <td>
         <form action="{% url 'award_delete' pk=award.id %}" onsubmit='return confirm("Are you sure you wish to drop award \"{{ award.badge.title }}\" from \"{{ award.person }}\"?")' method="POST">
           {% csrf_token %}

--- a/workshops/templates/workshops/dcselforganizedeventrequest.html
+++ b/workshops/templates/workshops/dcselforganizedeventrequest.html
@@ -15,7 +15,7 @@
       <a href="#" id="change_assignment"><span class="glyphicon glyphicon-cog"></span></a>
       Assignee:
       {% if object.assigned_to %}
-        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.get_full_name }}</a> (<a href="{% url 'dcselforganizedeventrequest_assign' object.pk %}" id="clear-assignment">clear</a>).
+        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.full_name }}</a> (<a href="{% url 'dcselforganizedeventrequest_assign' object.pk %}" id="clear-assignment">clear</a>).
       {% else %}
         no one (<a href="{% url 'dcselforganizedeventrequest_assign' object.pk user.pk %}" id="assign-yourself">assign yourself</a>).
       {% endif %}

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -31,7 +31,7 @@
       <a href="#" id="change_assignment"><span class="glyphicon glyphicon-cog"></span></a>
       Assignee:
       {% if event.assigned_to %}
-        <a href="{{ event.assigned_to.get_absolute_url }}">{{ event.assigned_to.get_full_name }}</a> (<a href="{% url 'event_assign' event.slug %}" id="clear-assignment">clear</a>).
+        <a href="{{ event.assigned_to.get_absolute_url }}">{{ event.assigned_to.full_name }}</a> (<a href="{% url 'event_assign' event.slug %}" id="clear-assignment">clear</a>).
       {% else %}
         no one (<a href="{% url 'event_assign' event.slug user.pk %}" id="assign-yourself">assign yourself</a>).
       {% endif %}
@@ -167,7 +167,7 @@
   <tr>
     <td class="text-center">{% if t.person_is_dc_instructor %}{% bootstrap_tag "DC" %}{% endif %}</td>
     <td class="text-center">{% if t.person_is_swc_instructor %}{% bootstrap_tag "SWC" %}{% endif %}</td>
-    <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.get_full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
+    <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
     <td><a href="{% url 'task_details' t.pk %}">{{ t.title|default:"—" }}</a></td>
     <td>{{ t.url|default:"—"|urlize_newtab }}</td>
     <td>{{ t.role.name }}</td>

--- a/workshops/templates/workshops/event_edit_form.html
+++ b/workshops/templates/workshops/event_edit_form.html
@@ -43,12 +43,12 @@
     </tr>
     {% for t in tasks %}
     <tr>
-      <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.get_full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
+      <td><a href="{{ t.person.get_absolute_url }}">{{ t.person.full_name }}</a>{% if t.person.email and t.person.may_contact %} &lt;{{ t.person.email|urlize }}&gt;{% endif %}</td>
       <td><a href="{% url 'task_details' t.pk %}">{{ t.title|default:"—" }}</a></td>
       <td>{{ t.url|default:"—"|urlize_newtab }}</td>
       <td>{{ t.role.name }}</td>
       <td>
-        <form action="{% url 'task_delete' t.id %}?next={{ request.get_full_path|urlencode }}#tasks" onsubmit='return confirm("Are you sure you wish to remove \"{{ t.person.get_full_name }}\" from {{ object.slug }}?")' method="POST">
+        <form action="{% url 'task_delete' t.id %}?next={{ request.get_full_path|urlencode }}#tasks" onsubmit='return confirm("Are you sure you wish to remove \"{{ t.person.full_name }}\" from {{ object.slug }}?")' method="POST">
           {% csrf_token %}
           <button type="submit" class="btn btn-danger">Delete</button>
         </form>

--- a/workshops/templates/workshops/event_review_metadata_changes.html
+++ b/workshops/templates/workshops/event_review_metadata_changes.html
@@ -12,12 +12,12 @@
     </tr>
     <tr>
       <th>Instructors</th>
-      <td>{% for t in event.task_set.instructors %}{{ t.person.get_full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+      <td>{% for t in event.task_set.instructors %}{{ t.person.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
       <td>{{ metadata.instructors|join:', ' }}</td>
     </tr>
     <tr>
       <th>Helpers</th>
-      <td>{% for t in event.task_set.helpers %}{{ t.person.get_full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+      <td>{% for t in event.task_set.helpers %}{{ t.person.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
       <td>{{ metadata.helpers|join:', ' }}</td>
     </tr>
     <tr>

--- a/workshops/templates/workshops/eventrequest.html
+++ b/workshops/templates/workshops/eventrequest.html
@@ -17,7 +17,7 @@
       <a href="#" id="change_assignment"><span class="glyphicon glyphicon-cog"></span></a>
       Assignee:
       {% if object.assigned_to %}
-        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.get_full_name }}</a> (<a href="{% url 'eventrequest_assign' object.pk %}" id="clear-assignment">clear</a>).
+        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.full_name }}</a> (<a href="{% url 'eventrequest_assign' object.pk %}" id="clear-assignment">clear</a>).
       {% else %}
         no one (<a href="{% url 'eventrequest_assign' object.pk user.pk %}" id="assign-yourself">assign yourself</a>).
       {% endif %}

--- a/workshops/templates/workshops/events_merge.html
+++ b/workshops/templates/workshops/events_merge.html
@@ -36,8 +36,8 @@
     </tr>
     <tr>
       <th>Assignee</th>
-      <td>{% if obj_a.assigned_to %}<a href="{{ obj_a.assigned_to.get_absolute_url }}">{{ obj_a.assigned_to.get_full_name }}</a>{% else %}—{% endif %}</td>
-      <td>{% if obj_b.assigned_to %}<a href="{{ obj_b.assigned_to.get_absolute_url }}">{{ obj_b.assigned_to.get_full_name }}</a>{% else %}—{% endif %}</td>
+      <td>{% if obj_a.assigned_to %}<a href="{{ obj_a.assigned_to.get_absolute_url }}">{{ obj_a.assigned_to.full_name }}</a>{% else %}—{% endif %}</td>
+      <td>{% if obj_b.assigned_to %}<a href="{{ obj_b.assigned_to.get_absolute_url }}">{{ obj_b.assigned_to.full_name }}</a>{% else %}—{% endif %}</td>
       <th>{% include "workshops/merge_radio.html" with field=form.assigned_to %}</th>
     </tr>
     <tr>

--- a/workshops/templates/workshops/eventsubmission.html
+++ b/workshops/templates/workshops/eventsubmission.html
@@ -15,7 +15,7 @@
       <a href="#" id="change_assignment"><span class="glyphicon glyphicon-cog"></span></a>
       Assignee:
       {% if object.assigned_to %}
-        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.get_full_name }}</a> (<a href="{% url 'eventsubmission_assign' object.pk %}" id="clear-assignment">clear</a>).
+        <a href="{{ object.assigned_to.get_absolute_url }}">{{ object.assigned_to.full_name }}</a> (<a href="{% url 'eventsubmission_assign' object.pk %}" id="clear-assignment">clear</a>).
       {% else %}
         no one (<a href="{% url 'eventsubmission_assign' object.pk user.pk %}" id="assign-yourself">assign yourself</a>).
       {% endif %}

--- a/workshops/templates/workshops/instructor_issues.html
+++ b/workshops/templates/workshops/instructor_issues.html
@@ -15,7 +15,7 @@
   </tr>
   {% for person in instructors %}
   <tr>
-    <td><a href="{% url 'person_details' person.id %}">{{ person.get_full_name }}</a></td>
+    <td><a href="{% url 'person_details' person.id %}">{{ person.full_name }}</a></td>
     <td>
       {% if person.email %}
       <a href="mailto:{{person.email}}?subject={% filter urlencode %}Missing location information{% endfilter %}&body={% filter urlencode %}Hi,
@@ -49,7 +49,7 @@ Thanks for your help.{% endfilter %}">
     {% regroup pending by person as trainings %}
     {% for person_training in trainings %}
     <tr>
-      <td><a href="{% url 'person_details' person_training.grouper.id %}">{{ person_training.grouper.get_full_name }}</a></td>
+      <td><a href="{% url 'person_details' person_training.grouper.id %}">{{ person_training.grouper.full_name }}</a></td>
       <td>
         {% for e in person_training.list %}
           <a href="{% url 'event_details' e.event.slug %}">{{ e.event }}</a>{% if not forloop.last %}, {% endif %}
@@ -85,7 +85,7 @@ Thanks for your help.{% endfilter %}">
     {% regroup stalled by person as trainings %}
     {% for person_training in trainings %}
     <tr>
-      <td><a href="{% url 'person_details' person_training.grouper.id %}">{{ person_training.grouper.get_full_name }}</a></td>
+      <td><a href="{% url 'person_details' person_training.grouper.id %}">{{ person_training.grouper.full_name }}</a></td>
       <td>
         {% for e in person_training.list %}
           <a href="{% url 'event_details' e.event.slug %}">{{ e.event }}</a>{% if not forloop.last %}, {% endif %}

--- a/workshops/templates/workshops/instructors_by_date.html
+++ b/workshops/templates/workshops/instructors_by_date.html
@@ -16,7 +16,7 @@
     {% for task in all_tasks %}
     <tr>
         <td><a href="{{ task.event.get_absolute_url }}">{{ task.event }}</a></td>
-        <td><a href="{{ task.person.get_absolute_url }}">{{ task.person.get_full_name }}</a>{% if task.person.email and task.person.may_contact %} &lt;{{ task.person.email|urlize }}&gt;{% endif %} (taught {{ task.taught_times }} times)</a></td>
+        <td><a href="{{ task.person.get_absolute_url }}">{{ task.person.full_name }}</a>{% if task.person.email and task.person.may_contact %} &lt;{{ task.person.email|urlize }}&gt;{% endif %} (taught {{ task.taught_times }} times)</a></td>
         <td><a href="{% url 'task_details' task.id %}">...</a></td>
     </tr>
     {% endfor %}

--- a/workshops/templates/workshops/last_modified.html
+++ b/workshops/templates/workshops/last_modified.html
@@ -1,6 +1,6 @@
 {% if created %}
   {% if created.revision.user %}
-  <p><a href="{% url 'object_changes' created.id %}">Created on {{ created.revision.date_created }}</a> by <a href="{{ created.revision.user.get_absolute_url }}">{{ created.revision.user.get_full_name }}</a>.</p>
+  <p><a href="{% url 'object_changes' created.id %}">Created on {{ created.revision.date_created }}</a> by <a href="{{ created.revision.user.get_absolute_url }}">{{ created.revision.user.full_name }}</a>.</p>
   {% else %}
   <p><a href="{% url 'object_changes' created.id %}">Created on {{ created.revision.date_created }}</a> by unknown user.</p>
   {% endif %}
@@ -9,7 +9,7 @@
 {% endif %}
 {% if last_modified %}
   {% if last_modified.revision.user %}
-  <p><a href="{% url 'object_changes' last_modified.id %}">Last modified on {{ last_modified.revision.date_created }}</a> by <a href="{{ last_modified.revision.user.get_absolute_url }}">{{ last_modified.revision.user.get_full_name }}</a>.</p>
+  <p><a href="{% url 'object_changes' last_modified.id %}">Last modified on {{ last_modified.revision.date_created }}</a> by <a href="{{ last_modified.revision.user.get_absolute_url }}">{{ last_modified.revision.user.full_name }}</a>.</p>
   {% else %}
   <p><a href="{% url 'object_changes' last_modified.id %}">Last modified on {{ last_modified.revision.date_created }}</a> by unknown user.</p>
   {% endif %}

--- a/workshops/templates/workshops/person.html
+++ b/workshops/templates/workshops/person.html
@@ -79,7 +79,7 @@
     <h5>Awards:</h5>
     <ul>
       {% for a in awards %}
-      <li>awarded {% if a.awarded_by %}by <a href="{{ a.awarded_by.get_absolute_url }}">{{ a.awarded_by.get_full_name }}</a>{% endif %} a(n) <a href="{{ a.badge.get_absolute_url }}">{{ a.badge }}</a> badge on {{ a.awarded }}{% if a.event %} for <a href="{{ a.event.get_absolute_url }}">{{ a.event }}</a>{% endif %}</li>
+      <li>awarded {% if a.awarded_by %}by <a href="{{ a.awarded_by.get_absolute_url }}">{{ a.awarded_by.full_name }}</a>{% endif %} a(n) <a href="{{ a.badge.get_absolute_url }}">{{ a.badge }}</a> badge on {{ a.awarded }}{% if a.event %} for <a href="{{ a.event.get_absolute_url }}">{{ a.event }}</a>{% endif %}</li>
       {% endfor %}
     </ul>
     {% else %}

--- a/workshops/templates/workshops/person_edit_form.html
+++ b/workshops/templates/workshops/person_edit_form.html
@@ -39,7 +39,7 @@
           <td><a href="{{ award.badge.get_absolute_url }}">{{ award.badge.title }}</a></td>
           <td>{{ award.awarded }}</td>
           <td>{% if award.event %}<a href="{{ award.event.get_absolute_url }}">{{ award.event }}</a>{% else %}—{% endif %}</td>
-          <td>{% if award.awarded_by %}<a href="{{ award.awarded_by.get_absolute_url }}">{{ award.awarded_by.get_full_name }}</a>{% else %}—{% endif %}</td>
+          <td>{% if award.awarded_by %}<a href="{{ award.awarded_by.get_absolute_url }}">{{ award.awarded_by.full_name }}</a>{% else %}—{% endif %}</td>
           <td>
             {% if perms.workshops.delete_award %}
             <form action="{% url 'award_delete' pk=award.id %}?next={{ request.get_full_path|urlencode }}#awards" onsubmit='return confirm("Are you sure you wish to drop award \"{{ award.badge.title }}\" from \"{{ award.person }}\"?")' method="POST">

--- a/workshops/templates/workshops/trainingrequest.html
+++ b/workshops/templates/workshops/trainingrequest.html
@@ -36,7 +36,7 @@
       <td>
         {% if req.person %}
           <a href="{% url 'person_details' req.person.pk %}">
-            {{ req.person.get_full_name }}</a>
+            {{ req.person.full_name }}</a>
           {% if req.person.email %}&lt;{{ req.person.email|urlize }}&gt;{% endif %}
         {% else %}—{% endif %}
       </td></tr>

--- a/workshops/templates/workshops/workshop_staff.html
+++ b/workshops/templates/workshops/workshop_staff.html
@@ -32,7 +32,7 @@
           {% bootstrap_tag badge.name|cut:"-instructor"|upper %}
         {% endif %}
         {% endfor %}</td>
-        <td><a href="{{ p.get_absolute_url }}">{{ p.get_full_name }}</a>{% if p.email and p.may_contact %} &lt;{{ p.email|urlize }}&gt;{% endif %}</td>
+        <td><a href="{{ p.get_absolute_url }}">{{ p.full_name }}</a>{% if p.email and p.may_contact %} &lt;{{ p.email|urlize }}&gt;{% endif %}</td>
         <td>{{ p.num_taught }}</td>
         <td>{% if p.pk in trainees %}yes{% else %}no{% endif %}</td>
         <td>{% if p.airport %}<a href="{{ p.airport.get_absolute_url }}">{{ p.airport }}</a>{% else %}—{% endif %}</td>

--- a/workshops/templatetags/training_progress.py
+++ b/workshops/templatetags/training_progress.py
@@ -34,7 +34,7 @@ def progress_description(progress):
         state=progress.get_state_display(),
         type=progress.requirement,
         evaluated_by=('evaluated by {}'.format(
-                         progress.evaluated_by.get_full_name())
+                         progress.evaluated_by.full_name)
                       if progress.evaluated_by is not None else 'submitted'),
         day=progress.created_at.strftime('%A %d %B %Y at %H:%M'),
         notes='<br />Notes: {}'.format(progress.notes) if progress.notes else '',

--- a/workshops/test/test_badge.py
+++ b/workshops/test/test_badge.py
@@ -29,7 +29,7 @@ class TestBadge(TestBase):
 
         awards = self.swc_instructor.award_set.all()
         for award in awards:
-            assert award.person.get_full_name() in content, \
+            assert award.person.full_name in content, \
                 "Award for {} not found".format(award.person)
 
     def test_badge_award(self):

--- a/workshops/test/test_search.py
+++ b/workshops/test/test_search.py
@@ -81,7 +81,7 @@ class TestSearchOrganization(TestBase):
         self.assertEqual(len(response.context['persons'])
                          + len(response.context['organizations']),
                          2, 'Expected two search results')
-        for result in {self.org_alpha.domain, self.hermione.get_full_name()}:
+        for result in {self.org_alpha.domain, self.hermione.full_name}:
             self.assertIn(result, doc)
 
     def test_search_for_training_requests(self):

--- a/workshops/test/test_training_request.py
+++ b/workshops/test/test_training_request.py
@@ -304,22 +304,6 @@ class TestTrainingRequestsListView(TestBase):
                          {self.first_training})
 
 
-class TestDownloadCSVView(TestBase):
-    def setUp(self):
-        self._setUpUsersAndLogin()
-
-    def test_basic(self):
-        tr = create_training_request(state='p', person=None)
-        rv = self.client.get(reverse('download_trainingrequests'))
-        self.assertEqual(rv.status_code, 200)
-        got = rv.content.decode('utf-8')
-        expected = (
-            'Created-on,State,Matched Trainee,Group Name,Personal,Family,Email,GitHub username,Occupation,Occupation (other),Affiliation,Location,Country,Expertise areas,Expertise areas (other),Under-represented,Previous Involvement,Previous Training in Teaching,Previous Training (other),Previous Training (explanation),Programming Language Usage,Reason,Teaching Frequency Expectation,Teaching Frequency Expectation (other),Max Travelling Frequency,Max Travelling Frequency (other),Comment\r\n'
-            '{:%Y-%m-%d %H:%M}'.format(tr.created_at) + ',Pending,—,,John,Smith,john@smith.com,,Other:,,AGH University of Science and Technology,Cracow,PL,,,No,,None,,,Every day,Just for fun.,Several times a year,,Once a year,,\r\n'
-        )
-        self.assertEqual(got, expected)
-
-
 class TestMatchingTrainingRequestAndDetailedView(TestBase):
     def setUp(self):
         self._setUpUsersAndLogin()

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -173,7 +173,6 @@ urlpatterns = [
     url(r'^autoupdate_profile/$', views.autoupdate_profile, name='autoupdate_profile'),
 
     url(r'^training_requests/$', views.all_trainingrequests, name='all_trainingrequests'),
-    url(r'^training_requests/csv/$', views.download_trainingrequests, name='download_trainingrequests'),
     url(r'^training_request/(?P<pk>\d+)/', include([
         url(r'^$', views.trainingrequest_details, name='trainingrequest_details'),
         url(r'^edit/$', views.TrainingRequestUpdate.as_view(), name='trainingrequest_edit'),

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3102,7 +3102,7 @@ def download_trainingrequests(request):
         writer.writerow([
             '{:%Y-%m-%d %H:%M}'.format(req.created_at),
             req.get_state_display(),
-            '—' if req.person is None else req.person.get_full_name(),
+            '—' if req.person is None else req.person.full_name,
             req.group_name,
             req.personal,
             req.family,

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -2790,8 +2790,10 @@ def all_trainingrequests(request):
         queryset=TrainingRequest.objects.all().prefetch_related(
             Prefetch('person__task_set',
                      to_attr='training_tasks',
-                     queryset=Task.objects.filter(role__name='learner',
-                                                  event__tags__name='TTT')),
+                     queryset=Task.objects
+                        .filter(role__name='learner', event__tags__name='TTT')
+                        .select_related('event')
+                     ),
         )
     )
 
@@ -3060,76 +3062,6 @@ def training_progress(request):
 
 # ------------------------------------------------------------
 # Instructor Training related views
-
-
-@admin_required
-def download_trainingrequests(request):
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = \
-        'attachment; filename="training_requests.csv"'
-
-    writer = csv.writer(response)
-    writer.writerow([
-        'Created-on',
-        'State',
-        'Matched Trainee',
-        'Group Name',
-        'Personal',
-        'Family',
-        'Email',
-        'GitHub username',
-        'Occupation',
-        'Occupation (other)',
-        'Affiliation',
-        'Location',
-        'Country',
-        'Expertise areas',
-        'Expertise areas (other)',
-        'Under-represented',
-        'Previous Involvement',
-        'Previous Training in Teaching',
-        'Previous Training (other)',
-        'Previous Training (explanation)',
-        'Programming Language Usage',
-        'Reason',
-        'Teaching Frequency Expectation',
-        'Teaching Frequency Expectation (other)',
-        'Max Travelling Frequency',
-        'Max Travelling Frequency (other)',
-        'Comment',
-    ])
-    for req in TrainingRequest.objects.all():
-        writer.writerow([
-            '{:%Y-%m-%d %H:%M}'.format(req.created_at),
-            req.get_state_display(),
-            '—' if req.person is None else req.person.full_name,
-            req.group_name,
-            req.personal,
-            req.family,
-            req.email,
-            req.github,
-            req.get_occupation_display(),
-            req.occupation_other,
-            req.affiliation,
-            req.location,
-            req.country,
-            ';'.join(d.name for d in req.domains.all()),
-            req.domains_other,
-            req.get_underrepresented_display(),
-            ';'.join(inv.name for inv in req.previous_involvement.all()),
-            req.get_previous_training_display(),
-            req.previous_training_other,
-            req.previous_training_explanation,
-            req.get_programming_language_usage_frequency_display(),
-            req.reason,
-            req.get_teaching_frequency_expectation_display(),
-            req.teaching_frequency_expectation_other,
-            req.get_max_travelling_frequency_display(),
-            req.max_travelling_frequency_other,
-            req.comment,
-        ])
-
-    return response
 
 
 class TrainingRequestUpdate(RedirectSupportMixin,


### PR DESCRIPTION
This fixes #1278 by replacing old CSV generation within `workshops` app with a newer API endpoint that supports filtering, multiple formats, and is browsable & tested.