### PR TITLE
Revision history of objects implementation

### DIFF
--- a/workshops/templates/workshops/object_diff.html
+++ b/workshops/templates/workshops/object_diff.html
@@ -4,10 +4,15 @@
 
 {% block title %}<h1>{{ verbose_name|title }} {{ object }}</h1>{% endblock %}
 {% block content %}
+
 <p>
   <a href="{{ object.get_absolute_url }}" class="btn btn-primary">View newest</a>
 </p>
-<p>Changed on {{ revision.date_created|date:'M j, P' }} by {{ revision.user|default:'Unknown user' }}.</p>
+
+{% include "reversion-compare/action_list_partial.html"  %}
+
+<p class="mt-4">Changed on {{ revision.date_created|date:'M j Y, P' }} by {{ revision.user|default:'Unknown user' }}.</p>
+{% with previous_version=version1 current_version=version2%}
 {% if previous_version == current_version %}
 <p>This is a new object, it doesn't have any previous revisions.</p>
 {% endif %}
@@ -27,4 +32,5 @@
   {% endfor %}
 </table>
 {% endblock %}
+{% endwith %}
 {% endblock %}

--- a/workshops/test/test_diff.py
+++ b/workshops/test/test_diff.py
@@ -37,13 +37,10 @@ class TestRevisions(TestBase):
                                      args=[self.newer.revision.pk]))
         # test returned context
         context = rv.context
-        assert context['previous_version'] == self.older
-        assert context['current_version'] == self.newer
+        assert context['version1'] == self.older
+        assert context['version2'] == self.newer
         assert context['revision'] == self.newer.revision
         assert context['object'] == self.event
-        assert 'object_prev' in context
-        assert context['object_prev'].__class__ == Event
-
 
     def test_diff_shows_coloured_labels(self):
         # get newer revision page


### PR DESCRIPTION
This fixes #1341. The fix is highly inspired by `HistoryCompareDetailView` from `django-reversion-compare` application:

https://github.com/jedie/django-reversion-compare/blob/master/reversion_compare/views.py

The changes allow users to choose which versions they want to compare with each other.