### PR TITLE
Search in comments

### DIFF
--- a/amy/templates/workshops/search.html
+++ b/amy/templates/workshops/search.html
@@ -8,7 +8,8 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm col-12">
+    {% if form.cleaned_data.in_organizations %}
+    <div class="col-sm">
       <h2>Organizations</h2>
       {% if organizations %}
       <ul>
@@ -16,10 +17,14 @@
         <li><a class="searchresult" href="{% url 'organization_details' organization.domain %}">{{ organization.domain }}</a></li>
         {% endfor %}
       </ul>
+      {% else %}
+      <p>No entries.</p>
       {% endif %}
     </div>
+    {% endif %}
 
-    <div class="col-sm col-12">
+    {% if form.cleaned_data.in_events %}
+    <div class="col-sm">
       <h2>Events</h2>
       {% if events %}
       <ul>
@@ -27,10 +32,14 @@
         <li><a class="searchresult" href="{% url 'event_details' e.slug %}">{{ e.slug }}</a></li>
         {% endfor %}
       </ul>
+      {% else %}
+      <p>No entries.</p>
       {% endif %}
     </div>
+    {% endif %}
 
-    <div class="col-sm col-12">
+    {% if form.cleaned_data.in_persons %}
+    <div class="col-sm">
       <h2>Persons</h2>
       {% if persons %}
       <ul>
@@ -38,10 +47,14 @@
         <li><a class="searchresult" href="{% url 'person_details' p.id %}">{{ p }}</a></li>
         {% endfor %}
       </ul>
+      {% else %}
+      <p>No entries.</p>
       {% endif %}
     </div>
+    {% endif %}
 
-    <div class="col-sm col-12">
+    {% if form.cleaned_data.in_airports %}
+    <div class="col-sm">
       <h2>Airports</h2>
       {% if airports %}
       <ul>
@@ -49,12 +62,14 @@
         <li><a class="searchresult" href="{% url 'airport_details' a.iata %}">{{ a }}</a></li>
         {% endfor %}
       </ul>
+      {% else %}
+      <p>No entries.</p>
       {% endif %}
     </div>
-  <!-- </div>
+    {% endif %}
 
-  <div class="row"> -->
-    <div class="col-sm col-12">
+    {% if form.cleaned_data.in_training_requests %}
+    <div class="col-sm">
       <h2>Training requests</h2>
       {% if training_requests %}
       <ul>
@@ -62,8 +77,26 @@
         <li><a class="searchresult" href="{{ r.get_absolute_url }}">{{ r }}</a></li>
         {% endfor %}
       </ul>
+      {% else %}
+      <p>No entries.</p>
       {% endif %}
     </div>
+    {% endif %}
+
+    {% if form.cleaned_data.in_comments %}
+    <div class="col-sm">
+      <h2>Comments</h2>
+      {% if comments %}
+      <ul>
+        {% for comment in comments %}
+        <li><a class="searchresult" href="{{ comment.content_object.get_absolute_url }}#c{{ comment.id }}">{{ comment.content_object }}</a></li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p>No entries.</p>
+      {% endif %}
+    </div>
+    {% endif %}
   </div>
 
 {% endblock %}

--- a/amy/workshops/forms.py
+++ b/amy/workshops/forms.py
@@ -332,6 +332,10 @@ class SearchForm(forms.Form):
                                               required=False,
                                               initial=True)
 
+    in_comments = forms.BooleanField(label='in comments',
+                                     required=False,
+                                     initial=True)
+
     helper = BootstrapHelper(
         add_cancel_button=False,
         use_get_method=True,

--- a/amy/workshops/tests/test_search.py
+++ b/amy/workshops/tests/test_search.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timezone
+
+from django.contrib.sites.models import Site
 from django.urls import reverse
+from django_comments.models import Comment
 
 from workshops.tests.base import TestBase
 from workshops.models import Organization, Person, TrainingRequest
@@ -14,13 +18,15 @@ class TestSearchOrganization(TestBase):
     def search_for(self, term,
                    in_organizations=False,
                    in_training_requests=False,
-                   in_persons=False):
+                   in_persons=False,
+                   in_comments=False):
         search_page = self.app.get(reverse('search'), user='admin')
         form = search_page.forms['main-form']
         form['term'] = term
         form['in_organizations'] = in_organizations
         form['in_training_requests'] = in_training_requests
         form['in_persons'] = in_persons
