### PR TITLE
Don't conjoin badges in Find Workshop Staff

### DIFF
--- a/amy/workshops/tests/test_workshop_staff_searching.py
+++ b/amy/workshops/tests/test_workshop_staff_searching.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.urls import reverse
 
 from workshops.tests.base import TestBase
@@ -126,7 +124,9 @@ class TestLocateWorkshopStaff(TestBase):
         self.assertIn(self.blackwidow, response.context['persons'])
 
     def test_instructor_badges(self):
-        """Ensure people with instructor badges are returned by search."""
+        """Ensure people with instructor badges are returned by search. The
+        search is OR'ed, so should return people with any of the selected
+        badges."""
         response = self.client.get(
             reverse('workshop_staff'),
             {'airport': self.airport_0_0.pk,
@@ -136,10 +136,9 @@ class TestLocateWorkshopStaff(TestBase):
         self.assertEqual(response.status_code, 200)
 
         # instructors
-        self.assertIn(self.hermione, response.context['persons'])
-        self.assertIn(self.harry, response.context['persons'])
-        # Ron doesn't have a DC badge
-        self.assertNotIn(self.ron, response.context['persons'])
+        self.assertIn(self.hermione, response.context['persons'])  # SWC, DC
+        self.assertIn(self.harry, response.context['persons'])  # SWC, DC
+        self.assertIn(self.ron, response.context['persons'])  # SWC only
         # non-instructors
         self.assertNotIn(self.spiderman, response.context['persons'])
         self.assertNotIn(self.ironman, response.context['persons'])

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1453,8 +1453,10 @@ def workshop_staff(request):
                 people = people.filter(gender=data['gender'])
 
             if data['instructor_badges']:
+                instr_badges_q = Q()
                 for badge in data['instructor_badges']:
-                    people = people.filter(badges__name=badge)
+                    instr_badges_q |= Q(badges__name=badge)
+                people = people.filter(instr_badges_q)
 
             # it's faster to count role=helper occurences than to check if user
             # had a role=helper


### PR DESCRIPTION
This fixes #1421 by generating `badge1 OR badge2 OR ...` instead of
`badge1 AND badge2 AND ...`.

The tests were adjusted properly.