### PR TITLE
Bulk upload training request manual score

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -2,13 +2,12 @@ from rest_framework_csv.renderers import CSVRenderer
 
 from .serializers import (
     TrainingRequestWithPersonSerializer,
+    TrainingRequestForManualScoringSerializer,
 )
 
 
-class TrainingRequestCSVRenderer(CSVRenderer):
-    # sets the columns ordering
-    header = TrainingRequestWithPersonSerializer.Meta.fields
-    labels = {
+class TrainingRequestCSVColumns:
+    translation_labels = {
         'created_at': 'Created at',
         'last_updated_at': 'Last updated at',
         'state': 'State',
@@ -51,3 +50,20 @@ class TrainingRequestCSVRenderer(CSVRenderer):
         'data_privacy_agreement': 'Data privacy agreement (yes/no)',
         'code_of_conduct_agreement': 'Code of Conduct agreement (yes/no)',
     }
+
+    def __init__(self):
+        self.header = self.serializer.Meta.fields
+        self.labels = {
+            k: v
+            for k, v in self.translation_labels.items()
+            if k in self.header
+        }
+
+
+class TrainingRequestCSVRenderer(CSVRenderer, TrainingRequestCSVColumns):
+    serializer = TrainingRequestWithPersonSerializer
+
+
+class TrainingRequestManualScoreCSVRenderer(CSVRenderer, TrainingRequestCSVColumns):
+    serializer = TrainingRequestForManualScoringSerializer
+    format = 'csv2'

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -373,6 +373,37 @@ class TrainingRequestWithPersonSerializer(TrainingRequestSerializer):
         )
 
 
+class TrainingRequestForManualScoringSerializer(TrainingRequestSerializer):
+    request_id = serializers.IntegerField(source='pk')
+
+    class Meta:
+        model = TrainingRequest
+        fields = (
+            'request_id',
+            'score_manual',
+            'score_notes',
+            'group_name',
+            'personal',
+            'middle',
+            'family',
+            'underrepresented',
+            'affiliation',
+            'nonprofit_teaching_experience',
+            'previous_training',
+            'previous_training_other',
+            'previous_training_explanation',
+            'previous_experience',
+            'previous_experience_other',
+            'previous_experience_explanation',
+            'teaching_frequency_expectation',
+            'teaching_frequency_expectation_other',
+            'max_travelling_frequency',
+            'max_travelling_frequency_other',
+            'reason',
+            'comment',
+        )
+
+
 # The serializers below are meant to help display user's data without any
 # links in relational fields; instead, either an expanded model is displayed,
 # or - if it's simple enough - its' string representation.

--- a/api/test/test_trainingrequests.py
+++ b/api/test/test_trainingrequests.py
@@ -26,7 +26,6 @@ from workshops.models import (
 
 class TestListingTrainingRequests(APITestBase):
     view = TrainingRequests
-    serializer_class = TrainingRequests.serializer_class
     url = 'api:training-requests'
     maxDiff = None
 
@@ -265,7 +264,8 @@ class TestListingTrainingRequests(APITestBase):
     def test_serialization(self, mock_request):
         # we're mocking a request here because it's not possible to create
         # a fake request context for the view
-        response = self.serializer_class(self.view().get_queryset(), many=True)
+        serializer_class = self.view().get_serializer_class()
+        response = serializer_class(self.view().get_queryset(), many=True)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0], self.expecting[0])
         self.assertEqual(response.data[1], self.expecting[1])
@@ -309,7 +309,8 @@ class TestListingTrainingRequests(APITestBase):
         """Some columns are M2M fields, but should be displayed as a string,
         not array /list/."""
         # the same mocking as in test_serialization
-        response = self.serializer_class(self.view().get_queryset(), many=True)
+        serializer_class = self.view().get_serializer_class()
+        response = serializer_class(self.view().get_queryset(), many=True)
         self.assertEqual(len(response.data), 2)
 
         self.assertEqual(response.data[0]['domains'], 'Chemistry, Medicine')

