### PR TITLE
Makefile: fix some potentially risky commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ outdated :
 ## upgrade      : force package upgrade using pip
 upgrade :
 	pip install --upgrade -r requirements.txt
-	yarn upgrade
+	yarn upgrade --frozen-lockfile
 
 ## clean        : clean up.
 clean :

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test :
 fast_test:
 	${MANAGE} test --keepdb --parallel
 
+## fast_test_fail	: run all tests really fast, fails as soon as any test fails.
+fast_test_fail:
+	${MANAGE} test --keepdb --parallel --failfast
+
 ## dev_database : re-make database using saved data
 dev_database :
 	rm -f ${APP_DB}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ commands : Makefile
 test :
 	${MANAGE} test
 
-## fast test	: run all tests really fast.
+## fast_test    : run all tests really fast.
 fast_test:
 	${MANAGE} test --keepdb --parallel
 
@@ -45,7 +45,7 @@ dev_database :
 airports :
 	@${MANAGE} export_airports
 
-## check-certs : check that all instructor certificates have been set (must set CERT_PATH to run)
+## check-certs  : check that all instructor certificates have been set (must set CERT_PATH to run)
 check-certs :
 	@if [ -z "${CERT_PATH}" ]; then echo ${E_CERT_PATH}; else ${MANAGE} check_certificates ${CERT_PATH}; fi
 
@@ -79,7 +79,7 @@ serve : node_modules amy/workshops/git_version.py
 serve_now :
 	${MANAGE} runserver
 
-## outdated		: show outdated dependencies
+## outdated     : show outdated dependencies
 outdated :
 	-pip list --outdated
 	-yarn outdated
@@ -102,7 +102,7 @@ coverage :
 	coverage --source=amy manage.py test
 	coverage html
 
-## bumpversion	: bump version strings in various files, expected envvars CURRENT, NEXT
+## bumpversion  : bump version strings in various files, expected envvars CURRENT, NEXT
 bumpversion :
 	@if [ "${CURRENT}" -a "$(NEXT)" ]; \
 	then \

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ dev_database :
 	${MANAGE} migrate
 	${MANAGE} fake_database
 	${MANAGE} createinitialrevisions
-
-## superuser    : make a super-user in the database
-superuser :
-	@${MANAGE} create_superuser
+	${MANAGE} create_superuser
 
 ## airports     : display YAML for airports
 airports :

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ fast_test_fail:
 
 ## dev_database : re-make database using saved data
 dev_database :
-	rm -f ${APP_DB}
+	@if test  -f ${APP_DB}; \
+	then \
+		echo "You must remove database file yourself!"; \
+		exit 1; \
+	fi
 	${MANAGE} migrate
 	${MANAGE} fake_database
 	${MANAGE} createinitialrevisions


### PR DESCRIPTION
This fixes #1474.

Some potential issues:
1. `make superuser` would create a superuser, and there was nothing to prevent that from happening even on production server; it was changed so that only `dev_database` creates this user.
2. `make dev_database` was removing `db.sqlite3` without warning. Now it requires user to remove it first.
3. `make upgrade` was changing `yarn.lock` file, but I'd rather stick to the values from the file.