+        form['in_comments'] = in_comments
         return form.submit().maybe_follow()
 
     def test_search_for_organization_with_no_matches(self):
@@ -110,6 +116,33 @@ class TestSearchOrganization(TestBase):
             'Lorem', in_training_requests=True, in_persons=True)
         self.assertEqual(len(response.context['training_requests']), 1)
 
-        # do not search in_persons, otherwise it'd redirect to Harry Potter's profile
+        # do not search in_persons, otherwise it'd redirect to Harry Potter's
+        # profile
         response = self.search_for('Potter', in_training_requests=True)
         self.assertEqual(len(response.context['training_requests']), 0)
+
+    def test_search_for_comments(self):
+        """After switching from `notes` fields to comments, we need to make
+        sure they're searchable."""
+        Comment.objects.create(
+            content_object=self.org_alpha,
+            user=self.hermione,
+            comment="Testing commenting system for Alpha Organization",
+            submit_date=datetime.now(tz=timezone.utc),
+            site=Site.objects.get_current(),
+        )
+
+        # search for "Alpha" in organizations and comments
+        response = self.search_for('Alpha',
+                                   in_organizations=True,
+                                   in_comments=True)
+
+        self.assertEqual(len(response.context['comments']), 1)
+        self.assertEqual(len(response.context['organizations']), 1)
+
+        # search for "Alpha" only in comments + check redirect
+        response = self.search_for('Alpha',
+                                   in_organizations=False,
+                                   in_comments=True)
+        self.assertEqual(response.request.path,
+                         self.org_alpha.get_absolute_url())

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1613,7 +1613,12 @@ def search(request):
 
             # only 1 record found? Let's move to it immediately
             if len(results) == 1:
-                return redirect(results[0].get_absolute_url())
+                result = results[0]
+                if isinstance(result, Comment):
+                    return redirect(result.content_object.get_absolute_url() +
+                                    "#c{}".format(result.id))
+                else:
+                    return redirect(result.get_absolute_url())
 
         else:
             messages.error(request, 'Fix errors below.')

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -41,6 +41,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.edit import (
     ModelFormMixin,
 )
+from django_comments.models import Comment
 from github.GithubException import GithubException
 from reversion.models import Version, Revision
 from reversion_compare.forms import SelectDiffForm
@@ -1532,6 +1533,7 @@ def search(request):
 
     term = ''
     organizations = events = persons = airports = training_requests = None
+    comments = None
 
     if request.method == 'GET' and 'term' in request.GET:
         form = SearchForm(request.GET)
@@ -1597,6 +1599,18 @@ def search(request):
                 )
                 results += list(training_requests)
 
+            if form.cleaned_data['in_comments']:
+                comments = Comment.objects.filter(
+                    Q(comment__icontains=term) |
+                    Q(user_name__icontains=term) |
+                    Q(user_email__icontains=term) |
+                    Q(user__personal__icontains=term) |
+                    Q(user__family__icontains=term) |
+                    Q(user__email__icontains=term) |
+                    Q(user__github__icontains=term)
+                ).prefetch_related('content_object')
+                results += list(comments)
+
             # only 1 record found? Let's move to it immediately
             if len(results) == 1:
                 return redirect(results[0].get_absolute_url())
@@ -1616,6 +1630,7 @@ def search(request):
         'events': events,
         'persons': persons,
         'airports': airports,
+        'comments': comments,
         'training_requests': training_requests,
     }
     return render(request, 'workshops/search.html', context)

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1533,11 +1533,11 @@ def search(request):
     term = ''
     organizations = events = persons = airports = training_requests = None
 
-    if request.method == 'GET':
+    if request.method == 'GET' and 'term' in request.GET:
         form = SearchForm(request.GET)
         if form.is_valid():
             term = form.cleaned_data['term']
-            tokens = re.split('\s+', term)
+            tokens = re.split(r'\s+', term)
             results = list()
 
             if form.cleaned_data['in_organizations']:
@@ -1600,6 +1600,9 @@ def search(request):
             # only 1 record found? Let's move to it immediately
             if len(results) == 1:
                 return redirect(results[0].get_absolute_url())
+
+        else:
+            messages.error(request, 'Fix errors below.')
 
     # if empty GET, we'll create a blank form
     else:


### PR DESCRIPTION
This fixes #1442. Comments found are displayed in new far-right column. Links redirect to specific comments within corresponding objects.