### PR TITLE
Update Travis config to work with Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: xenial
+sudo: required
 
 language: python
 
@@ -7,7 +8,7 @@ cache: pip
 python:
   - 3.5
   - 3.6
-  - "3.7-dev"
+  - 3.7
 
 env:
   - AMY_ENABLE_PYDATA=true


### PR DESCRIPTION
Solution:
https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905

I may consider switching entirely to Python v3.7, because it supports ["on-the-fly" SQLite backups](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.backup). Or we switch to PostgreSQL.