### PR TITLE
Revamping All Training Requests page with Datatables and saved checkboxes

### DIFF
--- a/amy/extrequests/forms.py
+++ b/amy/extrequests/forms.py
@@ -56,18 +56,17 @@ class BulkChangeTrainingRequestForm(forms.Form):
         # BulkMatchTrainingRequestForm.
         FormActions(
             Div(
-                Submit('discard', 'Discard selected requests',
-                       formnovalidate='formnovalidate',
-                       css_class="btn-danger"),
-                Submit('accept', 'Accept selected requests',
+                Submit('accept', 'Accept selected',
                        formnovalidate='formnovalidate',
                        css_class="btn-success"),
+                Submit('discard', 'Discard selected',
+                       formnovalidate='formnovalidate',
+                       css_class="btn-danger"),
+                Submit('unmatch', 'Unmatch selected from training',
+                       formnovalidate='formnovalidate',
+                       css_class="btn-primary"),
                 css_class="btn-group",
             ),
-            Submit('unmatch', 'Unmatch selected trainees from training',
-                   formnovalidate='formnovalidate'),
-            HTML('<a bulk-email-on-click class="btn btn-info text-white">'
-                 'Mail selected trainees</a>&nbsp;'),
         )
     )
 

--- a/amy/extrequests/tests/test_training_request.py
+++ b/amy/extrequests/tests/test_training_request.py
@@ -357,7 +357,7 @@ class TestTrainingRequestsListView(TestBase):
                               follow=True)
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Fix errors below and try again.'
+        msg = 'Fix errors in the form below and try again.'
         self.assertContains(rv, msg)
         msg = ('Some of the requests are not matched to a trainee yet. Before '
                'matching them to a training, you need to accept them '
@@ -399,7 +399,7 @@ class TestTrainingRequestsListView(TestBase):
 
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.resolver_match.view_name, 'all_trainingrequests')
-        msg = 'Fix errors below and try again.'
+        msg = 'Fix errors in the form below and try again.'
         self.assertContains(rv, msg)
 
         # Check that Spiderman is still matched to first_training even though

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -187,11 +187,12 @@ def all_trainingrequests(request):
         )
     )
 
+    form = BulkChangeTrainingRequestForm()
+    match_form = BulkMatchTrainingRequestForm()
 
     if request.method == 'POST' and 'match' in request.POST:
         # Bulk match people associated with selected TrainingRequests to
         # trainings.
-        form = BulkChangeTrainingRequestForm()
         match_form = BulkMatchTrainingRequestForm(request.POST)
 
         if match_form.is_valid():
@@ -250,14 +251,9 @@ def all_trainingrequests(request):
             messages.success(request, 'Successfully accepted and matched '
                                       'selected people to training.')
 
-            # Raw uri contains GET parameters from django filters. We use it
-            # to preserve filter settings.
-            return redirect(request.get_raw_uri())
-
     elif request.method == 'POST' and 'discard' in request.POST:
         # Bulk discard selected TrainingRequests.
         form = BulkChangeTrainingRequestForm(request.POST)
-        match_form = BulkMatchTrainingRequestForm()
 
         if form.is_valid():
             # Perform bulk discard
@@ -268,12 +264,9 @@ def all_trainingrequests(request):
             messages.success(request, 'Successfully discarded selected '
                                       'requests.')
 
-            return redirect(request.get_raw_uri())
-
     elif request.method == 'POST' and 'accept' in request.POST:
         # Bulk discard selected TrainingRequests.
         form = BulkChangeTrainingRequestForm(request.POST)
-        match_form = BulkMatchTrainingRequestForm()
 
         if form.is_valid():
             # Perform bulk discard
@@ -284,13 +277,10 @@ def all_trainingrequests(request):
             messages.success(request, 'Successfully accepted selected '
                                       'requests.')
 
-            return redirect(request.get_raw_uri())
-
     elif request.method == 'POST' and 'unmatch' in request.POST:
         # Bulk unmatch people associated with selected TrainingRequests from
         # trainings.
         form = BulkChangeTrainingRequestForm(request.POST)
-        match_form = BulkMatchTrainingRequestForm()
 
         form.check_person_matched = True
         if form.is_valid():
