### PR TITLE
Deployment automation: prepare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ cache: pip
 
 python:
   - 3.5
+  - 3.6
+  - 3.7
 
 env:
   - AMY_ENABLE_PYDATA=true
     AMY_PYDATA_USERNAME=username
     AMY_PYDATA_PASSWORD=password
+    CHECK_MIGRATION=true
   - CHECK_MIGRATION=true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache: pip
 python:
   - 3.5
   - 3.6
-  - 3.7
+  - "3.7-dev"
 
 env:
   - AMY_ENABLE_PYDATA=true

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,12 +49,9 @@ if not DEBUG and SECRET_KEY == DEFAULT_SECRET_KEY:
     raise ImproperlyConfigured('You must specify non-default value for '
                                'SECRET_KEY when running with Debug=FALSE.')
 
-SITE_URL = 'https://amy.software-carpentry.org'
-ALLOWED_HOSTS = [
-    'amy.software-carpentry.org',
-]
+ALLOWED_HOSTS = env.list('AMY_ALLOWED_HOSTS',
+                         default=['amy.software-carpentry.org'])
 if DEBUG:
-    SITE_URL = 'http://127.0.0.1:8000'
     ALLOWED_HOSTS.append('127.0.0.1')
 
 # DATABASES

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,6 +49,8 @@ if not DEBUG and SECRET_KEY == DEFAULT_SECRET_KEY:
     raise ImproperlyConfigured('You must specify non-default value for '
                                'SECRET_KEY when running with Debug=FALSE.')
 
+SITE_URL = env.str('AMY_SITE_URL',
+                   default='https://amy.software-carpentry.org')
 ALLOWED_HOSTS = env.list('AMY_ALLOWED_HOSTS',
                          default=['amy.software-carpentry.org'])
 if DEBUG:


### PR DESCRIPTION
This PR enhances Travis-CI testing and enables loading two setting parameters from environment: `SITE_URL` and `ALLOWED_HOSTS`. This is required for #1392 and #917.