### PR TITLE
Events API: Fix 500-error when filtering

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -8,22 +8,16 @@ from workshops.filters import (
 from workshops.models import Event, Task, Tag, Person, Badge
 
 
-def filter_tag_by_name(queryset, name, values):
-    # tags = Tag.objects.filter(name__in=values)
-    # for tag in tags:
-    #     queryset = queryset.filter(tags=tag)
-    # return queryset
-    return Tag.objects.all()
-
-
 class EventFilter(filters.FilterSet):
     start_after = filters.DateFilter(field_name='start', lookup_expr='gte')
     start_before = filters.DateFilter(field_name='start', lookup_expr='lte')
     end_after = filters.DateFilter(field_name='end', lookup_expr='gte')
     end_before = filters.DateFilter(field_name='end', lookup_expr='lte')
-    TAG_CHOICES = Tag.objects.all().values_list('name', 'name')
-    tag = filters.MultipleChoiceFilter(
-        choices=TAG_CHOICES, field_name='tags', method=filter_tag_by_name,
+    tags = filters.ModelMultipleChoiceFilter(
+        field_name='tags__name',
+        to_field_name='name',
+        queryset=Tag.objects.all(),
+        conjoined=True,
     )
     order_by = filters.OrderingFilter(
         fields=(
@@ -36,7 +30,7 @@ class EventFilter(filters.FilterSet):
     class Meta:
         model = Event
         fields = (
-            'completed', 'tag',
+            'completed', 'tags',
             'start', 'start_before', 'start_after',
             'end', 'end_before', 'end_after',
         )

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -1073,7 +1073,9 @@ class Event(AssignmentMixin, models.Model):
         null=True, blank=True,
         help_text=PUBLISHED_HELP_TEXT,
     )
-    end        = models.DateField(null=True, blank=True)
+    end = models.DateField(
+        null=True, blank=True,
+    )
     slug = models.SlugField(
         max_length=STR_LONG, unique=True,
         help_text='Use <code>YYYY-MM-DD-location</code> format, where '


### PR DESCRIPTION
This fixes #1351. The error was cryptic and well-hidden, but I narrowed
it to ill-made filter for tags.

Probably the idea was to allow people put in exact tag names, but now
it's easy to do with Django Filter options.