### PR TITLE
Admin notifications propagation to various emails

### DIFF
--- a/amy/settings.py
+++ b/amy/settings.py
@@ -2,12 +2,17 @@
 Django settings for AMY project.
 """
 
+from collections import namedtuple
 import json
 import os
 import sys
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
+
+
+# some basic structures
+Criterium = namedtuple('Criterium', ['name', 'value'])
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -66,11 +71,6 @@ ADMINS = (
 # sender for error emails
 SERVER_EMAIL = os.environ.get('AMY_SERVER_EMAIL', 'root@localhost')
 
-# addresses to receive "New workshop request" or "New profile update request"
-# notifications
-REQUEST_NOTIFICATIONS_RECIPIENTS = (
-    'admin-all@carpentries.org',
-)
 # default sender for non-error messages
 DEFAULT_FROM_EMAIL = os.environ.get('AMY_DEFAULT_FROM_EMAIL',
                                     'webmaster@localhost')
@@ -90,6 +90,31 @@ EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
 if DEBUG:
     # outgoing mails will be stored in `django.core.mail.outbox`
     EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+
+################# N O T I F I C A T I O N S #################
+# Admin notification filtering
+crit_UK = Criterium('country', 'GB')
+crit_CA = Criterium('country', 'CA')
+crit_NZ = Criterium('country', 'NZ')
+crit_AU = Criterium('country', 'AU')
+crit_Africa = Criterium(
+    'country',
+    (
+        'DZ', 'AO', 'BJ', 'BW', 'BF', 'BI', 'CM', 'CV', 'CF', 'TD', 'KM', 'CD',
+        'DJ', 'EG', 'GQ', 'ER', 'ET', 'GA', 'GM', 'GH', 'GN', 'GW', 'CI', 'KE',
+        'LS', 'LR', 'LY', 'MG', 'MW', 'ML', 'MR', 'MU', 'YT', 'MA', 'MZ', 'NA',
+        'NE', 'NG', 'CG', 'RE', 'RW', 'SH', 'ST', 'SN', 'SC', 'SL', 'SO', 'ZA',
+        'SS', 'SD', 'SZ', 'TZ', 'TG', 'TN', 'UG', 'EH', 'ZM', 'ZW',
+    ),
+)
+ADMIN_NOTIFICATION_CRITERIA = {
+    crit_UK: 'admin-uk@carpentries.org',
+    crit_CA: 'admin-ca@carpentries.org',
+    crit_NZ: 'admin-nz@carpentries.org',
+    crit_AU: 'admin-au@carpentries.org',
+    crit_Africa: 'admin-afr@carpentries.org',
+}
+ADMIN_NOTIFICATION_CRITERIA_DEFAULT = 'team@carpentries.org'
 
 ##################### S I T E,  H O S T S #####################
 

--- a/amy/settings.py
+++ b/amy/settings.py
@@ -61,7 +61,7 @@ else:
 
 # error email recipients
 ADMINS = (
-    ('Sysadmins ML', 'sysadmin@lists.software-carpentry.org'),
+    ('Sysadmins ML', 'sysadmin@lists.carpentries.org'),
 )
 # sender for error emails
 SERVER_EMAIL = os.environ.get('AMY_SERVER_EMAIL', 'root@localhost')

--- a/workshops/base_views.py
+++ b/workshops/base_views.py
@@ -198,12 +198,19 @@ class EmailSendMixin:
         """Generate email body (in TXT and HTML versions)."""
         return "", ""
 
+    def get_email_kwargs(self):
+        """Use this method to define email sender arguments, like:
+        * `to`: recipient address(es)
+        * `reply_to`: reply-to address
+        etc."""
+        return self.email_kwargs
+
     def prepare_email(self):
         """Set up email contents."""
         subject = self.get_subject()
         body_txt, body_html = self.get_body()
-        email = EmailMultiAlternatives(subject, body_txt,
-                                       **self.email_kwargs)
+        kwargs = self.get_email_kwargs()
+        email = EmailMultiAlternatives(subject, body_txt, **kwargs)
         email.attach_alternative(body_html, 'text/html')
         return email
 

--- a/workshops/test/test_workshop_requests.py
+++ b/workshops/test/test_workshop_requests.py
@@ -403,6 +403,7 @@ class TestWorkshopRequestExternalForm(TestBase):
             msg.subject,
             'New workshop request: Ministry of Magic, 03-04 November, 2018',
         )
+        self.assertEqual(msg.recipients(), ['admin-uk@carpentries.org'])
 
 
 class TestWorkshopRequestViews(TestBase):


### PR DESCRIPTION
This PR fixes #1368 and #1367.

New workshop request notifications will go to various addresses, depending on the country provided by the user.

// edit: addresses (or rather matching criteria) are hardcoded, but in a way that should be simple to universalize in a future, if needed. The `Criterium` object can easily be translated to a database model.