### PR TITLE
JS code breaks in `extrajs`

### DIFF
--- a/pydata/templates/pydata/person_create_form.html
+++ b/pydata/templates/pydata/person_create_form.html
@@ -7,7 +7,3 @@
 {% crispy form %}
 {% include "pydata/person_import_modal.html" %}
 {% endblock content %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/fields.py
+++ b/workshops/fields.py
@@ -1,5 +1,17 @@
+from dal_select2.widgets import (
+    Select2WidgetMixin as DALSelect2WidgetMixin,
+)
+from dal.autocomplete import (
+    Select2 as DALSelect2,
+    Select2Multiple as DALSelect2Multiple,
+    ListSelect2 as DALListSelect2,
+    ModelSelect2 as DALModelSelect2,
+    ModelSelect2Multiple as DALModelSelect2Multiple,
+    TagSelect2 as DALTagSelect2,
+)
 from django.core.validators import RegexValidator, MaxLengthValidator
 from django.db import models
+from django import forms
 
 
 GHUSERNAME_MAX_LENGTH_VALIDATOR = MaxLengthValidator(39,
@@ -29,3 +41,38 @@ class NullableGithubUsernameField(models.CharField):
         GHUSERNAME_MAX_LENGTH_VALIDATOR,
         GHUSERNAME_REGEX_VALIDATOR,
     ]
+
+#------------------------------------------------------------
+# "Rewrite" select2 widgets from Django Autocomplete Light so
+# that they don't use Django's admin-provided jQuery, which
+# causes errors with jQuery provided by us.
+
+class Select2WidgetMixin(DALSelect2WidgetMixin):
+    @property
+    def media(self):
+        m = super().media
+        js = list(m._js)
+        try:
+            js.remove('admin/js/vendor/jquery/jquery.js')
+            js.remove('admin/js/vendor/jquery/jquery.min.js')
+        except ValueError:
+            pass
+        return forms.Media(css=m._css, js=js)
+
+class Select2(Select2WidgetMixin, DALSelect2):
+    pass
+
+class Select2Multiple(Select2WidgetMixin, DALSelect2Multiple):
+    pass
+
+class ListSelect2(Select2WidgetMixin, DALListSelect2):
+    pass
+
+class ModelSelect2(Select2WidgetMixin, DALModelSelect2):
+    pass
+
+class ModelSelect2Multiple(Select2WidgetMixin, DALModelSelect2Multiple):
+    pass
+
+class TagSelect2(Select2WidgetMixin, DALTagSelect2):
+    pass

--- a/workshops/templates/base.html
+++ b/workshops/templates/base.html
@@ -14,6 +14,9 @@
     {% endcompress %}
     {% block extrastyle %}{% endblock extrastyle %}
 
+    {% compress js %}
+    <script src="{% static 'jquery/dist/jquery.js' %}"></script>
+    {% endcompress %}
 
     <title>AMY{% if title %}: {{ title }}{% endif %}</title>
   </head>
@@ -66,7 +69,6 @@
     </div>
 
     {% compress js %}
-    <script src="{% static 'jquery/dist/jquery.js' %}"></script>
     <script src="{% static 'popper.js/dist/umd/popper.js' %}"></script>
     <script src="{% static 'bootstrap/dist/js/bootstrap.js' %}"></script>
     <script src="{% static 'bootstrap-datepicker/dist/js/bootstrap-datepicker.js' %}"></script>

--- a/workshops/templates/forms/event_submit.html
+++ b/workshops/templates/forms/event_submit.html
@@ -17,7 +17,3 @@
 
 <p>Thank you.</p>
 {% endblock %}
-
-{% block extrajs %}
-{# {{ form.media }} #}
-{% endblock extrajs %}

--- a/workshops/templates/forms/profileupdate.html
+++ b/workshops/templates/forms/profileupdate.html
@@ -5,7 +5,3 @@
 {% block content %}
 {% crispy form %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/forms/trainingrequest.html
+++ b/workshops/templates/forms/trainingrequest.html
@@ -58,7 +58,3 @@ http://carpentries.github.io/instructor-training/</a>.</p>
 
 {% crispy form %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/forms/workshop_swc_request.html
+++ b/workshops/templates/forms/workshop_swc_request.html
@@ -10,7 +10,3 @@
 {% block content %}
 {% crispy form %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/workshops/autoupdate_profile.html
+++ b/workshops/templates/workshops/autoupdate_profile.html
@@ -8,7 +8,3 @@
 {% block content %}
 {% crispy form %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/workshops/event.html
+++ b/workshops/templates/workshops/event.html
@@ -247,5 +247,4 @@
     $.fn.modal.Constructor.prototype.enforceFocus = function() {};
   });
 </script>
-<!-- {{ admin_lookup_form.media }} -->
 {% endblock %}

--- a/workshops/templates/workshops/event_create_form.html
+++ b/workshops/templates/workshops/event_create_form.html
@@ -8,7 +8,3 @@
 
   {% include "includes/event_import_update_from_url.html" with update=False %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/workshops/event_edit_form.html
+++ b/workshops/templates/workshops/event_edit_form.html
@@ -98,9 +98,6 @@
 {% endblock %}
 
 {% block extrajs %}
-{{ form.media }}
-{{ task_form.media }}
-{{ sponsor_form.media }}
 <script type="text/javascript">
   $(function() {
     $('#tabs').stickyTabs();

--- a/workshops/templates/workshops/generic_form.html
+++ b/workshops/templates/workshops/generic_form.html
@@ -26,7 +26,3 @@
   {% crispy form %}
 
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/workshops/person_edit_form.html
+++ b/workshops/templates/workshops/person_edit_form.html
@@ -79,9 +79,6 @@
 {% endblock %}
 
 {% block extrajs %}
-{{ form.media }}
-{{ award_form.media }}
-{{ task_form.media }}
 <script type="text/javascript">
   $(document).ready(function() {
     $("#id_award-awarded").datepicker({

--- a/workshops/templates/workshops/todos_add.html
+++ b/workshops/templates/workshops/todos_add.html
@@ -5,7 +5,3 @@
 {% block content %}
 {% crispy formset %}
 {% endblock %}
-
-{% block extrajs %}
-{{ formset.media }}
-{% endblock %}

--- a/workshops/templates/workshops/trainingprogress_form.html
+++ b/workshops/templates/workshops/trainingprogress_form.html
@@ -8,7 +8,3 @@
 </form>
 {% crispy form %}
 {% endblock %}
-
-{% block extrajs %}
-{{ form.media }}
-{% endblock extrajs %}

--- a/workshops/templates/workshops/workshop_staff.html
+++ b/workshops/templates/workshops/workshop_staff.html
@@ -53,7 +53,3 @@
     <p>No matches.</p>
   {% endif %}
 {% endblock %}
-
-{% block extrajs %}
-{{ filter_form.media }}
-{% endblock extrajs %}


### PR DESCRIPTION
This fixes #1330. Again. :-)

So the issue, after I figured it out, quite simple: multiple things tried to include jQuery; some of those things were causing errors, that prevented further JS code from executing.

What tried to include jQuery?
1. we tried in our general JS import block (using django compressor)
2. forms using select2 widgets tried via widgets' `media` properties
3. Django Crispy Forms default behavior was to automatically render `media` in HTML
4. we tried to render `media` on our own in our own templates

A number of steps were taken to fix this situation:
1. jQuery import was moved from bottom of `<body>` to `<head>`
2. Select2 widgets from DAL were overwritten so that they don't try to include jQuery
3. Forms media renderings were removed from templates
4. Django Crispy Forms behavior was left unchanged

