### PR TITLE
Action required next page

### DIFF
--- a/amy/workshops/action_required.py
+++ b/amy/workshops/action_required.py
@@ -1,6 +1,7 @@
 from django.shortcuts import redirect
 from django.urls import reverse
 
+
 class PrivacyPolicy:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -17,11 +18,11 @@ class PrivacyPolicy:
         # also don't redirect if the requested page is the page we want to
         # redirect to
         if (
-                request.path not in allowed_urls and
-                not request.user.is_anonymous and
-                hasattr(request.user, 'data_privacy_agreement') and
-                not request.user.data_privacy_agreement
-            ):
-                return redirect(url)
+            request.path not in allowed_urls and
+            not request.user.is_anonymous and
+            hasattr(request.user, 'data_privacy_agreement') and
+            not request.user.data_privacy_agreement
+        ):
+            return redirect(url)
         else:
             return self.get_response(request)

--- a/amy/workshops/action_required.py
+++ b/amy/workshops/action_required.py
@@ -1,5 +1,6 @@
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.http import urlencode
 
 
 class PrivacyPolicy:
@@ -13,6 +14,18 @@ class PrivacyPolicy:
             reverse('logout'),
             url
         ]
+
+        if 'next' in request.GET:
+            # prepare `?next` URL if it's already present (e.g. user refreshes
+            # the `action_required_privacy` page)
+            next_param = request.GET['next']
+        else:
+            # grab requested page path to use in `?next` query string
+            next_param = request.path
+
+        # only add `?next` if it's outside the scope of allowed URLs
+        if next_param not in allowed_urls:
+            url += '?{}'.format(urlencode({'next': next_param}))
 
         # redirect only users who didn't agree on the privacy policy
         # also don't redirect if the requested page is the page we want to

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1797,7 +1797,7 @@ def action_required_privacy(request):
 
     # disable the view for users who already agreed
     if person.data_privacy_agreement:
-        return redirect(reverse('dispatch'))
+        raise Http404('This view is disabled.')
 
     form = ActionRequiredPrivacyForm(instance=person)
 

--- a/amy/workshops/views.py
+++ b/amy/workshops/views.py
@@ -1808,7 +1808,10 @@ def action_required_privacy(request):
             person = form.save()
             messages.success(request, 'Agreement successfully saved.')
 
-            return redirect(reverse('dispatch'))
+            if 'next' in request.GET:
+                return redirect(request.GET['next'])
+            else:
+                return redirect(reverse('dispatch'))
         else:
             messages.error(request, 'Fix errors below.')
 


### PR DESCRIPTION
This fixes #1463.

Changes in `action_required_policy` view:
* setting `?next` query parameter in the middleware
* adhering to the `?next` query parameter by `action_required_view`
* throwing Http 404 error when view accessed by user who already agreed on the policy