### PR TITLE
Django compressor: compress CSS files

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -2,7 +2,6 @@
 Django settings for AMY project.
 """
 
-from collections import namedtuple
 import os
 import sys
 
@@ -280,6 +279,14 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',
+]
+
+# DJANGO-COMPRESSOR
+# -----------------------------------------------------------------------------
+# https://django-compressor.readthedocs.io/en/stable/settings/
+COMPRESS_CSS_FILTERS = [
+    'compressor.filters.css_default.CssAbsoluteFilter',
+    'compressor.filters.cssmin.CSSCompressorFilter',
 ]
 
 # MEDIA

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ django-contrib-comments==1.9.0
 django-markdownx==2.0.28
 Markdown==3.0.1
 Pillow==5.3.0
+csscompressor==0.9.5


### PR DESCRIPTION
This gets rid of "source map" errors in browsers.

Source maps are stored as comments inside source CSS files, but when
we enable compression, the comments aren't preserved, and so the issue
is gone.