--- a/api/views.py
+++ b/api/views.py
@@ -80,6 +80,7 @@ from .filters import (
 
 from .renderers import (
     TrainingRequestCSVRenderer,
+    TrainingRequestManualScoreCSVRenderer,
 )
 
 
@@ -320,7 +321,7 @@ class TrainingRequests(ListAPIView):
     permission_classes = (IsAuthenticated, IsAdmin)
     paginator = None
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + \
-        [TrainingRequestCSVRenderer, ]
+        [TrainingRequestCSVRenderer, TrainingRequestManualScoreCSVRenderer]
     queryset = (
         TrainingRequest.objects.all()
             .select_related('person')

--- a/api/views.py
+++ b/api/views.py
@@ -65,6 +65,7 @@ from .serializers import (
     PersonSerializer,
     PersonSerializerAllData,
     TrainingRequestWithPersonSerializer,
+    TrainingRequestForManualScoringSerializer,
 )
 
 from .filters import (
@@ -318,7 +319,6 @@ class UserTodoItems(ListAPIView):
 class TrainingRequests(ListAPIView):
     permission_classes = (IsAuthenticated, IsAdmin)
     paginator = None
-    serializer_class = TrainingRequestWithPersonSerializer
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + \
         [TrainingRequestCSVRenderer, ]
     queryset = (
@@ -341,6 +341,13 @@ class TrainingRequests(ListAPIView):
             )
         )
     filterset_class = TrainingRequestFilterIDs
+
+    def get_serializer_class(self):
+        if self.request.query_params.get('manualscore'):
+            return TrainingRequestForManualScoringSerializer
+        else:
+            return TrainingRequestWithPersonSerializer
+
 
 
 class ReportsViewSet(ViewSet):

--- a/workshops/forms.py
+++ b/workshops/forms.py
@@ -357,9 +357,9 @@ class WorkshopStaffForm(forms.Form):
         return cleaned_data
 
 
-class PersonBulkAddForm(forms.Form):
-    '''Represent CSV upload form for bulk adding people.'''
-
+class BulkUploadCSVForm(forms.Form):
+    """This form allows to upload a single file; it's used by person bulk
+    upload and training request manual score bulk upload."""
     file = forms.FileField()
 
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -2187,6 +2187,10 @@ class TrainingRequest(CreatedUpdatedMixin,
         DataPrivacyAgreementMixin, COCAgreementMixin, StateMixin,
         models.Model):
 
+    MANUAL_SCORE_UPLOAD_FIELDS = (
+        'request_id', 'score_manual', 'score_notes',
+    )
+
     person = models.ForeignKey(Person, null=True, blank=True,
                                verbose_name='Matched Trainee',
                                on_delete=models.SET_NULL)

--- a/workshops/static/amy_utils.js
+++ b/workshops/static/amy_utils.js
@@ -108,6 +108,13 @@ $(document).ready(function() {
   */
   $('[data-toggle="popover"]').popover({placement: "auto", trigger: "click hover focus"});
 
+  /* Some pages may have checkboxes in tables selected by default; in those
+  cases, we should update URL in a[amy-download-selected] when the page
+  loads. */
+  $('a[amy-download-selected]').each(function(i, obj) {
+    $(this).updateIdsInHref();
+  });
+
   /*
   Add <input type="checkbox" select-all-checkbox> to your form to let user
   select/unselect all checkboxes with respond-to-select-all-checkbox attribute
@@ -123,6 +130,10 @@ $(document).ready(function() {
     } else {
         checkboxes.prop('checked', false);
     }
+    // below runs `updateIdsInHref` for all matching <a> (`.each` is required)
+    $(this).closest('form').find('a[amy-download-selected]').each(function(i, obj) {
+      $(this).updateIdsInHref();
+    });
   });
 
   /* When a checkbox is clicked, update "select all" checkbox state to checked,
@@ -130,7 +141,10 @@ $(document).ready(function() {
   on the state of all checkboxes. */
   $('[respond-to-select-all-checkbox]').change(function () {
     $(this).closest('form').find(':checkbox[select-all-checkbox]').updateSelectAllCheckbox();
-    $(this).closest('form').find('a#download_selected').updateIdsInHref();
+    // below runs `updateIdsInHref` for all matching <a> (`.each` is required)
+    $(this).closest('form').find('a[amy-download-selected]').each(function(i, obj) {
+      $(this).updateIdsInHref();
+    });
   });
 
   /* Set "select all" checkboxes to proper initial state. */

--- a/workshops/templates/navigation.html
+++ b/workshops/templates/navigation.html
@@ -58,6 +58,7 @@
             <a class="nav-link dropdown-toggle" href="#" id="requestsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Requests</a>
             <div class="dropdown-menu" aria-labelledby="requestsDropdown">
               {% navbar_element "Training requests" "all_trainingrequests" True %}
+              {% navbar_element "Bulk upload training request scores" "bulk_upload_training_request_scores" True %}
               <div class="dropdown-divider"></div>
               {% navbar_element "Workshop requests" "all_eventrequests" True %}
               {% navbar_element "Workshop submissions" "all_eventsubmissions" True %}

--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -154,9 +154,9 @@
           Download for bulk manual scoring
         </button>
         <div class="dropdown-menu" aria-labelledby="id_downloadBtn">
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1" amy-download-selected>Selected requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1">All requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1" amy-download-selected>Selected requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1">All requests as CSV</a>
         </div>
       </div>
     </div>

--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -143,9 +143,20 @@
           Download
         </button>
         <div class="dropdown-menu" aria-labelledby="id_downloadBtn">
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&" id="download_selected">Selected requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&" amy-download-selected>Selected requests as CSV</a>
           <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
           <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv">All requests as CSV</a>
+        </div>
+      </div>
+
+      <div class="btn-group" role="group">
+        <button id="id_downloadBtn" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Download for bulk manual scoring
+        </button>
+        <div class="dropdown-menu" aria-labelledby="id_downloadBtn">
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1" amy-download-selected>Selected requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
+          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&manualscore=1">All requests as CSV</a>
         </div>
       </div>
     </div>

--- a/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_confirmation.html
+++ b/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_confirmation.html
@@ -1,0 +1,60 @@
+{% extends "base_nav.html" %}
+
+{% block content %}
+
+<form method="POST" id="main-form">
+  <table class="table table-striped">
+    <tr>
+      <th>Matched request</th>
+      <th>Actual score</th>
+      <th>Actual score notes</th>
+      <th><code>request_id</code></th>
+      <th><code>score_manual</code></th>
+      <th><code>score_notes</code></th>
+      <th></th>
+    </tr>
+    {% for entry in zipped %}
+    <tr>
+      <td>
+        {% if entry.0.object %}
+        <a href="{{ entry.0.object.get_absolute_url }}">{{ entry.0.object }}</a>
+        {% else %}
+        —
+        {% endif %}
+      </td>
+      <td>
+        {% if entry.0.object.score_manual is None %}Not scored{% else %}
+        {{ entry.0.object.score_manual }}{% endif %}
+      </td>
+      <td>{{ entry.0.object.score_notes|default:"—" }}</td>
+      <td>{{ entry.1.request_id|default:"—" }}</td>
+      <td>{{ entry.1.score_manual|default:"—" }}</td>
+      <td>{{ entry.1.score_notes|default:"—" }}</td>
+      <td class="text-danger">
+      {% if entry.errors %}
+          <ul>
+          {% for error in entry.errors %}
+              <li>{{ error }}</li>
+          {% endfor %}
+          </ul>
+      {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  {% comment %}
+  This feels a little bit like cheating, but I don't have any better idea
+  how to distinguish between confirmation and cancelation.
+  The important implication of this approach is that the fields' names must
+  stay the way they're now: "confirm" and "cancel".  Values can change.
+  {% endcomment %}
+  {% if any_errors %}
+  <input type="button" name="confirm" value="Confirm and save" class="btn btn-success disabled">
+  {% else %}
+  <input type="submit" name="confirm" value="Confirm and save" class="btn btn-success">
+  {% endif %}
+  <input type="submit" name="cancel" value="Cancel" class="btn btn-secondary">
+  {% csrf_token %}
+</form>
+{% endblock %}

--- a/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_confirmation.html
+++ b/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_confirmation.html
@@ -26,18 +26,26 @@
         {% if entry.0.object.score_manual is None %}Not scored{% else %}
         {{ entry.0.object.score_manual }}{% endif %}
       </td>
-      <td>{{ entry.0.object.score_notes|default:"—" }}</td>
+      <td>
+        {% if entry.0.object.score_notes %}
+          <pre>{{ entry.0.object.score_notes }}</pre>
+        {% else %}—{% endif %}
+      </td>
       <td>{{ entry.1.request_id|default:"—" }}</td>
       <td>{{ entry.1.score_manual|default:"—" }}</td>
-      <td>{{ entry.1.score_notes|default:"—" }}</td>
+      <td>
+        {% if entry.1.score_notes %}
+          <pre>{{ entry.1.score_notes }}</pre>
+        {% else %}—{% endif %}
+      </td>
       <td class="text-danger">
-      {% if entry.errors %}
+        {% if entry.0.errors %}
           <ul>
-          {% for error in entry.errors %}
+          {% for error in entry.0.errors %}
               <li>{{ error }}</li>
           {% endfor %}
           </ul>
-      {% endif %}
+        {% endif %}
       </td>
     </tr>
     {% endfor %}

--- a/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_form.html
+++ b/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_form.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% load static %}
-<p><a href="{% url 'bulk_upload_training_request_scores_template' %}"><code>BulkTrainingRequestScoresTemplate.csv</code></a> is a blank template of a well-formed CSV file.</p>
+<p>You can use <i>Download for bulk manual scoring</i> link on <a href="{% url 'all_trainingrequests' %}">Training requests</a> page; you'll download a CSV file with data required for manual score and three columns for bulk upload (see table below).</p>
 
 <p>Hint: the uploaded CSV file needs to have these three columns &ndash; other columns will be ignored:</p>
 
@@ -13,7 +13,7 @@
   </tr>
   <tr>
     <td><code>request_id</code></td>
-    <td><i>Primary Key</i> &ndash; a field representing individual training request in the database; you can look it up in the CSV download of selected records on <a href="{% url 'all_trainingrequests' %}">Training Requests</a> page (below the table).</td>
+    <td><i>Primary Key</i> &ndash; a field representing individual training request in the database.</td>
   </tr>
   <tr>
     <td><code>score_manual</code></td>

--- a/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_form.html
+++ b/workshops/templates/workshops/trainingrequest_bulk_upload_manual_score_form.html
@@ -1,0 +1,37 @@
+{% extends "base_nav.html" %}
+
+{% block content %}
+{% load static %}
+<p><a href="{% url 'bulk_upload_training_request_scores_template' %}"><code>BulkTrainingRequestScoresTemplate.csv</code></a> is a blank template of a well-formed CSV file.</p>
+
+<p>Hint: the uploaded CSV file needs to have these three columns &ndash; other columns will be ignored:</p>
+
+<table class="table table-striped table-bordered table-sm">
+  <tr>
+    <th>Column header</th>
+    <th>Meaning</th>
+  </tr>
+  <tr>
+    <td><code>request_id</code></td>
+    <td><i>Primary Key</i> &ndash; a field representing individual training request in the database; you can look it up in the CSV download of selected records on <a href="{% url 'all_trainingrequests' %}">Training Requests</a> page (below the table).</td>
+  </tr>
+  <tr>
+    <td><code>score_manual</code></td>
+    <td>Integer value representing manual score; can be negative.</td>
+  </tr>
+  <tr>
+    <td><code>score_notes</code></td>
+    <td>Text value used for explanation of manual score, if required.</td>
+  </tr>
+</table>
+
+<form action="" method="post" enctype="multipart/form-data"
+      accept-charset="{{charset}}"
+      id="main-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+
+    <input type="submit" value="Submit" />
+</form>
+
+{% endblock %}

--- a/workshops/test/test_bulk_manual_score.py
+++ b/workshops/test/test_bulk_manual_score.py
@@ -1,0 +1,267 @@
+# coding: utf-8
+import cgi
+import datetime
+from io import StringIO
+
+from django.contrib.sessions.serializers import JSONSerializer
+from django.urls import reverse
+
+from ..models import Person, TrainingRequest
+from ..util import (
+    upload_trainingrequest_manual_score_csv,
+    clean_upload_trainingrequest_manual_score,
+    update_manual_score,
+)
+
+from .base import TestBase
+from .test_training_request import create_training_request
+
+
+class UploadTrainingRequestManualScoreCSVTestCase(TestBase):
+    def compute_from_string(self, csv_str):
+        """Wrap string into IO buffer & parse."""
+        csv_buf = StringIO(csv_str)
+        return upload_trainingrequest_manual_score_csv(csv_buf)
+
+    def test_basic_parsing(self):
+        """Test if perfectly correct CSV loads... correctly."""
+        csv = """request_id,score_manual,score_notes
+1,123,"This person exceeded at receiving big manual score."
+2,-321,They did bad at our survey"""
+        data = self.compute_from_string(csv)
+
+        # correct length
+        self.assertEqual(len(data), 2)
+
+        # ensure data has correct format
+        self.assertEqual(
+            set(data[0].keys()),
+            set(TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS + ("errors", ))
+        )
+
+    def test_csv_without_required_field(self):
+        """Only fields from TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS are
+        taken into consideration, and they all should be present."""
+        bad_csv = """request_id,completely_different_field,score_notes
+1,123,"This person exceeded at receiving big manual score."
+2,-321,They did bad at our survey"""
+        data = self.compute_from_string(bad_csv)
+        self.assertTrue(data[0]['score_manual'] is None)
+        self.assertTrue(data[1]['score_manual'] is None)
+
+    def test_csv_with_empty_lines(self):
+        csv = """request_id,score_manual,score_notes
+1,123,"This person exceeded at receiving big manual score."
+,,"""
+        data = self.compute_from_string(csv)
+        self.assertEqual(len(data), 1)
+
+    def test_empty_field(self):
+        """Ensure blank fields don't reorder other fields."""
+        csv = """request_id,score_manual,score_notes
+1,,'This person exceeded at receiving big manual score.'"""
+        data = self.compute_from_string(csv)
+        entry = data[0]
+        self.assertEqual(entry['score_manual'], '')
+
+    def test_serializability_of_parsed(self):
+        csv = """request_id,score_manual,score_notes
+1,123,"This person exceeded at receiving big manual score."
+2,-321,They did bad at our survey"""
+        data = self.compute_from_string(csv)
+
+        try:
+            serializer = JSONSerializer()
+            serializer.dumps(data)
+        except TypeError:
+            self.fail('Dumping manual scores for Training Requests into JSON '
+                      'unexpectedly failed!')
+
+    def test_malformed_CSV_with_proper_header_row(self):
+        csv = """request_id,score_manual,score_notes
+This is a malformed CSV"""
+        data = self.compute_from_string(csv)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['request_id'], 'This is a malformed CSV')
+        self.assertEqual(data[0]['score_manual'], None)
+        self.assertEqual(data[0]['score_notes'], None)
+
+
+class CSVBulkUploadTestBase(TestBase):
+    """Provide auxiliary methods used in descendant TestCases."""
+
+    def setUp(self):
+        """Prepare some existing Training Requests."""
+        self.tr1 = create_training_request(state='p', person=None)
+        self.tr1.score_manual = 10
+        self.tr1.score_notes = "This request received positive manual score"
+        self.tr1.save()
+
+        self.tr2 = create_training_request(state='p', person=None)
+        self.tr2.score_manual = -10
+        self.tr2.score_notes = "This request received negative manual score"
+        self.tr2.save()
+
+        self.tr3 = create_training_request(state='p', person=None)
+        self.tr3.score_manual = 0
+        self.tr3.score_notes = "This request was manually scored to zero"
+        self.tr3.save()
+
+        self.tr4 = create_training_request(state='p', person=None)
+        self.tr4.score_manual = None
+        self.tr4.score_notes = "This request hasn't been scored manually"
+        self.tr4.save()
+
+    def make_csv_data(self):
+        return """request_id,score_manual,score_notes
+{},-10,"This person did bad."
+{},0,"This person did neutral."
+{},10,"This person exceeded ."
+{},0,This person did OK.""".format(
+            self.tr1.pk, self.tr2.pk, self.tr3.pk, self.tr4.pk
+        )
+
+    def make_data(self):
+        csv_str = self.make_csv_data()
+        data = upload_trainingrequest_manual_score_csv(StringIO(csv_str))
+        return data
+
+
+class CleanUploadTrainingRequestManualScore(CSVBulkUploadTestBase):
+    """
+    Testing scenarios:
+    * everything is good
+    * missing request ID, score manual, or score notes
+    * wrong format for request ID or score manual
+    * request ID not matching any existing requests
+    """
+
+    def test_verify_with_good_data(self):
+        data = self.make_data()
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertFalse(has_errors)
+        # empty list evaluates to False
+        self.assertFalse(cleaned[0]['errors'])
+        self.assertFalse(cleaned[1]['errors'])
+        self.assertFalse(cleaned[2]['errors'])
+        self.assertFalse(cleaned[3]['errors'])
+
+    def test_missing_request_ID(self):
+        data = self.make_data()
+        data[1]['request_id'] = ''
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertTrue(has_errors)
+        self.assertFalse(cleaned[0]['errors'])
+        self.assertTrue(cleaned[1]['errors'])
+        self.assertFalse(cleaned[2]['errors'])
+        self.assertFalse(cleaned[3]['errors'])
+
+        self.assertIn('Request ID is missing.', cleaned[1]['errors'])
+
+    def test_missing_score_manual(self):
+        data = self.make_data()
+        data[1]['score_manual'] = ''
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertTrue(has_errors)
+        self.assertFalse(cleaned[0]['errors'])
+        self.assertTrue(cleaned[1]['errors'])
+        self.assertFalse(cleaned[2]['errors'])
+        self.assertFalse(cleaned[3]['errors'])
+
+        self.assertIn('Manual score is missing.', cleaned[1]['errors'])
+
+    def test_missing_score_notes(self):
+        """Missing notes should not trigger any errors."""
+        data = self.make_data()
+        data[1]['score_notes'] = ''
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertFalse(has_errors)
+        self.assertFalse(cleaned[0]['errors'])
+        self.assertFalse(cleaned[1]['errors'])
+        self.assertFalse(cleaned[2]['errors'])
+        self.assertFalse(cleaned[3]['errors'])
+
+    def test_request_ID_wrong_format(self):
+        data = self.make_data()
+        data[0]['request_id'] = '1.23.4'
+        data[1]['request_id'] = ' '
+        data[2]['request_id'] = '-123'
+        data[3]['request_id'] = '.0'
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertTrue(has_errors)
+        for i in range(4):
+            self.assertTrue(cleaned[i]['errors'])
+            self.assertIn('Request ID is not an integer value.',
+                          cleaned[i]['errors'], i)
+
+    def test_score_manual_wrong_format(self):
+        data = self.make_data()
+        data[0]['score_manual'] = '1.23.4'
+        data[1]['score_manual'] = ' '
+        data[2]['score_manual'] = '.0'
+        data[3]['score_manual'] = '-123'
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertTrue(has_errors)
+        for i in range(3):
+            self.assertTrue(cleaned[i]['errors'])
+            self.assertIn('Manual score is not an integer value.',
+                          cleaned[i]['errors'], i)
+
+        # last entry should be valid
+        self.assertFalse(cleaned[3]['errors'])
+
+    def test_request_ID_not_matching(self):
+        data = self.make_data()
+        data[0]['request_id'] = '3333'
+
+        has_errors, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertTrue(has_errors)
+        self.assertTrue(cleaned[0]['errors'])
+        self.assertIn('Request ID doesn\'t match any request.',
+                      cleaned[0]['errors'])
+        self.assertFalse(cleaned[1]['errors'])
+        self.assertFalse(cleaned[2]['errors'])
+        self.assertFalse(cleaned[3]['errors'])
+
+
+class UpdateTrainingRequestManualScore(CSVBulkUploadTestBase):
+    """
+    Testing scenarios:
+    * requests get updated correctly
+    """
+
+    def test_requests_updated(self):
+        # prepare data
+        data = self.make_data()
+
+        # check and clean data
+        errors_occur, cleaned = clean_upload_trainingrequest_manual_score(data)
+        self.assertFalse(errors_occur)
+
+        # make sure so far nothing changed
+        self.tr1.refresh_from_db()
+        self.tr2.refresh_from_db()
+        self.tr3.refresh_from_db()
+        self.tr4.refresh_from_db()
+        self.assertEqual(self.tr1.score_manual, 10)
+        self.assertEqual(self.tr2.score_manual, -10)
+        self.assertEqual(self.tr3.score_manual, 0)
+        self.assertEqual(self.tr4.score_manual, None)
+
+        records_updated = update_manual_score(cleaned)
+        # 4 records should be updated: self.tr1, self.tr2, self.tr3, self.tr4
+        self.assertEqual(records_updated, 4)
+        # make sure requests updated
+        self.tr1.refresh_from_db()
+        self.tr2.refresh_from_db()
+        self.tr3.refresh_from_db()
+        self.tr4.refresh_from_db()
+        self.assertEqual(self.tr1.score_manual, -10)
+        self.assertEqual(self.tr2.score_manual, 0)
+        self.assertEqual(self.tr3.score_manual, 10)
+        self.assertEqual(self.tr4.score_manual, 0)

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -184,6 +184,11 @@ urlpatterns = [
         url(r'^$', views.trainingrequest_details, name='trainingrequest_details'),
         url(r'^edit/$', views.TrainingRequestUpdate.as_view(), name='trainingrequest_edit'),
     ])),
+    url(r'^bulk_upload_training_request_scores/', include([
+        url(r'^$',views.bulk_upload_training_request_scores, name='bulk_upload_training_request_scores'),
+        url(r'^template/$',views.bulk_upload_training_request_scores_template, name='bulk_upload_training_request_scores_template'),
+        url(r'^confirm/$',views.bulk_upload_training_request_scores_confirmation, name='bulk_upload_training_request_scores_confirmation'),
+    ])),
 
     url(r'^trainees/$', views.all_trainees, name='all_trainees'),
 

--- a/workshops/urls.py
+++ b/workshops/urls.py
@@ -184,11 +184,8 @@ urlpatterns = [
         url(r'^$', views.trainingrequest_details, name='trainingrequest_details'),
         url(r'^edit/$', views.TrainingRequestUpdate.as_view(), name='trainingrequest_edit'),
     ])),
