### PR TITLE
Eligible trainees not showing up

### DIFF
--- a/workshops/filters.py
+++ b/workshops/filters.py
@@ -294,8 +294,13 @@ def filter_trainees_by_instructor_status(queryset, name, choice):
     elif choice == 'dc':
         return queryset.filter(is_dc_instructor=True)
     elif choice == 'eligible':
-        return queryset.filter(Q(swc_eligible=True, is_swc_instructor=False) |
-                               Q(dc_eligible=True, is_dc_instructor=False))
+        # Instructor eligible but without any badge.
+        # This code is kept in Q()-expressions to allow for fast condition
+        # change.
+        return queryset.filter(
+            Q(instructor_eligible=True) &
+            (Q(is_swc_instructor=False) & Q(is_dc_instructor=False))
+        )
     else:  # choice == 'no'
         return queryset.filter(is_swc_instructor=False, is_dc_instructor=False)
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -332,14 +332,16 @@ class PersonManager(BaseUserManager):
             passed_swc_demo=passed('SWC Demo'),
             passed_dc_demo=passed('DC Demo'),
         ).annotate(
-            swc_eligible=(F('passed_training') *
-                          F('passed_swc_homework') *
-                          F('passed_discussion') *
-                          F('passed_swc_demo')),
-            dc_eligible=(F('passed_training') *
-                         F('passed_dc_homework') *
-                         F('passed_discussion') *
-                         F('passed_dc_demo')),
+            # We're using Maths to calculate "binary" score for a person to
+            # be instructor badge eligible. Legend:
+            # * means "AND"
+            # + means "OR"
+            instructor_eligible=(
+                F('passed_training') *
+                (F('passed_swc_homework') + F('passed_dc_homework')) *
+                F('passed_discussion') *
+                (F('passed_swc_demo') + F('passed_dc_demo'))
+            )
         )
 
 

--- a/workshops/templatetags/training_progress.py
+++ b/workshops/templatetags/training_progress.py
@@ -1,4 +1,5 @@
 from django import template
+from django.template.defaultfilters import escape
 from django.utils.safestring import mark_safe
 
 from workshops.models import TrainingProgress
@@ -37,7 +38,7 @@ def progress_description(progress):
                          progress.evaluated_by.full_name)
                       if progress.evaluated_by is not None else 'submitted'),
         day=progress.created_at.strftime('%A %d %B %Y at %H:%M'),
-        notes='<br />Notes: {}'.format(progress.notes) if progress.notes else '',
+        notes='<br />Notes: {}'.format(escape(progress.notes)) if progress.notes else '',
     )
     text = text[0].upper() + text[1:]
     return mark_safe(text)


### PR DESCRIPTION
This fixes #1226 by changing "instructor eligibility" annotation query.

Additionally a small bug related to display of unescaped training progress notes in HTML was fixed.