@@ -300,12 +290,6 @@ def all_trainingrequests(request):
 
             messages.success(request, 'Successfully unmatched selected '
                                       'people from trainings.')
-
-            return redirect(request.get_raw_uri())
-
-    else:  # GET request
-        form = BulkChangeTrainingRequestForm()
-        match_form = BulkMatchTrainingRequestForm()
 
     context = {
         'title': 'Training Requests',

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -174,7 +174,7 @@ class WorkshopRequestAssign(OnlyForAdminsMixin, AssignView):
 
 @admin_required
 def all_trainingrequests(request):
-    filter = TrainingRequestFilter(
+    filter_ = TrainingRequestFilter(
         request.GET,
         queryset=TrainingRequest.objects.all().prefetch_related(
             Prefetch(
@@ -187,8 +187,6 @@ def all_trainingrequests(request):
         )
     )
 
-    emails = filter.qs.values_list('email', flat=True)
-    requests = get_pagination_items(request, filter.qs)
 
     if request.method == 'POST' and 'match' in request.POST:
         # Bulk match people associated with selected TrainingRequests to
@@ -311,11 +309,10 @@ def all_trainingrequests(request):
 
     context = {
         'title': 'Training Requests',
-        'requests': requests,
-        'filter': filter,
+        'requests': filter_.qs,
+        'filter': filter_,
         'form': form,
         'match_form': match_form,
-        'emails': emails,
     }
 
     return render(request, 'requests/all_trainingrequests.html', context)

--- a/amy/extrequests/views.py
+++ b/amy/extrequests/views.py
@@ -251,19 +251,6 @@ def all_trainingrequests(request):
             messages.success(request, 'Successfully accepted and matched '
                                       'selected people to training.')
 
-    elif request.method == 'POST' and 'discard' in request.POST:
-        # Bulk discard selected TrainingRequests.
-        form = BulkChangeTrainingRequestForm(request.POST)
-
-        if form.is_valid():
-            # Perform bulk discard
-            for r in form.cleaned_data['requests']:
-                r.state = 'd'
-                r.save()
-
-            messages.success(request, 'Successfully discarded selected '
-                                      'requests.')
-
     elif request.method == 'POST' and 'accept' in request.POST:
         # Bulk discard selected TrainingRequests.
         form = BulkChangeTrainingRequestForm(request.POST)
@@ -275,6 +262,19 @@ def all_trainingrequests(request):
                 r.save()
 
             messages.success(request, 'Successfully accepted selected '
+                                      'requests.')
+
+    elif request.method == 'POST' and 'discard' in request.POST:
+        # Bulk discard selected TrainingRequests.
+        form = BulkChangeTrainingRequestForm(request.POST)
+
+        if form.is_valid():
+            # Perform bulk discard
+            for r in form.cleaned_data['requests']:
+                r.state = 'd'
+                r.save()
+
+            messages.success(request, 'Successfully discarded selected '
                                       'requests.')
 
     elif request.method == 'POST' and 'unmatch' in request.POST:

--- a/amy/static/checkboxes_sessionstorage.js
+++ b/amy/static/checkboxes_sessionstorage.js
@@ -1,0 +1,104 @@
+/* Checkbox saving functionality: saves checked checkboxes in sessionStorage
+   (it's valid until user closes the tab) */
+
+// encode Array with JSON to convert it to Storage object
+function ArrayToStorage(data) {
+  return JSON.stringify(data);
+}
+
+// decode Storage string result with JSON back into Array object
+function StorageToArray(data) {
+  return JSON.parse(data);
+}
+
+/* See http://learn.jquery.com/plugins/basic-plugin-creation/ */
+$.fn.selectCheckboxesFromStorage = function (storageName) {
+  // list of nearest checkboxes
+  var checkboxes = $(this).closest('form')
+                          .find(':checkbox[respond-to-select-all-checkbox]');
+
+  if (sessionStorage.getItem(storageName)) {
+    // read saved IDs, find corresponding checkboxes and check them
+    var data = StorageToArray(sessionStorage.getItem(storageName));
+
+    data.forEach(function(item) {
+      checkboxes.closest('[value="' + item + '"]').prop('checked', true);
+    });
+
+  } else {
+    // save default array value
+    sessionStorage.setItem(storageName, ArrayToStorage(Array()));
+  }
+
+  return this;
+}
+
+$(document).ready(function() {
+  // storage enabled
+  if (typeof(Storage) !== "undefined") {
+    // figure out storage name
+    var storageName = 'TrainingRequests';
+
+    // read checkboxes from storage and toggle them
+    $('#table-requests').selectCheckboxesFromStorage(storageName);
+    // update "select all" checkbox - just to be sure
+    $('#table-requests :checkbox[select-all-checkbox]').updateSelectAllCheckbox();
+    // update links for "*(Action)* selected"
+    $('a[amy-download-selected]').each(function(i, obj) {
+      $(this).updateIdsInHref();
+    });
+
+
+    // for each checkbox: save to / remove from Session upon a click
+    $('#table-requests [respond-to-select-all-checkbox]').change(function() {
+      var list = Array();
+      var value = $(this).val();
+
+      if (sessionStorage.getItem(storageName)) {
+        list = StorageToArray(sessionStorage.getItem(storageName));
+      } else {
+        sessionStorage.setItem(storageName, ArrayToStorage(list));
+      }
+
+      if ($(this).prop('checked')) {
+        // check if ID not in the list
+        if (list.indexOf(value) == -1) {
+          // if not in the list, add
+          list.push(value);
+        }
+      } else {
+        // check if ID in the list
+        if (list.indexOf(value) != -1) {
+          // if in the list, remove it
+          list.splice(list.indexOf(value), 1);
+        }
+      }
+
+      // save back to sessionStorage
+      sessionStorage.setItem(storageName, ArrayToStorage(list));
+    });
+
+
+    // update whole session upon clicking "select-all-checkbox"
+    $('#table-requests :checkbox[select-all-checkbox]').change(function() {
+      var checkboxes = $(this).closest('form').find(':checkbox[respond-to-select-all-checkbox] :checked');
+      var list = Array();
+
+      // clear session storage entry
+      sessionStorage.setItem(storageName, ArrayToStorage(list));
+
+      // add to session storage
+      checkboxes.each(function(i, obj) {
+        var value = $(obj).val();
+        if (list.indexOf(value) == -1) {
+          // if not in the list, add
+          list.push(value);
+        }
+      });
+
+      // save back to sessionStorage
+      sessionStorage.setItem(storageName, ArrayToStorage(list));
+    });
+  }
+})
+

--- a/amy/templates/base.html
+++ b/amy/templates/base.html
@@ -76,6 +76,7 @@
     <script src="{% static 'jquery-stickytabs/jquery.stickytabs.js' %}"></script>
     <script src="{% static 'urijs/src/URI.js' %}"></script>
     <script src="{% static 'datatables.net/js/jquery.dataTables.js' %}"></script>
+    <script src="{% static 'datatables.net-bs4/js/dataTables.bootstrap4.js' %}"></script>
     <script src="{% static 'calendar_popup.js' %}"></script>
     <script src="{% static 'amy_utils.js' %}"></script>
     {% endcompress %}

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -120,36 +120,21 @@
     </table>
 
     <div class="btn-group" role="group" aria-label="Actions for list of training requests">
-      <a class="btn btn-info" href="mailto:?bcc={% for mail in emails %}{{ mail }}{% if not forloop.last %},{% endif %}{% endfor %}">Mail <strong>all</strong> people matching this query</a>
-      <a class="btn btn-success" href="{% url 'training_request' %}">Create new request</a>
-
-      <div class="btn-group" role="group">
-        <button id="id_downloadBtn" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Download
-        </button>
-        <div class="dropdown-menu" aria-labelledby="id_downloadBtn">
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&" amy-download-selected>Selected requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv">All requests as CSV</a>
-        </div>
-      </div>
-
-      <div class="btn-group" role="group">
-        <button id="id_downloadBtn" type="button" class="btn btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Download for bulk manual scoring
-        </button>
-        <div class="dropdown-menu" aria-labelledby="id_downloadBtn">
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1" amy-download-selected>Selected requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1&{{ request.GET.urlencode }}">Filtered requests as CSV</a>
-          <a class="dropdown-item" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1">All requests as CSV</a>
-        </div>
-      </div>
+      <a class="btn btn-info text-white" bulk-email-on-click>Mail selected</a>
+      <a class="btn btn-secondary" href="{% url 'api:training-requests' %}?format=csv&" amy-download-selected>Download selected</a>
+      <a class="btn btn-dark" href="{% url 'api:training-requests' %}?format=csv2&manualscore=1" amy-download-selected>Download selected for bulk manual scoring</a>
     </div>
 
     <hr>
 
-    <h2>Actions</h2>
+    <h2>Modify</h2>
+
     {% crispy form %}
+
+    <hr>
+
+    <h2>Accept & match</h2>
+
     {% crispy match_form %}
     </form>
 {% else %}

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -4,6 +4,7 @@
 {% load pagination %}
 {% load tags %}
 {% load state %}
+{% load static %}
 
 {% block content %}
   {% if requests %}
@@ -140,4 +141,33 @@
 {% else %}
     <p>No training requests.</p>
 {% endif %}
+{% endblock %}
+
+
+{% block extrajs %}
+<script type="text/javascript" src="{% static 'checkboxes_sessionstorage.js' %}"></script>
+<script type="text/javascript">
+  $(function () {
+    // datatables enabled for event tasks table
+    $("#table-requests").DataTable({
+      "lengthMenu": [
+        [25, 50, 100, 200, -1],
+        [25, 50, 100, 200, "All"]
+      ],
+      columnDefs: [
+        // disable ordering on "checkbox" column
+        {
+          orderable: false,
+          targets: 0
+        },
+        // disable ordering on additional links column
+        {
+          orderable: false,
+          targets: -1
+        }
+      ],
+      stateSave: true
+    });
+  });
+</script>
 {% endblock %}

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -9,9 +9,9 @@
   {% if requests %}
     <form role="form" class="form-horizontal" method="post" action="{% url 'all_trainingrequests' %}?{{ request.GET.urlencode }}">
     {% if form.errors.requests or match_form.errors.requests %}
-      <div class="alert alert-danger" role="alert">You didn't select any request.</div>
+      <div class="alert alert-danger" role="alert">You didn't select any requests.</div>
     {% elif form.errors or match_form.errors %}
-      <div class="alert alert-danger" role="alert">Fix errors below and try again.</div>
+      <div class="alert alert-danger" role="alert">Fix errors in the form below and try again.</div>
     {% endif %}
     <table class="table table-striped">
       <tr>

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -54,9 +54,7 @@
           <td>
             <input type="checkbox" name="requests" value="{{ req.pk }}"
                    respond-to-select-all-checkbox
-                   email="{% if req.person %}{{ req.person.email }}{% elif req.email %}{{ req.email }}{% endif %}"
-                   {% if req in form.cleaned_data.requests or req in match_form.cleaned_data.requests %}checked {% endif %}
-            />
+                   email="{% if req.person %}{{ req.person.email }}{% elif req.email %}{{ req.email }}{% endif %}" />
           </td>
           <td>
             {{ req.personal }} {{ req.middle }} {{ req.family }}<br />
@@ -120,7 +118,6 @@
       {% endfor %}
       </tbody>
     </table>
-    {% pagination requests %}
 
     <div class="btn-group" role="group" aria-label="Actions for list of training requests">
       <a class="btn btn-info" href="mailto:?bcc={% for mail in emails %}{{ mail }}{% if not forloop.last %},{% endif %}{% endfor %}">Mail <strong>all</strong> people matching this query</a>

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   {% if requests %}
-    <form role="form" class="form-horizontal" method="post">
+    <form role="form" class="form-horizontal" method="post" action="{% url 'all_trainingrequests' %}?{{ request.GET.urlencode }}">
     {% if form.errors.requests or match_form.errors.requests %}
       <div class="alert alert-danger" role="alert">You didn't select any request.</div>
     {% elif form.errors or match_form.errors %}

--- a/amy/templates/requests/all_trainingrequests.html
+++ b/amy/templates/requests/all_trainingrequests.html
@@ -13,47 +13,42 @@
     {% elif form.errors or match_form.errors %}
       <div class="alert alert-danger" role="alert">Fix errors in the form below and try again.</div>
     {% endif %}
-    <table class="table table-striped">
-      <tr>
-        <th width="10px">
-          <input type="checkbox" select-all-checkbox />
-        </th>
-        <th>Submitter</th>
-        <th>Reg. Code</th>
-        <th>
-          Affiliation
-          <i class="fas fa-question-circle"
-             data-toggle="popover" data-html="true" data-trigger="hover"
-             data-content="<p>If two lines are presented:
-                           <ul><li>the first line shows affiliation from training request,</li>
-                           <li>and the second line shows affiliation from trainee's profile</li></ul></p>
-                           "></i>
-        </th>
-        {% if request.GET.location %}
+    <table class="table table-striped table-bordered table-hover" id="table-requests">
+      <thead>
+        <tr>
+          <th><input type="checkbox" select-all-checkbox /></th>
+          <th>Submitter</th>
+          <th>Reg. Code</th>
+          <th>Affiliation
+              <i class="fas fa-question-circle"
+                 data-toggle="popover" data-html="true" data-trigger="hover"
+                 data-content="<p>If two lines are presented:
+                               <ul><li>the first line shows affiliation from training request,</li>
+                               <li>and the second line shows affiliation from trainee's profile</li></ul></p>"></i>
+          </th>
           <th>Location</th>
-        {% endif %}
-        {% if request.GET.order_by == 'created_at' or request.GET.order_by == '-created_at' %}
           <th>Created at</th>
-        {% endif %}
-        <th>Matched Trainee</th>
-        <th>Matched Training</th>
-        <th>Score</th>
-        <th width="50px">
-          State
-          <i class="fas fa-question-circle"
-             data-toggle="popover" data-html="true" data-trigger="hover"
-             data-content="<p>
-                           <span class='badge badge-warning'>Pending</span>
-                           <span class='badge badge-success'>Accepted</span>
-                           <span class='badge badge-danger'>Discarded</span>
-                           </p>
-                           <p>Click one of
-                           <a href='#'><i class='fas fa-info-circle'></i></a>
-                           icons below to start accepting request.</p>
-                          "></i>
-        </th>
-        <th class="additional-links"></th>
+          <th>Matched Trainee</th>
+          <th>Matched Training</th>
+          <th>Score</th>
+          <th width="50px">
+            State
+            <i class="fas fa-question-circle"
+               data-toggle="popover" data-html="true" data-trigger="hover"
+               data-content="<p>
+                             <span class='badge badge-warning'>Pending</span>
+                             <span class='badge badge-success'>Accepted</span>
+                             <span class='badge badge-danger'>Discarded</span>
+                             </p>
+                             <p>Click one of
+                             <a href='#'><i class='fas fa-info-circle'></i></a>
+                             icons below to start accepting request.</p>
+                            "></i>
+          </th>
+          <th></th>
+        </thead>
       </tr>
+      <tbody>
       {% for req in requests %}
         <tr>
           <td>
@@ -75,12 +70,8 @@
               {{ req.person.affiliation|default:"—" }}
             {% endif %}
           </td>
-          {% if request.GET.location %}
-            <td>{{ req.location|default:"—" }}</td>
-          {% endif %}
-          {% if request.GET.order_by == 'created_at' or request.GET.order_by == '-created_at' %}
-            <td>{{ req.created_at|date:'Y-m-d H:i' }}</td>
-          {% endif %}
+          <td>{{ req.location|default:"—" }}</td>
+          <td>{{ req.created_at|date:'Y-m-d H:i' }}</td>
           <td>
             {% if req.person %}
               <a href="{% url 'person_details' req.person.pk %}">
@@ -127,6 +118,7 @@
           </td>
         </tr>
       {% endfor %}
+      </tbody>
     </table>
     {% pagination requests %}
 


### PR DESCRIPTION
This fixes #1375.

Big changes (exclusive to All Training Requests page only):
1. switch to Datatables
2. no more pagination - it's now all handled by Datatables
3. filtering on the left hand side narrows data for the table, but the table can be sorted, paged, and even filtered even further by the Datatables script
4. table sorting/pagination/filtering is preserved in the browser
5. selected checkboxes are preserved in the browser
6. action buttons under the table are split into 3 categories: action (they don't change data, but instead allow you to work on the data [e.g. email, download CSV, etc]), modification (they modify the data), acceptance & match (advanced modification with parameters).

@karenword this should work and help you with your workflow, however be aware there may still be some errors or rough edges.