-    url(r'^bulk_upload_training_request_scores/', include([
-        url(r'^$',views.bulk_upload_training_request_scores, name='bulk_upload_training_request_scores'),
-        url(r'^template/$',views.bulk_upload_training_request_scores_template, name='bulk_upload_training_request_scores_template'),
-        url(r'^confirm/$',views.bulk_upload_training_request_scores_confirmation, name='bulk_upload_training_request_scores_confirmation'),
-    ])),
+    url(r'^bulk_upload_training_request_scores/', views.bulk_upload_training_request_scores, name='bulk_upload_training_request_scores'),
+    url(r'^bulk_upload_training_request_scores/confirm/$',views.bulk_upload_training_request_scores_confirmation, name='bulk_upload_training_request_scores_confirmation'),
 
     url(r'^trainees/$', views.all_trainees, name='all_trainees'),
 

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -314,6 +314,126 @@ def create_uploaded_persons_tasks(data):
     return persons_created, tasks_created
 
 
+def upload_trainingrequest_manual_score_csv(stream):
+    """Read manual score entries from CSV and return a JSON-serializable
+    list of dicts.
+
+    The input `stream` should be a file-like object that returns
+    Unicode data.
+
+    "Serializability" is required because we put this data into session.  See
+    https://docs.djangoproject.com/en/1.7/topics/http/sessions/ for details.
+    """
+    from workshops.models import TrainingRequest
+
+    result = []
+    reader = csv.DictReader(stream)
+
+    for row in reader:
+        # skip empty lines in the CSV
+        if not any(row.values()):
+            continue
+
+        entry = {}
+        for col in TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS:
+            try:
+                entry[col] = row[col].strip()
+            except (KeyError, IndexError, AttributeError):
+                # either `col` is not in `entry`, or not in `row`, or
+                # `.strip()` doesn't work (e.g. `row[col]` gives `None` instead
+                # of string)
+                entry[col] = None
+
+        entry['errors'] = None
+
+        result.append(entry)
+
+    return result
+
+
+def clean_upload_trainingrequest_manual_score(data):
+    """
+    Verify that uploaded data is correct.  Show errors by populating `errors`
+    dictionary item.  This function changes `data` in place.
+    """
+    from workshops.models import TrainingRequest
+
+    clean_data = []
+    errors_occur = False
+
+    for item in data:
+        errors = []
+        info = []
+
+        obj = None
+        request_id = item.get('request_id', None)
+        if not request_id:
+            errors.append('Request ID is missing.')
+        else:
+            try:
+                num_request_id = int(request_id)
+            except (ValueError, TypeError):
+                errors.append("Request ID is not an integer value.")
+            else:
+                try:
+                    obj = TrainingRequest.objects.get(pk=num_request_id)
+                except TrainingRequest.DoesNotExist:
+                    errors.append("Request ID doesn't match any request.")
+                except TrainingRequest.MultipleObjectsReturned:
+                    errors.append("Request ID matches multiple requests.")
+
+        score = item.get('score_manual', None)
+        score_manual = None
+        if not score:
+            errors.append('Manual score is missing.')
+        else:
+            try:
+                score_manual = int(score)
+            except (ValueError, TypeError):
+                errors.append("Manual score is not an integer value.")
+
+        score_notes = str(item.get('score_notes', ""))
+
+        if errors:
+            errors_occur = True
+
+        clean_data.append(
+            dict(
+                object=obj,
+                score_manual=score_manual,
+                score_notes=score_notes,
+            )
+        )
+    return errors_occur, clean_data
+
+
+def update_manual_score(cleaned_data):
+    """Updates manual score for selected objects.
+
+    `cleaned_data` is a list of dicts, each dict has 3 fields:
+    * `object` being the selected Training Request
+    * `score_manual` - manual score to be applied
+    * `score_notes` - notes regarding that manual score.
+    """
+    from workshops.models import TrainingRequest
+
+    records = 0
+    with transaction.atomic():
+        for item in cleaned_data:
+            try:
+                obj = item['object']
+                score_manual = item['score_manual']
+                score_notes = item['score_notes']
+                records += TrainingRequest.objects.filter(pk=obj.pk).update(
+                    score_manual=score_manual,
+                    score_notes=score_notes,
+                )
+            except (IntegrityError, ValueError, TypeError,
+                    ObjectDoesNotExist) as e:
+                raise e
+    return records
+
+
 def create_username(personal, family, tries=NUM_TRIES):
     '''Generate unique username.'''
     stem = normalize_name(family) + '_' + normalize_name(personal)

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -402,6 +402,7 @@ def clean_upload_trainingrequest_manual_score(data):
                 object=obj,
                 score_manual=score_manual,
                 score_notes=score_notes,
