### PR TITLE
Django Admin URL parametrized

### DIFF
--- a/amy/templates/navigation.html
+++ b/amy/templates/navigation.html
@@ -101,6 +101,10 @@
               <a class="dropdown-item" href="{% url 'api:export-person-data' %}?format=json">Download your data</a>
               <a class="dropdown-item" href="{% url 'person_password' user.id %}">Change password</a>
               <div class="dropdown-divider"></div>
+              {% if user.is_superuser %}
+              <a class="dropdown-item" href="{% url 'admin:index' %}">Django Admin</a>
+              <div class="dropdown-divider"></div>
+              {% endif %}
               <a class="dropdown-item" href="{% url 'logout' %}">Log out</a>
             </div>
           </li>

--- a/config/settings.py
+++ b/config/settings.py
@@ -403,7 +403,7 @@ ADMIN_NOTIFICATION_CRITERIA_DEFAULT = 'team@carpentries.org'
 # ADMIN
 # ------------------------------------------------------------------------------
 # Django Admin URL.
-ADMIN_URL = 'admin/'
+ADMIN_URL = env('AMY_ADMIN_URL', default='admin/')
 # https://docs.djangoproject.com/en/dev/ref/settings/#admins
 ADMINS = [
     ('Sysadmins ML', 'sysadmin@lists.carpentries.org'),

--- a/config/urls.py
+++ b/config/urls.py
@@ -27,7 +27,7 @@ from workshops.util import login_required
 
 urlpatterns = [
     path('', RedirectView.as_view(pattern_name='dispatch')),
-    path('admin/', admin.site.urls),
+    path(settings.ADMIN_URL, admin.site.urls),  # {% url 'admin:index' %}
 ]
 
 if settings.ENABLE_PYDATA:


### PR DESCRIPTION
For security purposes, Django Admin URL, until now accessible under `admin/` link, will be moved to a long and random URL.

This PR includes changes in `settings.py` and `urls.py` that enable this kind of operation. Additionally, a link visible only to superusers is added to the navigation bar.