### PR TITLE
Small improvements to admin dashboard

### DIFF
--- a/workshops/models.py
+++ b/workshops/models.py
@@ -836,10 +836,15 @@ class EventQuerySet(models.query.QuerySet):
         """Exclude cancelled events."""
         return self.exclude(tags__name='cancelled')
 
+    def not_unresponsive(self):
+        """Exclude unresponsive events."""
+        return self.exclude(tags__name='unresponsive')
+
     def active(self):
-        """Exclude inactive events (stalled, completed or cancelled)."""
+        """Exclude inactive events (stalled, completed, cancelled or
+        unresponsive)."""
         return self.exclude(tags__name='stalled').exclude(completed=True) \
-                   .not_cancelled()
+                   .not_cancelled().not_unresponsive()
 
     def past_events(self):
         '''Return past events.
@@ -904,10 +909,10 @@ class EventQuerySet(models.query.QuerySet):
         )
 
     def unpublished_events(self):
-        """Return events considered as unpublished (see
+        """Return active events considered as unpublished (see
         `unpublished_conditional` above)."""
         conditional = self.unpublished_conditional()
-        return self.not_cancelled().filter(conditional) \
+        return self.active().filter(conditional) \
                    .order_by('slug', 'id').distinct()
 
     def published_events(self):

--- a/workshops/templates/workshops/admin_dashboard.html
+++ b/workshops/templates/workshops/admin_dashboard.html
@@ -51,28 +51,42 @@
     <h3>Unpublished</h3>
     <table class="table table-striped">
       <tr>
+        <th>slug</th>
         <th>#I</th>
         <th>dates</th>
-        <th>slug</th>
+        <th>location</th>
+        <th>URL</th>
         <th>host</th>
       </tr>
       {% for event in unpublished_events %}
       <tr>
-        <td {% if event.num_instructors == 0 %}class="warning"{% endif %}>
-          {{ event.num_instructors }}
-        </td>
-        <td>
-          {% if event.start %}✓{% endif %}
-        </td>
-        <td {% if not event.slug %}class="warning"{% endif %}>
-          {% if not event.slug %}
-          —
-          {% else %}
-          <a href="{% url 'event_details' event.slug %}">
-            {{ event.slug }}
-          </a>
-          {% endif %}
-        </td>
+        <!-- SLUG -->
+        <td><a href="{% url 'event_details' event.slug %}">{{ event.slug }}</a></td>
+        <!-- INSTRUCTORS COUNT -->
+        {% if event.num_instructors == 0 %}
+        <td class="text-danger bg-danger">{{ event.num_instructors }}</td>
+        {% else %}
+        <td class="text-success">{{ event.num_instructors }}</td>
+        {% endif %}
+        <!-- DATES -->
+        {% if not event.start %}
+        <td class="text-danger bg-danger">✗</td>
+        {% else %}
+        <td class="text-success">✓</td>
+        {% endif %}
+        <!-- LOCATION -->
+        {% if not event.address or not event.venue or not event.country or not event.latitude or not event.longitude %}
+        <td class="text-danger bg-danger">✗</td>
+        {% else %}
+        <td class="text-success">✓</td>
+        {% endif %}
+        <!-- URL -->
+        {% if not event.url %}
+        <td class="text-danger bg-danger">✗</td>
+        {% else %}
+        <td class="text-success">✓</td>
+        {% endif %}
+        <!-- HOST -->
         <td>
           <a href="{% url 'organization_details' event.host.domain %}">
             {{ event.host }}

--- a/workshops/templates/workshops/admin_dashboard.html
+++ b/workshops/templates/workshops/admin_dashboard.html
@@ -35,29 +35,19 @@
     <table class="table table-striped">
     {% for event in current_events %}
     <tr>
-      {% for tag in carpentries %}
         <td class="text-center" width="25px">
-          {% if tag in event.tags.all %}
-            {% bootstrap_tag tag.name %}
-          {% endif %}
+          {% for tag in carpentries %}
+            {% if tag in event.tags.all %}
+              {% bootstrap_tag tag.name %}
+            {% endif %}
+          {% endfor %}
         </td>
-      {% endfor %}
       <td><a href="{{ event.get_absolute_url }}">{{ event.slug }}</a></td>
     </tr>
     {% endfor %}
     </table>
   </div>
-  <div class="col-xs-3">
-    <h3>Uninvoiced</h3>
-    <table class="table table-striped">
-    {% for event in uninvoiced_events %}
-    <tr>
-      <td><a href="{{ event.get_absolute_url }}">{{ event.slug }}</a></td>
-    </tr>
-    {% endfor %}
-    </table>
-  </div>
-  <div class="col-xs-5">
+  <div class="col-xs-8">
     <h3>Unpublished</h3>
     <table class="table table-striped">
       <tr>

--- a/workshops/test/test_landing_page.py
+++ b/workshops/test/test_landing_page.py
@@ -29,20 +29,38 @@ class TestAdminDashboard(TestBase):
         """Make sure we don't display stalled or completed events on the
         dashboard."""
         stalled_tag = Tag.objects.get(name='stalled')
+        unresponsive_tag = Tag.objects.get(name='unresponsive')
+        cancelled_tag = Tag.objects.get(name='unresponsive')
+
         stalled = Event.objects.create(
             slug='stalled-event', host=Organization.objects.first(),
         )
         stalled.tags.add(stalled_tag)
+
+        unresponsive = Event.objects.create(
+            slug='unresponsive-event', host=Organization.objects.first(),
+        )
+        unresponsive.tags.add(unresponsive_tag)
+
+        cancelled = Event.objects.create(
+            slug='cancelled-event', host=Organization.objects.first(),
+        )
+        cancelled.tags.add(cancelled_tag)
+
         completed = Event.objects.create(slug='completed-event',
                                          completed=True,
                                          host=Organization.objects.first())
 
         # stalled event appears in unfiltered list of events
-        self.assertIn(stalled, Event.objects.unpublished_events())
-        self.assertIn(completed, Event.objects.unpublished_events())
+        self.assertNotIn(stalled, Event.objects.unpublished_events())
+        self.assertNotIn(unresponsive, Event.objects.unpublished_events())
+        self.assertNotIn(cancelled, Event.objects.unpublished_events())
+        self.assertNotIn(completed, Event.objects.unpublished_events())
 
         response = self.client.get(reverse('admin-dashboard'))
         self.assertNotIn(stalled, response.context['unpublished_events'])
+        self.assertNotIn(unresponsive, response.context['unpublished_events'])
+        self.assertNotIn(cancelled, response.context['unpublished_events'])
         self.assertNotIn(completed, response.context['unpublished_events'])
 
 

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -182,8 +182,6 @@ def admin_dashboard(request):
         Event.objects.upcoming_events() | Event.objects.ongoing_events()
     ).active().prefetch_related('tags')
 
-    uninvoiced_events = Event.objects.active().uninvoiced_events()
-
     # This annotation may produce wrong number of instructors when
     # `unpublished_events` filters out events that contain a specific tag.
     # The bug was fixed in #1130.
@@ -201,14 +199,11 @@ def admin_dashboard(request):
 
     if assigned_to == 'me':
         current_events = current_events.filter(assigned_to=request.user)
-        uninvoiced_events = uninvoiced_events.filter(assigned_to=request.user)
         unpublished_events = unpublished_events.filter(
             assigned_to=request.user)
 
     elif assigned_to == 'noone':
         current_events = current_events.filter(assigned_to__isnull=True)
-        uninvoiced_events = uninvoiced_events.filter(
-            assigned_to__isnull=True)
         unpublished_events = unpublished_events.filter(
             assigned_to__isnull=True)
 
@@ -231,7 +226,6 @@ def admin_dashboard(request):
         'is_admin': is_admin,
         'assigned_to': assigned_to,
         'current_events': current_events,
-        'uninvoiced_events': uninvoiced_events,
         'unpublished_events': unpublished_events,
         'todos_start_date': TodoItemQuerySet.current_week_dates()[0],
         'todos_end_date': TodoItemQuerySet.next_week_dates()[1],


### PR DESCRIPTION
This PR changes some things on admin dashboard:

1. the workshop tag (SWC/DC/LC) is not in its own column, but they're all in the same column in "Current events" (see screenshot)
2. "Uninvoiced" events is hidden
3. "Unpublished" events have a different conditions now:
  a. any event that's not "unresponsive", "stalled", "cancelled" or marked as "complete"
  b. and has no known start date, or country, or venue, or address, or lat/lng, or URL.

![screenshot_2018-07-08 amy](https://user-images.githubusercontent.com/72821/42417526-ce9bd328-828c-11e8-8bcc-adb32d150855.png)
