### PR TITLE
Fix PersonViewSet queryset to include only distinct results

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -736,7 +736,8 @@ class PersonViewSet(viewsets.ReadOnlyModelViewSet):
     """List many people or retrieve only one person."""
     permission_classes = (IsAuthenticated, IsAdmin)
     queryset = Person.objects.all().select_related('airport') \
-                     .prefetch_related('badges', 'domains', 'lessons')
+                     .prefetch_related('badges', 'domains', 'lessons') \
+                     .distinct()
     serializer_class = PersonSerializer
     pagination_class = StandardResultsSetPagination
     filterset_class = PersonFilter


### PR DESCRIPTION
The addition of `distinct()` prevents API from showing more than one
result for people who match a number of criteria simultaneously.
This fixes #1395.