+                errors=errors,
             )
         )
     return errors_occur, clean_data

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -372,6 +372,8 @@ def clean_upload_trainingrequest_manual_score(data):
         else:
             try:
                 num_request_id = int(request_id)
+                if num_request_id < 0:
+                    raise ValueError('Request ID should not be negative')
             except (ValueError, TypeError):
                 errors.append("Request ID is not an integer value.")
             else:

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3458,19 +3458,6 @@ def trainingrequests_merge(request):
 
 
 @admin_required
-def bulk_upload_training_request_scores_template(request):
-    """Dynamically generate a CSV template that can be used to bulk-upload
-    training request scores."""
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = \
-        'attachment; filename=BulkTrainingRequestScoresTemplate.csv'
-
-    writer = csv.writer(response)
-    writer.writerow(TrainingRequest.MANUAL_SCORE_UPLOAD_FIELDS)
-    return response
-
-
-@admin_required
 @permission_required(['workshops.change_trainingrequest'],
                      raise_exception=True)
 def bulk_upload_training_request_scores(request):

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3564,6 +3564,11 @@ def bulk_upload_training_request_scores_confirmation(request):
 
     else:
         errors, cleaned_data = clean_upload_trainingrequest_manual_score(data)
+        if errors:
+            messages.warning(
+                request,
+                'Please fix errors in the provided CSV file and re-upload.',
+            )
 
     context = {
         'title': 'Confirm uploaded Training Requests manual score data',

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -3471,6 +3471,8 @@ def bulk_upload_training_request_scores_template(request):
 
 
 @admin_required
+@permission_required(['workshops.change_trainingrequest'],
+                     raise_exception=True)
 def bulk_upload_training_request_scores(request):
     if request.method == "POST":
         form = BulkUploadCSVForm(request.POST, request.FILES)
@@ -3513,6 +3515,8 @@ def bulk_upload_training_request_scores(request):
 
 
 @admin_required
+@permission_required(['workshops.change_trainingrequest'],
+                     raise_exception=True)
 def bulk_upload_training_request_scores_confirmation(request):
     """This view allows for verifying and saving of uploaded training
     request scores."""


### PR DESCRIPTION
@karenword @ErinBecker here's snapshot of the new "Download for manual scoring" button group:
![screenshot_2018-10-13 amy training requests](https://user-images.githubusercontent.com/72821/46909984-2d4fec00-cf3c-11e8-8fd6-1f1626753b9c.png)

The same selected requests that you can see in the screenshot generate this CSV (zipped because GitHub):
[two_results.zip](https://github.com/swcarpentry/amy/files/2475843/two_results.zip)

Uploading this CSV file without any changes on the Bulk Upload page gives this result:
![screenshot_2018-10-13 amy confirm uploaded training requests manual score data](https://user-images.githubusercontent.com/72821/46909994-8455c100-cf3c-11e8-9726-5a07d531f377.png)

I didn't implement inline editing, like in bulk add persons, therefore in case of errors the user would have to fix the file and re-upload.

Please tell me what you think - e.g. if there's something wrong with the CSV.