### PR TITLE
Log failed login attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ mediafiles/*
 
 # Database backup files
 DB_backups/*
+
+# log file
+amy.log

--- a/amy/workshops/signals.py
+++ b/amy/workshops/signals.py
@@ -1,7 +1,26 @@
-from django.dispatch import Signal
+import logging
 
+from django.contrib.auth.signals import user_login_failed
+from django.dispatch import Signal, receiver
+from django.http.request import HttpRequest
+
+
+# AMY server logger
+logger = logging.getLogger("amy.server_logs")
 
 # signal generated when a comment regarding specific object should be saved
 create_comment_signal = Signal(
     providing_args=["content_object", "comment", "timestamp"]
 )
+
+
+# a receiver for "failed login attempt" signal
+@receiver(user_login_failed)
+def log_user_login_failed(sender, **kwargs):
+    credentials = kwargs.get('credentials') or dict()
+    request = kwargs.get('request') or HttpRequest()
+
+    ip = request.META.get('REMOTE_ADDR') or 'UNKNOWN'
+    username = credentials.get('username') or 'UNKNOWN'
+    msg = "Login failure from IP {} for user '{}'".format(ip, username)
+    logger.error(msg)

--- a/config/settings.py
+++ b/config/settings.py
@@ -460,6 +460,16 @@ REST_FRAMEWORK = {
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,  # merge with default configuration
+    'formatters': {
+        'verbose': {
+            'format': '{asctime}::{levelname}::{message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname}::{message}',
+            'style': '{',
+        },
+    },
     'handlers': {
         'null': {
             'class': 'logging.NullHandler',
@@ -470,12 +480,27 @@ LOGGING = {
             'email_backend': EMAIL_BACKEND,
             'include_html': True,
         },
+        'log_file': {
+            'level': 'ERROR',
+            'class': 'logging.FileHandler',
+            'formatter': 'verbose',
+            'filename': env.path('AMY_SERVER_LOGFILE', default='amy.log'),
+        },
     },
     'loggers': {
         # disable "Invalid HTTP_HOST" notifications
         'django.security.DisallowedHost': {
             'handlers': ['null'],
             'propagate': False,
+        },
+        'amy': {
+            'handlers': ['null', ],
+            'level': 'WARNING',
+        },
+        'amy.server_logs': {
+            'handlers': ['log_file', ],
+            'level': 'ERROR',
+            'propagate': True,
         },
     },
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -464,6 +464,12 @@ LOGGING = {
         'null': {
             'class': 'logging.NullHandler',
         },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'email_backend': EMAIL_BACKEND,
+            'include_html': True,
+        },
     },
     'loggers': {
         # disable "Invalid HTTP_HOST" notifications

--- a/config/settings.py
+++ b/config/settings.py
@@ -484,7 +484,8 @@ LOGGING = {
             'level': 'ERROR',
             'class': 'logging.FileHandler',
             'formatter': 'verbose',
-            'filename': env.path('AMY_SERVER_LOGFILE', default='amy.log'),
+            # `str()` prevents some strange bug on Py3.5
+            'filename': str(env.path('AMY_SERVER_LOGFILE', default='amy.log')),
         },
     },
     'loggers': {


### PR DESCRIPTION
This fixes #1499 by enhancing logging + reacting upon `user_failed_login` signal sent from `django.contrib.auth`.

A new envvar `AMY_SERVER_LOGFILE` is used for log file name.