### PR TITLE
Redirect from old URLs to new ones

### DIFF
--- a/amy/workshops/tests/test_security.py
+++ b/amy/workshops/tests/test_security.py
@@ -221,18 +221,6 @@ class TestViews(TestBase):
         'complete',
         'disconnect',
         'disconnect_individual',
-
-        # redirections to new form addresses
-        'old_swc_workshop_request',
-        'old_swc_workshop_request_confirm',
-        'old_dc_workshop_request',
-        'old_dc_workshop_request_confirm',
-        'old_dc_workshop_selforganized_request',
-        'old_dc_workshop_selforganized_request_confirm',
-        'old_event_submit',
-        'old_event_submission_confirm',
-        'old_profileupdate_request',
-        'old_training_request',
     ]
 
     def test_all_views_have_explicit_access_control_defined(self):

--- a/amy/workshops/urls.py
+++ b/amy/workshops/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path, include
-from django.views.generic import RedirectView
 
 from workshops import views
 
@@ -94,39 +93,3 @@ urlpatterns = [
     path('action_required/privacy/',
          views.action_required_privacy, name='action_required_privacy'),
 ]
-
-redirects_urlpatterns = [
-    # redirects for the old forms
-    path('swc/request/',
-         RedirectView.as_view(pattern_name='swc_workshop_request', permanent=True),
-         name='old_swc_workshop_request'),
-    path('swc/request/confirm/',
-         RedirectView.as_view(pattern_name='swc_workshop_request_confirm', permanent=True),
-         name='old_swc_workshop_request_confirm'),
-    path('dc/request/',
-         RedirectView.as_view(pattern_name='dc_workshop_request', permanent=True),
-         name='old_dc_workshop_request'),
-    path('dc/request/confirm/',
-         RedirectView.as_view(pattern_name='dc_workshop_request_confirm', permanent=True),
-         name='old_dc_workshop_request_confirm'),
-    path('dc/request_selforganized/',
-         RedirectView.as_view(pattern_name='dc_workshop_selforganized_request', permanent=True),
-         name='old_dc_workshop_selforganized_request'),
-    path('dc/request_selforganized/confirm/',
-         RedirectView.as_view(pattern_name='dc_workshop_selforganized_request_confirm', permanent=True),
-         name='old_dc_workshop_selforganized_request_confirm'),
-    path('submit/',
-         RedirectView.as_view(pattern_name='event_submit', permanent=True),
-         name='old_event_submit'),
-    # path('submit/confirm/',
-    #      RedirectView.as_view(pattern_name='event_submission_confirm', permanent=True),
-    #      name='old_event_submission_confirm'),
-    path('update_profile/',
-         RedirectView.as_view(pattern_name='profileupdate_request', permanent=True),
-         name='old_profileupdate_request'),
-    path('request_training/',
-         RedirectView.as_view(pattern_name='training_request', permanent=True),
-         name='old_training_request'),
-]
-
-urlpatterns += redirects_urlpatterns

--- a/config/urls.py
+++ b/config/urls.py
@@ -83,6 +83,57 @@ urlpatterns += [
     path('', include('social_django.urls', namespace='social')),
 ]
 
