### PR TITLE
Bulk upload - a couple of fixes

### DIFF
--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -72,14 +72,18 @@
             {% if entry.similar_persons %}
                 <ul>
                 {% for person in entry.similar_persons %}
-                    <li>Matching person: <a href="{% url 'person_details' person.id %}">{{ person.personal }} {{ person.middle }} {{ person.family }} &lt;{{ person.email|default:"—" }}&gt;</a>. <a href="{% url 'person_bulk_add_match_person' i person.id %}">Use this person</a>.</li>
+                    {% if person.0 == entry.existing_person_id %}
+                    <li>Matched person: <a href="{% url 'person_details' person.0 %}">{{ person.1 }}</a>. <a href="{% url 'person_bulk_add_match_person' i %}">Unmatch</a>.</li>
+                    {% else %}
+                    <li>Matching person: <a href="{% url 'person_details' person.0 %}">{{ person.1 }}</a>. <a href="{% url 'person_bulk_add_match_person' i person.0 %}">Use this person</a>.</li>
+                    {% endif %}
                 {% endfor %}
                 </ul>
             {% endif %}
             </td>
             <td>
             {% if persons_tasks|length > 1 %}
-            <a href="{% url 'person_bulk_add_remove_entry' i %}" title='Remove this entry'><span class="glyphicon glyphicon-remove"></span></a>
+            <a href="{% url 'person_bulk_add_remove_entry' i %}" title='Remove this entry'><span class="glyphicon glyphicon-remove text-danger"></span></a>
             {% endif %}
             </td>
         {% endwith %}

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
         url(r'^confirm/$',views.person_bulk_add_confirmation, name='person_bulk_add_confirmation'),
         url(r'^(?P<entry_id>\d+)/remove/$',views.person_bulk_add_remove_entry, name='person_bulk_add_remove_entry'),
         url(r'^(?P<entry_id>\d+)/match_person/(?P<person_id>\d+)$',views.person_bulk_add_match_person, name='person_bulk_add_match_person'),
+        url(r'^(?P<entry_id>\d+)/match_person/$',views.person_bulk_add_match_person, name='person_bulk_add_match_person'),
     ])),
 
     url(r'^persons/', include([


### PR DESCRIPTION
This PR provides:
1. a couple of style, text or function documentation changes
2. a sort-of fix for #1216 (more on that below)
3. a fix for #1215 

Changes in bulk-upload:
1. when first uploaded, entries from CSV are matched against people in the database; as long as the entries are correct, there's no need to go manually through the table and click "match with selected person" for each entry - this is easier and faster to implement than what was proposed in #1216, but I hope it's good enough
2. when someone is matched, they can be later unmatched (#1215)