### PR TITLE
Force encoding for languages registry (used in migrations)

### DIFF
--- a/amy/workshops/migrations/0097_auto_20160519_0739.py
+++ b/amy/workshops/migrations/0097_auto_20160519_0739.py
@@ -17,7 +17,7 @@ def populate_languages(apps, schema_editor):
     [2]: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
     [3]: https://github.com/mattcg/language-subtag-registry/
     """
-    languages = json.load(open('data/registry.json'))
+    languages = json.load(open('data/registry.json', encoding='utf-8'))
     Language = apps.get_model('workshops', 'Language')
     for language in languages:
         if language['Type'] == 'language' and len(language['Subtag']) <= 2:

--- a/amy/workshops/migrations/0139_fix_language_names.py
+++ b/amy/workshops/migrations/0139_fix_language_names.py
@@ -19,7 +19,7 @@ def fix_truncated_language_names(apps, schema_editor):
     Language = apps.get_model('workshops', 'Language')
 
     # read list of languages
-    languages_json = json.load(open('data/registry.json'))
+    languages_json = json.load(open('data/registry.json', encoding='utf-8'))
     # 1. (most inner) filter out non-language (sublanguages, dialects etc.)
     # 2. (middle) apply ' '.join(language['Description']) and therefore make it
     #    a list of descriptions


### PR DESCRIPTION
`open(filename)` used default system encoding, but it turns out some systems don't use `utf-8` by default :disappointed: 