### PR TITLE
Training Requests list refinements

### DIFF
--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -19,20 +19,18 @@
           <input type="checkbox" select-all-checkbox />
         </th>
         <th>Submitter</th>
-        {% if request.GET.affiliation or request.GET.location %}
-          <th>
-            Affiliation
-            <i class="fas fa-question-circle"
-               data-toggle="popover" data-html="true"
-               data-content="<p>If two lines are presented:
-                             <ul><li>the first line shows affiliation from training request,</li>
-                             <li>and the second line shows affiliation from trainee's profile</li></ul></p>
-                             "></i>
-          </th>
+        <th>Group</th>
+        <th>
+          Affiliation
+          <i class="fas fa-question-circle"
+             data-toggle="popover" data-html="true"
+             data-content="<p>If two lines are presented:
+                           <ul><li>the first line shows affiliation from training request,</li>
+                           <li>and the second line shows affiliation from trainee's profile</li></ul></p>
+                           "></i>
+        </th>
+        {% if request.GET.location %}
           <th>Location</th>
-        {% endif %}
-        {% if request.GET.group_name %}
-          <th>Group</th>
         {% endif %}
         {% if request.GET.order_by == 'created_at' or request.GET.order_by == '-created_at' %}
           <th>Created at</th>
@@ -69,18 +67,16 @@
             {{ req.personal }} {{ req.middle }} {{ req.family }}<br />
             &lt;{{ req.email|urlize }}&gt;
           </td>
-          {% if request.GET.affiliation or request.GET.location %}
-            <td>
-              {{ req.affiliation }}
-              {% if req.person %}
-                 <br />
-                {{ req.person.affiliation }}
-              {% endif %}
-            </td>
-            <td>{{ req.location }}</td>
-          {% endif %}
-          {% if request.GET.group_name %}
-            <td>{{ req.group_name }}</td>
+          <td>{{ req.group_name|default:"—" }}</td>
+          <td>
+            {{ req.affiliation|default:"—" }}
+            {% if req.person %}
+               <hr />
+              {{ req.person.affiliation|default:"—" }}
+            {% endif %}
+          </td>
+          {% if request.GET.location %}
+            <td>{{ req.location|default:"—" }}</td>
           {% endif %}
           {% if request.GET.order_by == 'created_at' or request.GET.order_by == '-created_at' %}
             <td>{{ req.created_at|date:'Y-m-d H:i' }}</td>

--- a/workshops/templates/workshops/all_trainingrequests.html
+++ b/workshops/templates/workshops/all_trainingrequests.html
@@ -59,7 +59,7 @@
           <td>
             <input type="checkbox" name="requests" value="{{ req.pk }}"
                    respond-to-select-all-checkbox
-                   email="{% if req.person %}{{ req.person.email }}{% endif %}"
+                   email="{% if req.person %}{{ req.person.email }}{% elif req.email %}{{ req.email }}{% endif %}"
                    {% if req in form.cleaned_data.requests or req in match_form.cleaned_data.requests %}checked {% endif %}
             />
           </td>


### PR DESCRIPTION
This fixes #1383.

Changes:
1. Group column is no longer conditionally displayed.
2. Affiliation column is no longer conditionally displayed.
3. Location is kept conditionally (whenever someone searches for location) displayed (there's little screen estate to display this column unconditionally).
4. Request's email is alternatively used for contacting when no person is matched to the request. 