+redirect_urlpatterns = [
+    path('workshops/', RedirectView.as_view(pattern_name='dispatch')),
+    path('workshops/admin-dashboard/', RedirectView.as_view(pattern_name='admin-dashboard')),
+    path('workshops/trainee-dashboard/', RedirectView.as_view(pattern_name='trainee-dashboard')),
+    path('workshops/trainee-dashboard/training_progress/', RedirectView.as_view(pattern_name='training-progress')),
+    path('workshops/autoupdate_profile/', RedirectView.as_view(pattern_name='autoupdate_profile')),
+
+    path('workshops/training_requests/', RedirectView.as_view(pattern_name='all_trainingrequests')),
+    path('workshops/training_requests/merge', RedirectView.as_view(pattern_name='trainingrequests_merge')),
+    path('workshops/bulk_upload_training_request_scores', RedirectView.as_view(pattern_name='bulk_upload_training_request_scores')),
+    path('workshops/bulk_upload_training_request_scores/confirm', RedirectView.as_view(pattern_name='bulk_upload_training_request_scores_confirmation')),
+
+    path('workshops/workshop_requests/', RedirectView.as_view(pattern_name='all_workshoprequests')),
+    path('workshops/requests/', RedirectView.as_view(pattern_name='all_eventrequests')),
+    path('workshops/dc_selforganized_requests/', RedirectView.as_view(pattern_name='all_dcselforganizedeventrequests')),
+    path('workshops/submissions/', RedirectView.as_view(pattern_name='all_eventsubmissions')),
+    path('workshops/profile_updates/', RedirectView.as_view(pattern_name='all_profileupdaterequests')),
+    path('workshops/invoices/', RedirectView.as_view(pattern_name='all_invoicerequests')),
+
+    path('workshops/organizations/', RedirectView.as_view(pattern_name='all_organizations')),
+    path('workshops/memberships/', RedirectView.as_view(pattern_name='all_memberships')),
+
+    path('workshops/reports/instructors_by_date/', RedirectView.as_view(pattern_name='instructors_by_date')),
+    path('workshops/reports/workshops_over_time/', RedirectView.as_view(pattern_name='workshops_over_time')),
+    path('workshops/reports/learners_over_time/', RedirectView.as_view(pattern_name='learners_over_time')),
+    path('workshops/reports/instructors_over_time/', RedirectView.as_view(pattern_name='instructors_over_time')),
+    path('workshops/reports/instructor_num_taught/', RedirectView.as_view(pattern_name='instructor_num_taught')),
+    path('workshops/reports/all_activity_over_time/', RedirectView.as_view(pattern_name='all_activity_over_time')),
+    path('workshops/reports/membership_trainings_stats/', RedirectView.as_view(pattern_name='membership_trainings_stats')),
+    path('workshops/reports/workshop_issues/', RedirectView.as_view(pattern_name='workshop_issues')),
+    path('workshops/reports/instructor_issues/', RedirectView.as_view(pattern_name='instructor_issues')),
+    path('workshops/reports/duplicate_persons/', RedirectView.as_view(pattern_name='duplicate_persons')),
+    path('workshops/reports/duplicate_training_requests/', RedirectView.as_view(pattern_name='duplicate_training_requests')),
+
+    path('workshops/trainings/', RedirectView.as_view(pattern_name='all_trainings')),
+    path('workshops/trainees/', RedirectView.as_view(pattern_name='all_trainees')),
+
+    # old form addresses below, to be removed in future
+    path('workshops/swc/request/', RedirectView.as_view(pattern_name='swc_workshop_request', permanent=True)),
+    path('workshops/swc/request/confirm/', RedirectView.as_view(pattern_name='swc_workshop_request_confirm', permanent=True)),
+    path('workshops/dc/request/', RedirectView.as_view(pattern_name='dc_workshop_request', permanent=True)),
+    path('workshops/dc/request/confirm/', RedirectView.as_view(pattern_name='dc_workshop_request_confirm', permanent=True)),
+    path('workshops/dc/request_selforganized/', RedirectView.as_view(pattern_name='dc_workshop_selforganized_request', permanent=True)),
+    path('workshops/dc/request_selforganized/confirm/', RedirectView.as_view(pattern_name='dc_workshop_selforganized_request_confirm', permanent=True)),
+    path('workshops/submit/', RedirectView.as_view(pattern_name='event_submit', permanent=True)),
+    path('workshops/update_profile/', RedirectView.as_view(pattern_name='profileupdate_request', permanent=True)),
+    path('workshops/request_training/', RedirectView.as_view(pattern_name='training_request', permanent=True)),
+]
+
+urlpatterns += redirect_urlpatterns
+
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [


### PR DESCRIPTION
This fixes #1423 by adding redirects from old architecture addresses to
new architecture addresses. Mostly the URLs were switched from
a `workshops` application namespace to a new application namespace. The
redirects are placed in top-most `urls.py`.

Additionally redirects for old external forms were moved from
`workshops.urls` to top-most `urls.py`.

The same redirects were removed from tests opt-out, since we handle
redirect views in the tests separately.