### PR TITLE
Training progress note in trainee dashboard

### DIFF
--- a/amy/templates/dashboard/training_progress.html
+++ b/amy/templates/dashboard/training_progress.html
@@ -25,6 +25,8 @@
   </div>
   {% endif %}
 
+  <div class="alert alert-warning" role="alert">Due to the structure of our checkout tracking progress, all steps towards checkout may not be included here. If your instructor badge (DC, LC, and/or SWC) is correctly displayed, you are in good standing.</div>
+
   <table class="table table-striped">
     <tr>
       <th>1. Training</th>
@@ -103,6 +105,7 @@
       </td>
     </tr>
   </table>
+
 
   <p>In the case of any questions, please send us email at <a href="mailto:team@carpentries.org">team@carpentries.org</a></p>
 </div>


### PR DESCRIPTION
This fixes #1464 by adding a requested note to the training progress
page of the trainee dashboard.

@maneesha this is how it looks:
![screenshot_2019-02-28 amy your training progress](https://user-images.githubusercontent.com/72821/53587284-41faec80-3b8a-11e9-91df-b643195369c2.png)
