### PR TITLE
[fix #1284] Add API Key to fix Google Maps

### DIFF
--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -219,7 +219,7 @@
 {% block extrajs %}
 {{ todo_form.media }}
 {{ admin_lookup_form.media }}
-<script src="https://maps.googleapis.com/maps/api/js?v=3.exp"></script>
+<script src="https://maps.googleapis.com/maps/api/js?api=AIzaSyC2WQkpSyrmJhXRcBdqsonpcQjyy8BtPrA&v=3.exp"></script>
 <script type="text/javascript">
   var gmap = null;
 


### PR DESCRIPTION
Generated an API key that will only work at all Carpentry Domains (*.software-carpentry.org, *.carpentries.org and *.datacarpentry.org). Note: Now maps may not work properly when running from localhost or on other domains.